### PR TITLE
feat: add custom commands system with UI management

### DIFF
--- a/.claude/commands/create-command.md
+++ b/.claude/commands/create-command.md
@@ -1,0 +1,265 @@
+---
+description: Interactively create a new custom Claude Code command in .claude/commands/
+---
+
+Create a new reusable custom command that can be invoked with `/<name>` in Claude Code or OmniDesk's command palette. Walk the user through providing a name, description, and instruction body — validate everything, write the Markdown file, and confirm success.
+
+If `$ARGUMENTS` is provided, use it as the proposed command name and skip to Step 2 (gathering description and body).
+
+---
+
+## Background
+
+Custom commands live as `.md` files in one of two places:
+
+| Scope | Location | Notes |
+|-------|----------|-------|
+| **project** | `<project-root>/.claude/commands/<name>.md` | Git-tracked; shared with the whole team |
+| **user** | `~/.claude/commands/<name>.md` | Personal; available in all your projects |
+
+When invoked, the file's content is used as a prompt template sent to Claude. Use `$ARGUMENTS` anywhere in the body as a placeholder for runtime input (e.g., `/my-command foo bar` → `$ARGUMENTS` becomes `foo bar`).
+
+OmniDesk watches both directories and surfaces commands in the command palette (Ctrl+Shift+P) within ~1 second of the file being written.
+
+---
+
+## Step 1 — Gather the command name
+
+If `$ARGUMENTS` is non-empty, use it as the proposed name. Otherwise ask:
+
+```
+What should the command be called?
+(Use kebab-case, e.g. "deploy-staging", "review-pr", "fix-types")
+```
+
+Name rules (validated in Step 4):
+- Only lowercase letters, numbers, and hyphens
+- Must start and end with a letter or number
+- 1–60 characters after slugification
+- Cannot conflict with Claude Code built-ins: `help`, `init`, `config`, `login`, `logout`, `version`, `update`
+
+---
+
+## Step 2 — Gather description and body
+
+Ask for the **description** (required, 1–200 characters):
+
+```
+Short description shown in the command palette:
+```
+
+Then ask for the **instruction body** (required, non-empty):
+
+```
+Instruction body — what Claude should do when /<name> is invoked.
+You can use $ARGUMENTS as a placeholder for runtime input.
+(Example: "Explain this code: $ARGUMENTS")
+
+Body:
+```
+
+If the user provides an empty value for either field, say **"That field is required."** and ask again.
+
+---
+
+## Step 3 — Ask for scope
+
+```
+Where should this command be saved?
+  1. project  →  .claude/commands/<name>.md   (git-tracked, shared with team)  [default]
+  2. user     →  ~/.claude/commands/<name>.md  (personal, all your projects)
+
+Choice [1]:
+```
+
+Default to `project` if the user presses Enter or types `1`.
+
+---
+
+## Step 4 — Validate the name
+
+### 4a. Slugify
+Apply: `name.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '')`
+
+Examples:
+- `"My Deploy Script"` → `"my-deploy-script"`
+- `"run_tests!"` → `"run-tests"`
+- `"  fix bug  "` → `"fix-bug"`
+
+If the slug differs from what the user typed, confirm before proceeding:
+
+```
+I'll save this as /<slug> — is that OK? [y/n]
+```
+
+If the user says no, ask for a new name and restart from Step 1.
+
+### 4b. Check forbidden names
+If the slug is any of: `help`, `init`, `config`, `login`, `logout`, `version`, `update`
+
+→ Reject: *"That name conflicts with a Claude Code built-in command. Please choose a different name."*
+
+### 4c. Check length
+- Empty after slugification → ask for a valid name
+- Longer than 60 characters → ask for a shorter name, suggest the first 60 characters as a starting point
+
+### 4d. Check for an existing file
+Determine the full target path:
+- Project scope: `<current_working_directory>/.claude/commands/<slug>.md`
+- User scope: `~/.claude/commands/<slug>.md`
+
+Run:
+```bash
+test -f "<full_target_path>" && echo "EXISTS" || echo "NEW"
+```
+
+**If EXISTS**, present this choice:
+
+```
+⚠️  A command named /<slug> already exists at:
+    <full_target_path>
+
+What would you like to do?
+  1. Overwrite it with the new content
+  2. Choose a different name        [default]
+  3. Cancel
+
+Choice [2]:
+```
+
+- Overwrite → continue to Step 5
+- Rename → go back to Step 1
+- Cancel → print *"No command was created."* and stop
+
+---
+
+## Step 5 — Preview and confirm
+
+**Before writing anything**, show the user the exact content:
+
+```
+About to create: <full_target_path>
+
+─────────────────────────────────────────
+---
+description: <description>
+---
+
+<body>
+─────────────────────────────────────────
+
+Proceed? [y/n]
+```
+
+If the user says no, ask what they want to change and loop back to the relevant step.
+
+---
+
+## Step 6 — Write the file
+
+### 6a. Ensure the directory exists
+```bash
+mkdir -p "<target_directory>"
+```
+
+### 6b. Write the file
+Write to `<full_target_path>` using this exact format:
+
+```
+---
+description: <description>
+---
+
+<body>
+```
+
+Rules:
+- The `---` frontmatter block must be the very first thing in the file
+- There must be a blank line between the closing `---` and the body
+- The body is written verbatim — preserve all line breaks and formatting
+
+If the user explicitly asked for formal parameters (only prompt if they ask), extend the frontmatter:
+
+```
+---
+description: <description>
+parameters:
+  - name: <param_name>
+    description: <param_description>
+    required: true
+    default: <default_value_if_any>
+---
+
+<body>
+```
+
+---
+
+## Step 7 — Verify and confirm
+
+After writing, verify the file was created:
+```bash
+cat "<full_target_path>"
+```
+
+**On success**, print:
+
+```
+✅ Command /<slug> created!
+
+  File:  <full_target_path>
+  Scope: <Project | User>
+
+  How to use it:
+    Claude Code:      /<slug>
+    With arguments:   /<slug> your args here
+    OmniDesk palette: Ctrl+Shift+P → type /<slug>
+
+OmniDesk will auto-detect the new command within ~1 second.
+For standalone Claude Code CLI, the command is available immediately.
+```
+
+**On failure** (file missing or content mismatch), report the error and provide the content for manual creation:
+
+```
+❌ Failed to write the file.
+Error: <error message>
+
+You can create it manually by saving this content to:
+  <full_target_path>
+
+---
+description: <description>
+---
+
+<body>
+```
+
+---
+
+## Edge case reference
+
+| Situation | Action |
+|-----------|--------|
+| Name has uppercase letters | Auto-lowercase, show result, ask confirmation |
+| Name has spaces or special chars | Slugify, show result, ask confirmation |
+| Slug is empty after slugification | Ask for a valid name (letters/numbers required) |
+| Slug exceeds 60 characters | Ask for a shorter name; suggest first 60 characters |
+| Slug matches a built-in command | Reject; suggest a prefixed alternative (e.g., `my-config` instead of `config`) |
+| Empty description | Re-prompt: *"Description is required"* |
+| Empty body | Re-prompt: *"Instruction body cannot be empty"* |
+| File already exists | Offer overwrite / rename / cancel; default rename (safer) |
+| `.claude/commands/` directory missing | Create automatically with `mkdir -p` |
+| `~/.claude/commands/` directory missing | Create automatically with `mkdir -p` |
+| Body starts with `---` on the first line | Warn: may confuse frontmatter parsers; suggest wrapping in a heading |
+| User cancels at any point | Print *"No command was created."* and stop |
+| Write permission denied | Report the error and full path; show content for manual creation |
+
+---
+
+## Important rules
+
+- **Never write outside** `.claude/commands/` (project) or `~/.claude/commands/` (user). Do not accept arbitrary paths.
+- **Always show the preview** before writing and wait for explicit confirmation.
+- **Always confirm slug transformations** with the user before proceeding.
+- If you cannot determine the current working directory (for project scope), use `pwd` to find it.

--- a/src/main/command-registry.ts
+++ b/src/main/command-registry.ts
@@ -208,6 +208,7 @@ export class CommandRegistry {
         panels: { label: 'Panels', icon: 'sidebar' },
         settings: { label: 'Settings', icon: 'settings' },
         help: { label: 'Help', icon: 'help-circle' },
+        'custom-commands': { label: 'Custom Commands', icon: 'terminal' },
       },
     };
   }

--- a/src/main/custom-command-manager.security.test.ts
+++ b/src/main/custom-command-manager.security.test.ts
@@ -1,0 +1,775 @@
+/**
+ * Security tests for CustomCommandManager
+ *
+ * Tests the following security fixes:
+ * 1. Path Traversal: updateCommand, deleteCommand, and getCommand reject
+ *    slugs containing "..", absolute paths, null bytes, slashes, etc.
+ * 2. YAML Injection: serializeCommand sanitizes newlines in description
+ *    and parameter scalar fields to prevent frontmatter delimiter injection.
+ *
+ * These tests verify that the guards in each method prevent attacks
+ * before resolveFilePath() is ever called.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// Mock fs module BEFORE any imports that use it
+vi.mock('fs');
+
+// Mock os BEFORE any imports that use it
+vi.mock('os', () => ({
+  homedir: vi.fn(() => '/home/testuser'),
+}));
+
+// Mock IPCEmitter BEFORE importing CustomCommandManager
+vi.mock('./ipc-emitter');
+
+// NOW import the modules that were mocked above
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import { CustomCommandManager } from './custom-command-manager';
+import { IPCEmitter } from './ipc-emitter';
+import type { CustomCommand, CommandParameter } from '../shared/types/custom-command-types';
+
+const mockedFs = vi.mocked(fs);
+const mockedOs = vi.mocked(os);
+const MockedIPCEmitter = vi.mocked(IPCEmitter);
+
+describe('CustomCommandManager Security', () => {
+  let manager: CustomCommandManager;
+  let mockEmitter: any;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    // Reset fs mocks to default behaviors
+    mockedFs.existsSync.mockReturnValue(false);
+    mockedFs.mkdirSync.mockReturnValue(undefined);
+    mockedFs.writeFileSync.mockReturnValue(undefined);
+    mockedFs.renameSync.mockReturnValue(undefined);
+    mockedFs.readFileSync.mockReturnValue('');
+    mockedFs.statSync.mockReturnValue({
+      size: 100,
+      mtimeMs: Date.now(),
+    } as any);
+    mockedFs.readdirSync.mockReturnValue([]);
+    mockedFs.watch.mockReturnValue({
+      close: vi.fn(),
+      on: vi.fn(function () {
+        return this;
+      }),
+    } as any);
+    mockedFs.unlinkSync.mockReturnValue(undefined);
+
+    mockEmitter = {
+      emit: vi.fn(),
+    };
+
+    manager = new CustomCommandManager();
+    manager.setEmitter(mockEmitter);
+  });
+
+  afterEach(() => {
+    manager.destroy();
+  });
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // PATH TRAVERSAL TESTS
+  // ──────────────────────────────────────────────────────────────────────────
+
+  describe('Path Traversal Protection', () => {
+    describe('getCommand() slug validation', () => {
+      it('should reject slug with path traversal ".."', () => {
+        const result = manager.getCommand('../../etc/passwd', 'user');
+        expect(result).toBeNull();
+      });
+
+      it('should reject slug with multiple ".." segments', () => {
+        const result = manager.getCommand('../../../sensitive-file', 'user');
+        expect(result).toBeNull();
+      });
+
+      it('should reject slug starting with "."', () => {
+        const result = manager.getCommand('.hidden', 'user');
+        expect(result).toBeNull();
+      });
+
+      it('should reject slug with forward slash', () => {
+        const result = manager.getCommand('parent/child', 'user');
+        expect(result).toBeNull();
+      });
+
+      it('should reject slug with backward slash', () => {
+        const result = manager.getCommand('parent\\child', 'user');
+        expect(result).toBeNull();
+      });
+
+      it('should reject slug with null byte', () => {
+        const result = manager.getCommand('test\x00name', 'user');
+        expect(result).toBeNull();
+      });
+
+      it('should reject absolute path with /etc/passwd', () => {
+        const result = manager.getCommand('/etc/passwd', 'user');
+        expect(result).toBeNull();
+      });
+
+      it('should reject Windows absolute path C:\\file', () => {
+        const result = manager.getCommand('C:\\Windows\\System32', 'user');
+        expect(result).toBeNull();
+      });
+
+      it('should reject uppercase letters (not kebab-case)', () => {
+        const result = manager.getCommand('Deploy-Staging', 'user');
+        expect(result).toBeNull();
+      });
+
+      it('should reject underscore (not kebab-case)', () => {
+        const result = manager.getCommand('deploy_staging', 'user');
+        expect(result).toBeNull();
+      });
+
+      it('should reject leading hyphen', () => {
+        const result = manager.getCommand('-deploy', 'user');
+        expect(result).toBeNull();
+      });
+
+      it('should reject trailing hyphen', () => {
+        const result = manager.getCommand('deploy-', 'user');
+        expect(result).toBeNull();
+      });
+
+      it('should accept valid kebab-case slug', () => {
+        mockedFs.existsSync.mockReturnValue(true);
+        mockedFs.readFileSync.mockReturnValue(`---
+description: Test
+---
+test body`);
+        mockedFs.statSync.mockReturnValue({
+          size: 100,
+          mtimeMs: Date.now(),
+        } as any);
+
+        const result = manager.getCommand('valid-deploy-command', 'user');
+        expect(result).toBeDefined();
+      });
+
+      it('should accept single-character valid slug', () => {
+        mockedFs.existsSync.mockReturnValue(true);
+        mockedFs.readFileSync.mockReturnValue(`---
+description: Test
+---
+test body`);
+        mockedFs.statSync.mockReturnValue({
+          size: 100,
+          mtimeMs: Date.now(),
+        } as any);
+
+        const result = manager.getCommand('x', 'user');
+        expect(result).toBeDefined();
+      });
+
+      it('should accept slug with numbers', () => {
+        mockedFs.existsSync.mockReturnValue(true);
+        mockedFs.readFileSync.mockReturnValue(`---
+description: Test
+---
+test body`);
+        mockedFs.statSync.mockReturnValue({
+          size: 100,
+          mtimeMs: Date.now(),
+        } as any);
+
+        const result = manager.getCommand('deploy-v2-prod', 'user');
+        expect(result).toBeDefined();
+      });
+    });
+
+    describe('updateCommand() slug validation', () => {
+      it('should throw when updating with path traversal slug', () => {
+        expect(() => {
+          manager.updateCommand({
+            slug: '../../etc/passwd',
+            scope: 'user',
+            description: 'malicious',
+          });
+        }).toThrow('Invalid command slug');
+      });
+
+      it('should throw when updating with multiple ".." segments', () => {
+        expect(() => {
+          manager.updateCommand({
+            slug: '../../../config',
+            scope: 'user',
+            description: 'malicious',
+          });
+        }).toThrow('Invalid command slug');
+      });
+
+      it('should throw when updating with forward slash', () => {
+        expect(() => {
+          manager.updateCommand({
+            slug: 'parent/child',
+            scope: 'user',
+            description: 'malicious',
+          });
+        }).toThrow('Invalid command slug');
+      });
+
+      it('should throw when updating with backward slash', () => {
+        expect(() => {
+          manager.updateCommand({
+            slug: 'parent\\child',
+            scope: 'user',
+            description: 'malicious',
+          });
+        }).toThrow('Invalid command slug');
+      });
+
+      it('should throw when updating with absolute path', () => {
+        expect(() => {
+          manager.updateCommand({
+            slug: '/etc/passwd',
+            scope: 'user',
+            description: 'malicious',
+          });
+        }).toThrow('Invalid command slug');
+      });
+
+      it('should throw when updating with Windows absolute path', () => {
+        expect(() => {
+          manager.updateCommand({
+            slug: 'C:\\Windows\\System32',
+            scope: 'user',
+            description: 'malicious',
+          });
+        }).toThrow('Invalid command slug');
+      });
+
+      it('should throw when updating with null byte', () => {
+        expect(() => {
+          manager.updateCommand({
+            slug: 'test\x00file',
+            scope: 'user',
+            description: 'malicious',
+          });
+        }).toThrow('Invalid command slug');
+      });
+
+      it('should succeed when updating with valid kebab-case slug', () => {
+        mockedFs.existsSync.mockReturnValue(true);
+        mockedFs.readFileSync.mockReturnValue(`---
+description: Original
+---
+body`);
+        mockedFs.statSync.mockReturnValue({
+          size: 100,
+          mtimeMs: Date.now(),
+        } as any);
+
+        const result = manager.updateCommand({
+          slug: 'valid-slug',
+          scope: 'user',
+          description: 'Updated',
+        });
+
+        expect(result).toBeDefined();
+        expect(result.description).toBe('Updated');
+      });
+    });
+
+    describe('deleteCommand() slug validation', () => {
+      it('should return false when deleting with path traversal slug', () => {
+        const result = manager.deleteCommand({
+          slug: '../../etc/passwd',
+          scope: 'user',
+        });
+        expect(result).toBe(false);
+      });
+
+      it('should return false when deleting with ".." slug', () => {
+        const result = manager.deleteCommand({
+          slug: '../../../config',
+          scope: 'user',
+        });
+        expect(result).toBe(false);
+      });
+
+      it('should return false when deleting with forward slash', () => {
+        const result = manager.deleteCommand({
+          slug: 'parent/child',
+          scope: 'user',
+        });
+        expect(result).toBe(false);
+      });
+
+      it('should return false when deleting with backward slash', () => {
+        const result = manager.deleteCommand({
+          slug: 'parent\\child',
+          scope: 'user',
+        });
+        expect(result).toBe(false);
+      });
+
+      it('should return false when deleting with absolute path', () => {
+        const result = manager.deleteCommand({
+          slug: '/etc/passwd',
+          scope: 'user',
+        });
+        expect(result).toBe(false);
+      });
+
+      it('should return false when deleting with Windows absolute path', () => {
+        const result = manager.deleteCommand({
+          slug: 'C:\\sensitive\\file',
+          scope: 'user',
+        });
+        expect(result).toBe(false);
+      });
+
+      it('should return false when deleting with null byte', () => {
+        const result = manager.deleteCommand({
+          slug: 'test\x00data',
+          scope: 'user',
+        });
+        expect(result).toBe(false);
+      });
+
+      it('should succeed when deleting with valid kebab-case slug', () => {
+        mockedFs.existsSync.mockReturnValue(true);
+
+        const result = manager.deleteCommand({
+          slug: 'valid-slug',
+          scope: 'user',
+        });
+
+        expect(result).toBe(true);
+        expect(mockedFs.unlinkSync).toHaveBeenCalled();
+      });
+
+      it('should not call fs.unlinkSync for invalid slug', () => {
+        mockedFs.existsSync.mockReturnValue(true);
+
+        manager.deleteCommand({
+          slug: '../../etc/passwd',
+          scope: 'user',
+        });
+
+        // unlinkSync should NOT be called because slug validation fails first
+        expect(mockedFs.unlinkSync).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('Slug validation order (guard first, filesystem second)', () => {
+      it('should reject invalid slug before checking filesystem', () => {
+        // Set existsSync to always return true (pretend file exists everywhere)
+        mockedFs.existsSync.mockReturnValue(true);
+
+        // Try to delete a dangerous slug
+        const result = manager.deleteCommand({
+          slug: '../../etc/passwd',
+          scope: 'user',
+        });
+
+        // Should return false WITHOUT calling any filesystem methods
+        expect(result).toBe(false);
+        expect(mockedFs.existsSync).not.toHaveBeenCalled();
+      });
+
+      it('should reject invalid slug in updateCommand before checking filesystem', () => {
+        mockedFs.existsSync.mockReturnValue(true);
+
+        expect(() => {
+          manager.updateCommand({
+            slug: '../../../sensitive',
+            scope: 'user',
+            description: 'test',
+          });
+        }).toThrow('Invalid command slug');
+
+        // Filesystem methods should not be called
+        expect(mockedFs.existsSync).not.toHaveBeenCalled();
+      });
+
+      it('should reject invalid slug in getCommand before checking filesystem', () => {
+        mockedFs.existsSync.mockReturnValue(true);
+
+        const result = manager.getCommand('../../etc/hosts', 'user');
+
+        expect(result).toBeNull();
+        // existsSync should not be called because slug is invalid
+        expect(mockedFs.existsSync).not.toHaveBeenCalled();
+      });
+    });
+  });
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // YAML INJECTION TESTS
+  // ──────────────────────────────────────────────────────────────────────────
+
+  describe('YAML Injection Prevention', () => {
+    describe('serializeCommand() description sanitization', () => {
+      it('should sanitize newline in description', () => {
+        const cmd: CustomCommand = {
+          slug: 'test',
+          description: 'Line 1\nLine 2',
+          body: 'test body',
+          parameters: [],
+          scope: 'user',
+          filePath: '/test.md',
+          tags: [],
+          icon: 'Terminal',
+          updatedAt: Date.now(),
+        };
+
+        // Import the internal serializeCommand function for testing
+        // We'll verify the output by mocking and checking what gets written
+        mockedFs.existsSync.mockReturnValue(false);
+
+        manager.createCommand({
+          name: 'Test',
+          description: 'Line 1\nLine 2',
+          body: 'test body',
+          scope: 'user',
+        });
+
+        const writtenContent = mockedFs.writeFileSync.mock.calls[0][1];
+        const lines = (writtenContent as string).split('\n');
+
+        // Find the description line
+        const descLine = lines.find(l => l.startsWith('description:'));
+        expect(descLine).toBeDefined();
+
+        // The newline should be converted to a space, so description line should NOT contain a literal newline
+        const descValue = descLine?.substring('description:'.length).trim();
+        expect(descValue).toBe('Line 1 Line 2');
+      });
+
+      it('should sanitize carriage return in description', () => {
+        mockedFs.existsSync.mockReturnValue(false);
+
+        manager.createCommand({
+          name: 'Test',
+          description: 'Line 1\rLine 2',
+          body: 'test body',
+          scope: 'user',
+        });
+
+        const writtenContent = mockedFs.writeFileSync.mock.calls[0][1];
+        const lines = (writtenContent as string).split('\n');
+
+        const descLine = lines.find(l => l.startsWith('description:'));
+        const descValue = descLine?.substring('description:'.length).trim();
+
+        // Carriage return should be converted to space
+        expect(descValue).toBe('Line 1 Line 2');
+      });
+
+      it('should sanitize multiple newlines in description', () => {
+        mockedFs.existsSync.mockReturnValue(false);
+
+        manager.createCommand({
+          name: 'Test',
+          description: 'Line 1\n\nLine 2\n\nLine 3',
+          body: 'test body',
+          scope: 'user',
+        });
+
+        const writtenContent = mockedFs.writeFileSync.mock.calls[0][1];
+
+        // The entire frontmatter should be intact (not prematurely closed by injection)
+        expect(writtenContent).toContain('---');
+
+        // Count closing --- to ensure frontmatter is not broken
+        const frontmatterMatches = (writtenContent as string).match(/^---\n/gm);
+        expect(frontmatterMatches).toBeDefined();
+      });
+
+      it('should prevent YAML injection by sanitizing description newlines', () => {
+        mockedFs.existsSync.mockReturnValue(false);
+
+        // Attempt injection: close frontmatter, add injected content
+        const injectedDescription = 'Description\n---\nInjected: true\n---\nBody';
+
+        manager.createCommand({
+          name: 'Test',
+          description: injectedDescription,
+          body: 'test body',
+          scope: 'user',
+        });
+
+        const writtenContent = mockedFs.writeFileSync.mock.calls[0][1] as string;
+
+        // Parse the written content
+        const lines = writtenContent.split('\n');
+
+        // Find the opening ---
+        let frontmatterEnd = -1;
+        for (let i = 1; i < lines.length; i++) {
+          if (lines[i] === '---') {
+            frontmatterEnd = i;
+            break;
+          }
+        }
+
+        // There should be exactly ONE closing --- after opening ---
+        // (not two because newlines were sanitized)
+        expect(frontmatterEnd).toBeGreaterThan(0);
+
+        // Count how many "---" appear in the entire output
+        const frontmatterCount = (writtenContent.match(/^---$/gm) || []).length;
+        expect(frontmatterCount).toBe(2); // Opening and closing only
+      });
+    });
+
+    describe('serializeCommand() parameter sanitization', () => {
+      it('should sanitize newline in parameter name', () => {
+        mockedFs.existsSync.mockReturnValue(false);
+
+        manager.createCommand({
+          name: 'Test',
+          description: 'Test',
+          body: 'test body',
+          scope: 'user',
+          parameters: [
+            {
+              name: 'env\ninjected',
+              description: 'Environment',
+              required: true,
+            },
+          ],
+        });
+
+        const writtenContent = mockedFs.writeFileSync.mock.calls[0][1] as string;
+
+        // The newline in parameter name should be converted to space
+        expect(writtenContent).toContain('name: env injected');
+        expect(writtenContent).not.toContain('name: env\ninjected');
+      });
+
+      it('should sanitize newline in parameter description', () => {
+        mockedFs.existsSync.mockReturnValue(false);
+
+        manager.createCommand({
+          name: 'Test',
+          description: 'Test',
+          body: 'test body',
+          scope: 'user',
+          parameters: [
+            {
+              name: 'env',
+              description: 'Line 1\nLine 2',
+              required: true,
+            },
+          ],
+        });
+
+        const writtenContent = mockedFs.writeFileSync.mock.calls[0][1] as string;
+
+        // The newline should be converted to space
+        expect(writtenContent).toContain('description: Line 1 Line 2');
+      });
+
+      it('should sanitize newline in parameter default value', () => {
+        mockedFs.existsSync.mockReturnValue(false);
+
+        manager.createCommand({
+          name: 'Test',
+          description: 'Test',
+          body: 'test body',
+          scope: 'user',
+          parameters: [
+            {
+              name: 'env',
+              description: 'Environment',
+              required: false,
+              default: 'staging\ninjected',
+            },
+          ],
+        });
+
+        const writtenContent = mockedFs.writeFileSync.mock.calls[0][1] as string;
+
+        // The newline in default value should be converted to space
+        expect(writtenContent).toContain('default: "staging injected"');
+      });
+
+      it('should prevent YAML injection in parameters by sanitizing newlines', () => {
+        mockedFs.existsSync.mockReturnValue(false);
+
+        manager.createCommand({
+          name: 'Test',
+          description: 'Test',
+          body: 'test body',
+          scope: 'user',
+          parameters: [
+            {
+              name: 'exploit\n---\nmalicious',
+              description: 'Try to inject',
+              required: true,
+            },
+          ],
+        });
+
+        const writtenContent = mockedFs.writeFileSync.mock.calls[0][1] as string;
+
+        // Count closing --- (should be exactly 2: opening and closing)
+        const frontmatterCount = (writtenContent.match(/^---$/gm) || []).length;
+        expect(frontmatterCount).toBe(2);
+      });
+
+      it('should handle multiple parameters with newlines', () => {
+        mockedFs.existsSync.mockReturnValue(false);
+
+        manager.createCommand({
+          name: 'Test',
+          description: 'Test\nDescription',
+          body: 'test body',
+          scope: 'user',
+          parameters: [
+            {
+              name: 'param1\ninjected',
+              description: 'First\nparam',
+              required: true,
+              default: 'value\ninjected',
+            },
+            {
+              name: 'param2',
+              description: 'Second',
+              required: false,
+              default: 'normal',
+            },
+          ],
+        });
+
+        const writtenContent = mockedFs.writeFileSync.mock.calls[0][1] as string;
+
+        // All newlines should be sanitized
+        expect(writtenContent).not.toContain('param1\ninjected');
+        expect(writtenContent).toContain('param1 injected');
+        expect(writtenContent).not.toContain('First\nparam');
+        expect(writtenContent).toContain('First param');
+      });
+    });
+
+    describe('YAML parsing resilience', () => {
+      it('should parse generated YAML correctly after sanitization', () => {
+        mockedFs.existsSync.mockReturnValue(false);
+
+        manager.createCommand({
+          name: 'Test',
+          description: 'Description\nwith\nnewlines',
+          body: 'test body',
+          scope: 'user',
+          parameters: [
+            {
+              name: 'param\ninjection',
+              description: 'Desc\nwith\ninjection',
+              required: true,
+              default: 'value\ninjection',
+            },
+          ],
+        });
+
+        const writtenContent = mockedFs.writeFileSync.mock.calls[0][1] as string;
+
+        // The output should have valid YAML structure
+        const lines = writtenContent.split('\n');
+        const openingIndex = lines.findIndex(l => l === '---');
+        const closingIndex = lines.findIndex((l, i) => i > openingIndex && l === '---');
+
+        expect(openingIndex).toBeGreaterThanOrEqual(0);
+        expect(closingIndex).toBeGreaterThan(openingIndex);
+
+        // Verify frontmatter section is well-formed
+        const frontmatter = lines.slice(openingIndex + 1, closingIndex).join('\n');
+        expect(frontmatter).toContain('description:');
+        expect(frontmatter).toContain('parameters:');
+      });
+
+      it('should allow legitimate newlines in command body (after ---)', () => {
+        mockedFs.existsSync.mockReturnValue(false);
+
+        const multilineBody = `#!/bin/bash
+if [ "$?" -eq 0 ]; then
+  echo "Success"
+else
+  exit 1
+fi`;
+
+        manager.createCommand({
+          name: 'Test',
+          description: 'Test script',
+          body: multilineBody,
+          scope: 'user',
+        });
+
+        const writtenContent = mockedFs.writeFileSync.mock.calls[0][1] as string;
+
+        // Body should retain all newlines
+        expect(writtenContent).toContain('if [ "$?" -eq 0 ]; then');
+        expect(writtenContent).toContain('echo "Success"');
+        expect(writtenContent).toContain('exit 1');
+      });
+    });
+  });
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // COMBINED SECURITY TESTS
+  // ──────────────────────────────────────────────────────────────────────────
+
+  describe('Combined Attack Scenarios', () => {
+    it('should prevent path traversal AND YAML injection combined', () => {
+      // Attempt to combine both attacks
+      const injectedSlug = '../../../etc/shadow';
+      const injectedDesc = 'Description\n---\nmalicious: true';
+
+      // The slug guard should catch this first
+      expect(() => {
+        manager.updateCommand({
+          slug: injectedSlug,
+          scope: 'user',
+          description: injectedDesc,
+        });
+      }).toThrow('Invalid command slug');
+
+      // File system should not be accessed
+      expect(mockedFs.existsSync).not.toHaveBeenCalled();
+    });
+
+    it('should sanitize YAML injection in parameters even with valid slug', () => {
+      mockedFs.existsSync.mockReturnValue(false);
+
+      manager.createCommand({
+        name: 'legitimate-command',
+        description: 'Legitimate description',
+        body: 'legitimate body',
+        scope: 'user',
+        parameters: [
+          {
+            name: 'param',
+            description: 'Close frontmatter\n---\ninjected: "malicious"',
+            required: false,
+          },
+        ],
+      });
+
+      const writtenContent = mockedFs.writeFileSync.mock.calls[0][1] as string;
+
+      // Should have exactly 2 --- (opening and closing, not 4 from injection)
+      const count = (writtenContent.match(/^---$/gm) || []).length;
+      expect(count).toBe(2);
+
+      // Verify the frontmatter doesn't contain the injection as a separate field
+      const lines = writtenContent.split('\n');
+      const frontmatterEnd = lines.findIndex((l, i) => i > 0 && l === '---');
+      const frontmatter = lines.slice(0, frontmatterEnd).join('\n');
+
+      // The "---" in the description should have been converted to spaces,
+      // so there should not be a separate "injected:" field after a "---" delimiter
+      const afterClosing = lines.slice(frontmatterEnd + 1).join('\n');
+      expect(afterClosing).not.toMatch(/^\s*injected:/m);
+    });
+  });
+});

--- a/src/main/custom-command-manager.test.ts
+++ b/src/main/custom-command-manager.test.ts
@@ -1,0 +1,843 @@
+/**
+ * Tests for CustomCommandManager
+ *
+ * Covers:
+ *   - Happy path: create, read, update, delete commands
+ *   - Duplicate name detection and conflict resolution
+ *   - Invalid inputs (empty name, reserved names, empty body)
+ *   - File system operations (atomic writes, directory creation)
+ *   - Session-only vs persistent commands
+ *   - Command listing with scope merging
+ *   - Name validation and slug generation
+ *   - File watching and debouncing
+ *   - Error handling for filesystem issues
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// Mock fs module BEFORE any imports that use it
+vi.mock('fs');
+
+// Mock os BEFORE any imports that use it
+vi.mock('os', () => ({
+  homedir: vi.fn(() => '/home/testuser'),
+}));
+
+// Mock IPCEmitter BEFORE importing CustomCommandManager
+vi.mock('./ipc-emitter');
+
+// NOW import the modules that were mocked above
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import { CustomCommandManager } from './custom-command-manager';
+import { IPCEmitter } from './ipc-emitter';
+import type { CustomCommand, CommandParameter } from '../shared/types/custom-command-types';
+
+const mockedFs = vi.mocked(fs);
+const mockedOs = vi.mocked(os);
+const MockedIPCEmitter = vi.mocked(IPCEmitter);
+
+describe('CustomCommandManager', () => {
+  let manager: CustomCommandManager;
+  let mockEmitter: any;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    // Reset fs mocks to default behaviors
+    mockedFs.existsSync.mockReturnValue(false);
+    mockedFs.mkdirSync.mockReturnValue(undefined);
+    mockedFs.writeFileSync.mockReturnValue(undefined);
+    mockedFs.renameSync.mockReturnValue(undefined);
+    mockedFs.readFileSync.mockReturnValue('');
+    mockedFs.statSync.mockReturnValue({
+      size: 100,
+      mtimeMs: Date.now(),
+    } as any);
+    mockedFs.readdirSync.mockReturnValue([]);
+    mockedFs.watch.mockReturnValue({
+      close: vi.fn(),
+      on: vi.fn(function () {
+        return this;
+      }),
+    } as any);
+    mockedFs.unlinkSync.mockReturnValue(undefined);
+
+    mockEmitter = {
+      emit: vi.fn(),
+    };
+
+    manager = new CustomCommandManager();
+    manager.setEmitter(mockEmitter);
+  });
+
+  afterEach(() => {
+    manager.destroy();
+  });
+
+  // ── Happy Path Tests ────────────────────────────────────────────────────
+
+  describe('happy path', () => {
+    it('should create a user-scoped command and write to disk', () => {
+      mockedFs.existsSync.mockReturnValue(false);
+
+      const request = {
+        name: 'Deploy Staging',
+        description: 'Deploy to staging environment',
+        body: 'npm run deploy:staging',
+        scope: 'user' as const,
+      };
+
+      const cmd = manager.createCommand(request);
+
+      expect(cmd.slug).toBe('deploy-staging');
+      expect(cmd.description).toBe('Deploy to staging environment');
+      expect(cmd.body).toBe('npm run deploy:staging');
+      expect(cmd.scope).toBe('user');
+      expect(cmd.filePath).toContain('deploy-staging.md');
+      expect(cmd.parameters).toEqual([]);
+      expect(cmd.tags).toEqual([]);
+      expect(cmd.icon).toBe('Terminal');
+
+      // Verify atomic write was called
+      expect(mockedFs.writeFileSync).toHaveBeenCalled();
+      expect(mockedFs.renameSync).toHaveBeenCalled();
+    });
+
+    it('should create a project-scoped command', () => {
+      mockedFs.existsSync.mockReturnValue(false);
+
+      const request = {
+        name: 'Run Tests',
+        description: 'Run test suite',
+        body: 'npm test',
+        scope: 'project' as const,
+        projectDir: '/home/user/project',
+      };
+
+      const cmd = manager.createCommand(request);
+
+      expect(cmd.slug).toBe('run-tests');
+      expect(cmd.scope).toBe('project');
+      // Handle both Unix and Windows path separators
+      expect(cmd.filePath).toMatch(/run-tests\.md$/);
+      expect(cmd.filePath).toMatch(/\.claude[\\/]commands/);
+    });
+
+    it('should create a session-only command (not written to disk)', () => {
+      const request = {
+        name: 'Session Command',
+        description: 'Temporary session command',
+        body: 'echo hello',
+        scope: 'session' as const,
+        sessionId: 'session-1',
+      };
+
+      const cmd = manager.createCommand(request);
+
+      expect(cmd.slug).toBe('session-command');
+      expect(cmd.scope).toBe('session');
+      expect(cmd.filePath).toBeNull();
+
+      // Verify no filesystem operations
+      expect(mockedFs.writeFileSync).not.toHaveBeenCalled();
+      expect(mockedFs.renameSync).not.toHaveBeenCalled();
+    });
+
+    it('should create command with parameters', () => {
+      mockedFs.existsSync.mockReturnValue(false);
+
+      const params: CommandParameter[] = [
+        {
+          name: 'environment',
+          description: 'Deployment environment',
+          required: true,
+          default: 'staging',
+        },
+        {
+          name: 'verbose',
+          description: 'Enable verbose output',
+          required: false,
+        },
+      ];
+
+      const request = {
+        name: 'Deploy',
+        description: 'Deploy app',
+        body: 'deploy --env={{environment}} {{verbose && "--verbose"}}',
+        scope: 'user' as const,
+        parameters: params,
+      };
+
+      const cmd = manager.createCommand(request);
+
+      expect(cmd.parameters).toHaveLength(2);
+      expect(cmd.parameters[0].name).toBe('environment');
+      expect(cmd.parameters[0].required).toBe(true);
+      expect(cmd.parameters[0].default).toBe('staging');
+    });
+
+    it('should create command with tags and icon', () => {
+      mockedFs.existsSync.mockReturnValue(false);
+
+      const request = {
+        name: 'Build',
+        description: 'Build project',
+        body: 'npm run build',
+        scope: 'user' as const,
+        tags: ['build', 'production'],
+        icon: 'Hammer',
+      };
+
+      const cmd = manager.createCommand(request);
+
+      expect(cmd.tags).toEqual(['build', 'production']);
+      expect(cmd.icon).toBe('Hammer');
+    });
+
+    it('should list commands with shadowing logic', () => {
+      // Mock existence checks
+      mockedFs.existsSync.mockImplementation((filePath) => {
+        if (typeof filePath === 'string' && filePath.includes('.md')) {
+          return true; // Pretend all .md files exist
+        }
+        return false;
+      });
+
+      mockedFs.readFileSync.mockReturnValue(`---
+description: Test
+---
+test body`);
+
+      mockedFs.statSync.mockReturnValue({
+        size: 100,
+        mtimeMs: Date.now(),
+      } as any);
+
+      // List with projectDir should attempt to load both project and user scopes
+      const cmds = manager.listCommands({
+        projectDir: '/home/user/project',
+      });
+
+      // The listing should work without errors
+      expect(Array.isArray(cmds)).toBe(true);
+      expect(cmds).toBeDefined();
+    });
+
+    it('should update an existing command', () => {
+      mockedFs.existsSync.mockReturnValue(true);
+      mockedFs.readFileSync.mockReturnValue(`---
+description: Old description
+---
+old body`);
+      mockedFs.statSync.mockReturnValue({
+        size: 100,
+        mtimeMs: Date.now(),
+      } as any);
+
+      const updateRequest = {
+        slug: 'deploy-staging',
+        scope: 'user' as const,
+        description: 'New description',
+        body: 'new body',
+      };
+
+      const updated = manager.updateCommand(updateRequest);
+
+      expect(updated.description).toBe('New description');
+      expect(updated.body).toBe('new body');
+      expect(mockedFs.writeFileSync).toHaveBeenCalled();
+    });
+
+    it('should delete a command', () => {
+      mockedFs.existsSync.mockReturnValue(true);
+
+      const deleteRequest = {
+        slug: 'deploy-staging',
+        scope: 'user' as const,
+      };
+
+      const deleted = manager.deleteCommand(deleteRequest);
+
+      expect(deleted).toBe(true);
+      expect(mockedFs.unlinkSync).toHaveBeenCalled();
+    });
+
+    it('should return false when deleting non-existent command', () => {
+      mockedFs.existsSync.mockReturnValue(false);
+
+      const deleteRequest = {
+        slug: 'nonexistent',
+        scope: 'user' as const,
+      };
+
+      const deleted = manager.deleteCommand(deleteRequest);
+
+      expect(deleted).toBe(false);
+    });
+  });
+
+  // ── Validation Tests ────────────────────────────────────────────────────
+
+  describe('name validation', () => {
+    it('should reject empty name', () => {
+      const validation = manager.validateName('', 'user');
+
+      expect(validation.valid).toBe(false);
+      expect(validation.errors).toContain(
+        'Command name must contain at least one alphanumeric character',
+      );
+    });
+
+    it('should reject reserved command names', () => {
+      const validation = manager.validateName('help', 'user');
+
+      expect(validation.valid).toBe(false);
+      expect(validation.errors).toContain('"help" is a reserved Claude Code command name');
+    });
+
+    it('should reject all reserved names', () => {
+      const reserved = ['help', 'init', 'config', 'login', 'logout', 'version', 'update'];
+
+      for (const name of reserved) {
+        const validation = manager.validateName(name, 'user');
+        expect(validation.valid).toBe(false);
+        expect(validation.errors).toContain(
+          `"${name}" is a reserved Claude Code command name`,
+        );
+      }
+    });
+
+    it('should detect duplicate names in same scope', () => {
+      mockedFs.existsSync.mockReturnValue(true);
+
+      const validation = manager.validateName('deploy-staging', 'user');
+
+      expect(validation.valid).toBe(false);
+      expect(validation.errors).toContain(
+        'A command named "deploy-staging" already exists in user scope',
+      );
+    });
+
+    it('should suggest a valid slug from messy input', () => {
+      mockedFs.existsSync.mockReturnValue(false);
+
+      const validation = manager.validateName('  My Deploy Script!  ', 'user');
+
+      expect(validation.suggestedSlug).toBe('my-deploy-script');
+      expect(validation.valid).toBe(true);
+    });
+
+    it('should handle spaces, underscores, and special chars', () => {
+      mockedFs.existsSync.mockReturnValue(false);
+
+      const validation = manager.validateName('run_tests-now!', 'user');
+
+      expect(validation.suggestedSlug).toBe('run-tests-now');
+      expect(validation.valid).toBe(true);
+    });
+
+    it('should reject very long names', () => {
+      mockedFs.existsSync.mockReturnValue(false);
+
+      const longName = 'a'.repeat(100);
+      const cmd = manager.createCommand({
+        name: longName,
+        description: 'Test',
+        body: 'test',
+        scope: 'user',
+      });
+
+      // Slug should be truncated to 60 chars
+      expect(cmd.slug.length).toBeLessThanOrEqual(60);
+    });
+  });
+
+  // ── Invalid Input Tests ─────────────────────────────────────────────────
+
+  describe('invalid inputs', () => {
+    it('should throw when creating with empty description', () => {
+      mockedFs.existsSync.mockReturnValue(false);
+
+      const request = {
+        name: 'Valid Name',
+        description: '', // Empty description should still work (shown as empty in UI)
+        body: 'body',
+        scope: 'user' as const,
+      };
+
+      // Should not throw - empty description is allowed
+      const cmd = manager.createCommand(request);
+      expect(cmd.description).toBe('');
+    });
+
+    it('should throw when creating with empty body', () => {
+      mockedFs.existsSync.mockReturnValue(false);
+
+      const request = {
+        name: 'Valid Name',
+        description: 'Test',
+        body: '', // Empty body
+        scope: 'user' as const,
+      };
+
+      // Should not throw - empty body is technically allowed (unusual but not invalid)
+      const cmd = manager.createCommand(request);
+      expect(cmd.body).toBe('');
+    });
+
+    it('should throw when creating session command without sessionId', () => {
+      const request = {
+        name: 'Session Cmd',
+        description: 'Test',
+        body: 'body',
+        scope: 'session' as const,
+        // Missing sessionId
+      };
+
+      expect(() => manager.createCommand(request as any)).toThrow(
+        'sessionId is required for session-scoped commands',
+      );
+    });
+
+    it('should throw when creating project command without projectDir', () => {
+      mockedFs.existsSync.mockReturnValue(false);
+
+      const request = {
+        name: 'Project Cmd',
+        description: 'Test',
+        body: 'body',
+        scope: 'project' as const,
+        // Missing projectDir
+      };
+
+      expect(() => manager.createCommand(request as any)).toThrow(
+        'projectDir is required for project-scoped commands',
+      );
+    });
+
+    it('should throw on duplicate command name in same scope', () => {
+      mockedFs.existsSync.mockReturnValue(true);
+
+      const request = {
+        name: 'Existing Command',
+        description: 'Test',
+        body: 'body',
+        scope: 'user' as const,
+      };
+
+      expect(() => manager.createCommand(request)).toThrow(
+        'A command named "existing-command" already exists in user scope',
+      );
+    });
+
+    it('should allow duplicate names across different scopes', () => {
+      mockedFs.existsSync.mockReturnValue(false);
+
+      // Create in user scope
+      const userCmd = manager.createCommand({
+        name: 'Deploy',
+        description: 'User deploy',
+        body: 'user deploy',
+        scope: 'user',
+      });
+
+      // Create same name in project scope
+      const projectCmd = manager.createCommand({
+        name: 'Deploy',
+        description: 'Project deploy',
+        body: 'project deploy',
+        scope: 'project',
+        projectDir: '/home/user/project',
+      });
+
+      expect(userCmd.slug).toBe(projectCmd.slug);
+      expect(userCmd.scope).not.toBe(projectCmd.scope);
+    });
+  });
+
+  // ── File System Error Handling ──────────────────────────────────────────
+
+  describe('file system error handling', () => {
+    it('should handle mkdirSync failure gracefully', () => {
+      mockedFs.mkdirSync.mockImplementation(() => {
+        throw new Error('Permission denied');
+      });
+
+      const request = {
+        name: 'Deploy',
+        description: 'Test',
+        body: 'body',
+        scope: 'user' as const,
+      };
+
+      expect(() => manager.createCommand(request)).toThrow('Permission denied');
+    });
+
+    it('should handle write failure and clean up temp file', () => {
+      mockedFs.existsSync.mockReturnValue(false);
+      mockedFs.writeFileSync.mockImplementation(() => {
+        throw new Error('Disk full');
+      });
+
+      const request = {
+        name: 'Deploy',
+        description: 'Test',
+        body: 'body',
+        scope: 'user' as const,
+      };
+
+      expect(() => manager.createCommand(request)).toThrow('Disk full');
+    });
+
+    it('should handle delete failure gracefully', () => {
+      mockedFs.existsSync.mockReturnValue(true);
+      mockedFs.unlinkSync.mockImplementation(() => {
+        throw new Error('Permission denied');
+      });
+
+      const deleteRequest = {
+        slug: 'deploy',
+        scope: 'user' as const,
+      };
+
+      const deleted = manager.deleteCommand(deleteRequest);
+      expect(deleted).toBe(false);
+    });
+
+    it('should skip oversized files when scanning directories', () => {
+      const largeFile = { name: 'large.md', isFile: () => true };
+      mockedFs.readdirSync.mockReturnValue([largeFile] as any);
+
+      // First call: stat returns large file
+      mockedFs.statSync.mockReturnValue({
+        size: 100000, // > 50KB
+        mtimeMs: Date.now(),
+      } as any);
+
+      const cmds = manager.listCommands({});
+
+      expect(cmds).toHaveLength(0); // Should skip large file
+    });
+  });
+
+  // ── Session Management Tests ────────────────────────────────────────────
+
+  describe('session-only commands', () => {
+    it('should store session commands in memory only', () => {
+      const sessionId = 'session-1';
+
+      manager.createCommand({
+        name: 'Temp',
+        description: 'Temporary',
+        body: 'body',
+        scope: 'session',
+        sessionId,
+      });
+
+      // Verify no filesystem calls
+      expect(mockedFs.writeFileSync).not.toHaveBeenCalled();
+    });
+
+    it('should update session-only command', () => {
+      const sessionId = 'session-1';
+
+      const created = manager.createCommand({
+        name: 'Temp',
+        description: 'Original',
+        body: 'original body',
+        scope: 'session',
+        sessionId,
+      });
+
+      const updated = manager.updateCommand({
+        slug: 'temp',
+        scope: 'session',
+        sessionId,
+        description: 'Updated',
+      });
+
+      expect(updated.description).toBe('Updated');
+      expect(updated.body).toBe('original body'); // Unchanged
+    });
+
+    it('should list session commands separately', () => {
+      const sessionId = 'session-1';
+
+      manager.createCommand({
+        name: 'Session Cmd',
+        description: 'In session',
+        body: 'body',
+        scope: 'session',
+        sessionId,
+      });
+
+      const cmds = manager.listCommands({ sessionId });
+
+      expect(cmds.some(c => c.scope === 'session')).toBe(true);
+    });
+
+    it('should cleanup session commands when session is closed', () => {
+      const sessionId = 'session-1';
+
+      manager.createCommand({
+        name: 'Temp',
+        description: 'Test',
+        body: 'body',
+        scope: 'session',
+        sessionId,
+      });
+
+      manager.cleanupSession(sessionId);
+
+      const cmds = manager.listCommands({ sessionId });
+      expect(cmds.filter(c => c.scope === 'session')).toHaveLength(0);
+    });
+
+    it('should throw when updating session command without sessionId', () => {
+      const updateRequest = {
+        slug: 'temp',
+        scope: 'session' as const,
+        // Missing sessionId
+      };
+
+      expect(() => manager.updateCommand(updateRequest as any)).toThrow(
+        'sessionId is required for session-scoped commands',
+      );
+    });
+  });
+
+  // ── Slug and Name Handling ──────────────────────────────────────────────
+
+  describe('slug and name handling', () => {
+    it('should convert names to kebab-case slugs', () => {
+      mockedFs.existsSync.mockReturnValue(false);
+
+      const testCases = [
+        { name: 'Deploy Staging', slug: 'deploy-staging' },
+        { name: 'run_tests', slug: 'run-tests' },
+        { name: 'My-Test-Script', slug: 'my-test-script' },
+        { name: '  trim   spaces  ', slug: 'trim-spaces' },
+        { name: 'UPPERCASE', slug: 'uppercase' },
+        { name: 'CamelCase', slug: 'camelcase' },
+        { name: 'test123script', slug: 'test123script' },
+        { name: '123-numbers', slug: '123-numbers' },
+      ];
+
+      for (const { name, slug } of testCases) {
+        const cmd = manager.createCommand({
+          name,
+          description: 'Test',
+          body: 'body',
+          scope: 'user',
+        });
+        expect(cmd.slug).toBe(slug);
+      }
+    });
+
+    it('should handle single-character slug', () => {
+      mockedFs.existsSync.mockReturnValue(false);
+
+      const cmd = manager.createCommand({
+        name: 'x',
+        description: 'Single char',
+        body: 'body',
+        scope: 'user',
+      });
+
+      expect(cmd.slug).toBe('x');
+    });
+  });
+
+  // ── File Watching Tests ─────────────────────────────────────────────────
+
+  describe('file watching and debouncing', () => {
+    it('should watch user commands directory on creation', () => {
+      const manager2 = new CustomCommandManager();
+
+      expect(mockedFs.watch).toHaveBeenCalled();
+      const callArgs = mockedFs.watch.mock.calls[0];
+      // Handle both Unix and Windows path separators
+      expect(String(callArgs[0])).toMatch(/\.claude[\\/]commands/);
+
+      manager2.destroy();
+    });
+
+    it('should debounce file change notifications', async () => {
+      manager.setProjectDir('/home/user/project');
+
+      // Simulate multiple file change events
+      const watchCallback = mockedFs.watch.mock.calls[0][1];
+      const onEvent = (mockedFs.watch as any).mock.results[0].value.on;
+
+      expect(onEvent).toBeDefined();
+      // Note: Full debounce testing would require clock mocking (vi.useFakeTimers)
+    });
+
+    it('should emit command changed events', () => {
+      const manager2 = new CustomCommandManager();
+      const mockEmitter2 = { emit: vi.fn() };
+      manager2.setEmitter(mockEmitter2);
+
+      // The emitter should be set and available
+      expect(mockEmitter2).toBeDefined();
+
+      manager2.destroy();
+    });
+
+    it('should close watchers on destroy', () => {
+      const mockWatcher = {
+        close: vi.fn(),
+        on: vi.fn(function () {
+          return this;
+        }),
+      };
+      mockedFs.watch.mockReturnValue(mockWatcher as any);
+
+      const manager2 = new CustomCommandManager();
+      manager2.destroy();
+
+      // Watcher should be closed (mocked)
+      expect(mockWatcher.close).toHaveBeenCalled();
+    });
+  });
+
+  // ── GetCommand and GetCommand Tests ────────────────────────────────────
+
+  describe('get single command', () => {
+    it('should retrieve a single command by slug and scope', () => {
+      mockedFs.existsSync.mockReturnValue(true);
+      mockedFs.readFileSync.mockReturnValue(`---
+description: Test Command
+---
+body content`);
+      mockedFs.statSync.mockReturnValue({
+        size: 100,
+        mtimeMs: Date.now(),
+      } as any);
+
+      const cmd = manager.getCommand('test-cmd', 'user');
+
+      expect(cmd).toBeDefined();
+      expect(cmd?.slug).toBe('test-cmd');
+      expect(cmd?.description).toBe('Test Command');
+    });
+
+    it('should return null for non-existent command', () => {
+      mockedFs.existsSync.mockReturnValue(false);
+
+      const cmd = manager.getCommand('nonexistent', 'user');
+
+      expect(cmd).toBeNull();
+    });
+
+    it('should return null for session scope (requires sessionId)', () => {
+      const cmd = manager.getCommand('test', 'session');
+
+      expect(cmd).toBeNull();
+    });
+  });
+
+  // ── Update Command Edge Cases ───────────────────────────────────────────
+
+  describe('update command edge cases', () => {
+    it('should throw when updating non-existent command', () => {
+      mockedFs.existsSync.mockReturnValue(false);
+
+      const updateRequest = {
+        slug: 'nonexistent',
+        scope: 'user' as const,
+        description: 'New description',
+      };
+
+      expect(() => manager.updateCommand(updateRequest)).toThrow(
+        'Command "nonexistent" not found in user scope',
+      );
+    });
+
+    it('should throw when updating session command not found', () => {
+      const updateRequest = {
+        slug: 'nonexistent',
+        scope: 'session' as const,
+        sessionId: 'session-1',
+        description: 'New description',
+      };
+
+      expect(() => manager.updateCommand(updateRequest)).toThrow(
+        'Session command "nonexistent" not found',
+      );
+    });
+
+    it('should preserve unspecified fields during update', () => {
+      mockedFs.existsSync.mockReturnValue(true);
+      mockedFs.readFileSync.mockReturnValue(`---
+description: Original
+tags:
+  - tag1
+---
+original body`);
+      mockedFs.statSync.mockReturnValue({
+        size: 100,
+        mtimeMs: Date.now(),
+      } as any);
+
+      const updated = manager.updateCommand({
+        slug: 'test',
+        scope: 'user',
+        description: 'Updated',
+        // body not specified, so should remain unchanged
+      });
+
+      expect(updated.description).toBe('Updated');
+      expect(updated.body).toContain('original body');
+    });
+  });
+
+  // ── Project Dir Management ──────────────────────────────────────────────
+
+  describe('project directory management', () => {
+    it('should change watched project directory', () => {
+      manager.setProjectDir('/home/user/project1');
+
+      // Should create a new watcher
+      expect(mockedFs.watch).toHaveBeenCalled();
+
+      manager.setProjectDir('/home/user/project2');
+
+      // Should have been called again
+      expect(mockedFs.watch.mock.calls.length).toBeGreaterThan(1);
+    });
+
+    it('should close old watcher when changing project dir', () => {
+      const mockWatcher = {
+        close: vi.fn(),
+        on: vi.fn(function () {
+          return this;
+        }),
+      };
+      mockedFs.watch.mockReturnValue(mockWatcher as any);
+
+      manager.setProjectDir('/home/user/project1');
+      manager.setProjectDir('/home/user/project2');
+
+      // Old watcher should be closed
+      expect(mockWatcher.close).toHaveBeenCalled();
+    });
+
+    it('should clear project dir by passing null', () => {
+      const mockWatcher = {
+        close: vi.fn(),
+        on: vi.fn(function () {
+          return this;
+        }),
+      };
+      mockedFs.watch.mockReturnValue(mockWatcher as any);
+
+      manager.setProjectDir('/home/user/project');
+      manager.setProjectDir(null);
+
+      expect(mockWatcher.close).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/main/custom-command-manager.ts
+++ b/src/main/custom-command-manager.ts
@@ -1,0 +1,644 @@
+/**
+ * CustomCommandManager — manages Claude Code custom slash commands.
+ *
+ * Commands are stored as Markdown files with YAML frontmatter in:
+ *   - Project scope: <projectDir>/.claude/commands/*.md
+ *   - User scope:    ~/.claude/commands/*.md
+ *   - Session scope: in-memory Map (never written to disk)
+ *
+ * The format aligns with Claude Code's native custom command convention so that
+ * commands created here also work in standalone claude CLI sessions.
+ *
+ * File watching uses a 500ms debounce (same pattern as GitManager) because
+ * Windows fs.watch fires multiple events per file change.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import { IPCEmitter } from './ipc-emitter';
+import { isValidCommandSlug } from '../shared/types/custom-command-types';
+import type {
+  CustomCommand,
+  CommandScope,
+  CommandParameter,
+  CommandListRequest,
+  CommandCreateRequest,
+  CommandUpdateRequest,
+  CommandDeleteRequest,
+  CommandValidation,
+} from '../shared/types/custom-command-types';
+
+// ── Constants ──────────────────────────────────────────────────────────────
+
+const USER_COMMANDS_DIR = path.join(os.homedir(), '.claude', 'commands');
+const MAX_FILE_SIZE_BYTES = 51200; // 50 KB
+
+/**
+ * Claude Code built-in command names that must not be shadowed.
+ * Validated against the slug (lowercased, hyphenated) form of the user's input.
+ */
+const FORBIDDEN_SLUGS = new Set([
+  'help', 'init', 'config', 'login', 'logout', 'version', 'update',
+]);
+
+// ── YAML frontmatter parser (no external dependency) ──────────────────────
+
+interface ParsedFrontmatter {
+  meta: Record<string, unknown>;
+  body: string;
+}
+
+/**
+ * Minimal YAML parser for our specific frontmatter schema.
+ * Handles: string scalars, booleans, lists of scalars, lists of objects.
+ * Does NOT attempt to handle YAML anchors, multiline strings, or quotes.
+ */
+function parseSimpleYaml(yaml: string): Record<string, unknown> {
+  const result: Record<string, unknown> = {};
+  const lines = yaml.split(/\r?\n/);
+  let i = 0;
+
+  while (i < lines.length) {
+    const line = lines[i];
+
+    // Skip blank lines
+    if (!line.trim()) { i++; continue; }
+
+    // Root-level key: value (non-empty value on the same line)
+    const kvMatch = line.match(/^(\w+):\s+(.+)$/);
+    if (kvMatch) {
+      const val = kvMatch[2].trim();
+      if (val === 'true') result[kvMatch[1]] = true;
+      else if (val === 'false') result[kvMatch[1]] = false;
+      else result[kvMatch[1]] = val;
+      i++;
+      continue;
+    }
+
+    // Root-level key: (no value — starts an array)
+    const listKeyMatch = line.match(/^(\w+):\s*$/);
+    if (listKeyMatch) {
+      const key = listKeyMatch[1];
+      const items: unknown[] = [];
+      i++;
+
+      while (i < lines.length) {
+        const subLine = lines[i];
+
+        // Skip blank lines inside a list
+        if (!subLine.trim()) { i++; continue; }
+
+        // End of list: line is not indented
+        if (!subLine.startsWith('  ')) break;
+
+        // Object list item: "  - firstKey: value"
+        const objItemMatch = subLine.match(/^  - (\w+):\s*(.*)$/);
+        if (objItemMatch) {
+          const item: Record<string, unknown> = {};
+          const firstVal = objItemMatch[2].trim();
+          if (firstVal === 'true') item[objItemMatch[1]] = true;
+          else if (firstVal === 'false') item[objItemMatch[1]] = false;
+          else item[objItemMatch[1]] = firstVal;
+          i++;
+
+          // Read continuation properties: "    key: value"
+          while (i < lines.length) {
+            const propLine = lines[i];
+            if (!propLine.trim()) { i++; continue; }
+            if (!propLine.startsWith('    ')) break;
+            const propMatch = propLine.match(/^    (\w+):\s*(.*)$/);
+            if (!propMatch) { i++; continue; }
+            const v = propMatch[2].trim();
+            if (v === 'true') item[propMatch[1]] = true;
+            else if (v === 'false') item[propMatch[1]] = false;
+            else item[propMatch[1]] = v;
+            i++;
+          }
+
+          items.push(item);
+          continue;
+        }
+
+        // Scalar list item: "  - value"
+        const scalarItemMatch = subLine.match(/^  - (.+)$/);
+        if (scalarItemMatch) {
+          items.push(scalarItemMatch[1].trim());
+          i++;
+          continue;
+        }
+
+        i++; // Unrecognized indented line — skip
+      }
+
+      result[key] = items;
+      continue;
+    }
+
+    i++; // Skip unrecognized root-level line
+  }
+
+  return result;
+}
+
+function parseFrontmatter(content: string): ParsedFrontmatter {
+  const match = content.match(/^---\r?\n([\s\S]*?)\r?\n---\r?\n?([\s\S]*)$/);
+  if (!match) {
+    return { meta: {}, body: content.trim() };
+  }
+  try {
+    const meta = parseSimpleYaml(match[1]);
+    const body = match[2].trim();
+    return { meta, body };
+  } catch (err) {
+    console.warn('[CustomCommandManager] Failed to parse frontmatter YAML:', err);
+    return { meta: {}, body: match[2].trim() };
+  }
+}
+
+// ── Serialization ──────────────────────────────────────────────────────────
+
+/**
+ * Strip CR and LF from a scalar YAML value so a user-supplied newline cannot
+ * close the frontmatter block early and inject arbitrary text into the body.
+ */
+function sanitizeScalar(value: string): string {
+  return value.replace(/[\r\n]/g, ' ');
+}
+
+function serializeCommand(cmd: CustomCommand): string {
+  let fm = '---\n';
+  fm += `description: ${sanitizeScalar(cmd.description)}\n`;
+
+  if (cmd.parameters.length > 0) {
+    fm += 'parameters:\n';
+    for (const p of cmd.parameters) {
+      fm += `  - name: ${sanitizeScalar(p.name)}\n`;
+      fm += `    description: ${sanitizeScalar(p.description)}\n`;
+      fm += `    required: ${p.required}\n`;
+      if (p.default !== undefined && p.default !== '') {
+        fm += `    default: "${sanitizeScalar(p.default)}"\n`;
+      }
+    }
+  }
+
+  if (cmd.tags.length > 0) {
+    fm += 'tags:\n';
+    for (const t of cmd.tags) {
+      fm += `  - ${t}\n`;
+    }
+  }
+
+  if (cmd.icon && cmd.icon !== 'Terminal') {
+    fm += `icon: ${cmd.icon}\n`;
+  }
+
+  fm += '---\n\n';
+  return fm + cmd.body;
+}
+
+// ── Slug utilities ─────────────────────────────────────────────────────────
+
+function slugify(name: string): string {
+  return name
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-|-$/g, '')
+    .slice(0, 60);
+}
+
+// ── Manager ────────────────────────────────────────────────────────────────
+
+export class CustomCommandManager {
+  /** In-memory store for session-only commands, keyed by sessionId. */
+  private sessionCommands: Map<string, CustomCommand[]> = new Map();
+
+  private userWatcher: fs.FSWatcher | null = null;
+  private projectWatcher: fs.FSWatcher | null = null;
+  private debounceTimer: NodeJS.Timeout | null = null;
+  private emitter: IPCEmitter | null = null;
+  private currentProjectDir: string | null = null;
+
+  constructor() {
+    this.ensureUserCommandsDir();
+    this.watchUserDir();
+  }
+
+  // ── Setup ──────────────────────────────────────────────────────────────
+
+  setEmitter(emitter: IPCEmitter): void {
+    this.emitter = emitter;
+  }
+
+  /**
+   * Change the watched project directory.
+   * Called when the active session switches to a different workspace.
+   */
+  setProjectDir(dir: string | null): void {
+    if (this.projectWatcher) {
+      this.projectWatcher.close();
+      this.projectWatcher = null;
+    }
+    this.currentProjectDir = dir;
+    if (dir) {
+      const cmdsDir = path.join(dir, '.claude', 'commands');
+      this.watchProjectDir(cmdsDir);
+    }
+  }
+
+  destroy(): void {
+    this.userWatcher?.close();
+    this.projectWatcher?.close();
+    if (this.debounceTimer) clearTimeout(this.debounceTimer);
+    this.sessionCommands.clear();
+    this.emitter = null;
+  }
+
+  // ── Public API ─────────────────────────────────────────────────────────
+
+  /**
+   * List all commands accessible to the caller.
+   * Resolution order: project commands shadow user commands with the same slug.
+   * Result order: project first, then user, then session.
+   */
+  listCommands(request: CommandListRequest): CustomCommand[] {
+    const userCommands = this.loadFromDir(USER_COMMANDS_DIR, 'user');
+
+    let projectCommands: CustomCommand[] = [];
+    if (request.projectDir) {
+      const dir = path.join(request.projectDir, '.claude', 'commands');
+      projectCommands = this.loadFromDir(dir, 'project');
+    }
+
+    let sessionCmds: CustomCommand[] = [];
+    if (request.sessionId) {
+      sessionCmds = this.sessionCommands.get(request.sessionId) ?? [];
+    }
+
+    // Project commands shadow user commands with the same slug
+    const projectSlugs = new Set(projectCommands.map(c => c.slug));
+    const filteredUser = userCommands.filter(c => !projectSlugs.has(c.slug));
+
+    return [...projectCommands, ...filteredUser, ...sessionCmds];
+  }
+
+  /**
+   * Get a single command by slug and scope.
+   * Returns null if not found.
+   */
+  getCommand(slug: string, scope: CommandScope, projectDir?: string): CustomCommand | null {
+    if (!isValidCommandSlug(slug)) return null;
+    if (scope === 'session') return null; // Cannot look up session commands without sessionId
+
+    const filePath = this.resolveFilePath(slug, scope, projectDir);
+    if (!filePath || !fs.existsSync(filePath)) return null;
+    return this.parseCommandFile(filePath, scope);
+  }
+
+  /**
+   * Validate a command name — check slug, forbidden names, uniqueness.
+   */
+  validateName(name: string, scope: CommandScope, projectDir?: string): CommandValidation {
+    const suggestedSlug = slugify(name);
+    const errors: string[] = [];
+
+    if (!suggestedSlug) {
+      return {
+        valid: false,
+        errors: ['Command name must contain at least one alphanumeric character'],
+        suggestedSlug: 'command',
+      };
+    }
+
+    if (FORBIDDEN_SLUGS.has(suggestedSlug)) {
+      errors.push(`"${suggestedSlug}" is a reserved Claude Code command name`);
+    }
+
+    if (scope !== 'session') {
+      const filePath = this.resolveFilePath(suggestedSlug, scope, projectDir);
+      if (filePath && fs.existsSync(filePath)) {
+        errors.push(`A command named "${suggestedSlug}" already exists in ${scope} scope`);
+      }
+    }
+
+    return { valid: errors.length === 0, errors, suggestedSlug };
+  }
+
+  /**
+   * Create a new custom command.
+   * For session scope: stored in memory only.
+   * For project/user scope: written to disk as a .md file.
+   */
+  createCommand(request: CommandCreateRequest): CustomCommand {
+    const slug = slugify(request.name);
+
+    if (!slug) {
+      throw new Error('Command name must contain at least one alphanumeric character');
+    }
+    if (FORBIDDEN_SLUGS.has(slug)) {
+      throw new Error(`"${slug}" is a reserved Claude Code command name`);
+    }
+
+    const now = Date.now();
+    const params: CommandParameter[] = request.parameters ?? [];
+    const tags: string[] = request.tags ?? [];
+    const icon = request.icon ?? 'Terminal';
+
+    // ── Session-only ──
+    if (request.scope === 'session') {
+      if (!request.sessionId) throw new Error('sessionId is required for session-scoped commands');
+
+      const cmd: CustomCommand = {
+        slug,
+        description: request.description,
+        body: request.body,
+        parameters: params,
+        scope: 'session',
+        filePath: null,
+        tags,
+        icon,
+        updatedAt: now,
+      };
+
+      const existing = this.sessionCommands.get(request.sessionId) ?? [];
+      const idx = existing.findIndex(c => c.slug === slug);
+      if (idx >= 0) {
+        existing[idx] = cmd;
+      } else {
+        existing.push(cmd);
+      }
+      this.sessionCommands.set(request.sessionId, existing);
+      return cmd;
+    }
+
+    // ── Disk-based (project or user) ──
+    const dir = this.resolveDir(request.scope, request.projectDir);
+    fs.mkdirSync(dir, { recursive: true });
+
+    const filePath = path.join(dir, `${slug}.md`);
+    if (fs.existsSync(filePath)) {
+      throw new Error(`A command named "${slug}" already exists in ${request.scope} scope`);
+    }
+
+    const cmd: CustomCommand = {
+      slug,
+      description: request.description,
+      body: request.body,
+      parameters: params,
+      scope: request.scope,
+      filePath,
+      tags,
+      icon,
+      updatedAt: now,
+    };
+
+    this.atomicWrite(filePath, serializeCommand(cmd));
+    return cmd;
+  }
+
+  /**
+   * Update an existing custom command. Merges the provided fields over the existing state.
+   */
+  updateCommand(request: CommandUpdateRequest): CustomCommand {
+    if (!isValidCommandSlug(request.slug)) {
+      throw new Error(`Invalid command slug: "${request.slug}"`);
+    }
+
+    // ── Session-only ──
+    if (request.scope === 'session') {
+      if (!request.sessionId) throw new Error('sessionId is required for session-scoped commands');
+      const cmds = this.sessionCommands.get(request.sessionId) ?? [];
+      const idx = cmds.findIndex(c => c.slug === request.slug);
+      if (idx < 0) throw new Error(`Session command "${request.slug}" not found`);
+
+      const cmd = { ...cmds[idx] };
+      if (request.description !== undefined) cmd.description = request.description;
+      if (request.body !== undefined) cmd.body = request.body;
+      if (request.parameters !== undefined) cmd.parameters = request.parameters;
+      if (request.tags !== undefined) cmd.tags = request.tags;
+      if (request.icon !== undefined) cmd.icon = request.icon;
+      cmd.updatedAt = Date.now();
+
+      cmds[idx] = cmd;
+      this.sessionCommands.set(request.sessionId, cmds);
+      return cmd;
+    }
+
+    // ── Disk-based ──
+    const filePath = this.resolveFilePath(request.slug, request.scope, request.projectDir);
+    if (!filePath || !fs.existsSync(filePath)) {
+      throw new Error(`Command "${request.slug}" not found in ${request.scope} scope`);
+    }
+
+    const existing = this.parseCommandFile(filePath, request.scope);
+    if (!existing) throw new Error(`Failed to parse command file: ${filePath}`);
+
+    if (request.description !== undefined) existing.description = request.description;
+    if (request.body !== undefined) existing.body = request.body;
+    if (request.parameters !== undefined) existing.parameters = request.parameters;
+    if (request.tags !== undefined) existing.tags = request.tags;
+    if (request.icon !== undefined) existing.icon = request.icon;
+    existing.updatedAt = Date.now();
+
+    this.atomicWrite(filePath, serializeCommand(existing));
+    return existing;
+  }
+
+  /**
+   * Delete a command. Returns true if deleted, false if not found.
+   */
+  deleteCommand(request: CommandDeleteRequest): boolean {
+    if (!isValidCommandSlug(request.slug)) return false;
+
+    // ── Session-only ──
+    if (request.scope === 'session') {
+      if (!request.sessionId) return false;
+      const cmds = this.sessionCommands.get(request.sessionId) ?? [];
+      const idx = cmds.findIndex(c => c.slug === request.slug);
+      if (idx < 0) return false;
+      cmds.splice(idx, 1);
+      this.sessionCommands.set(request.sessionId, cmds);
+      return true;
+    }
+
+    // ── Disk-based ──
+    const filePath = this.resolveFilePath(request.slug, request.scope, request.projectDir);
+    if (!filePath || !fs.existsSync(filePath)) return false;
+
+    try {
+      fs.unlinkSync(filePath);
+      return true;
+    } catch (err) {
+      console.error(`[CustomCommandManager] Failed to delete ${filePath}:`, err);
+      return false;
+    }
+  }
+
+  /**
+   * Remove all session-only commands for a given session.
+   * Call this when a session is closed.
+   */
+  cleanupSession(sessionId: string): void {
+    this.sessionCommands.delete(sessionId);
+  }
+
+  // ── Private helpers ────────────────────────────────────────────────────
+
+  private ensureUserCommandsDir(): void {
+    try {
+      fs.mkdirSync(USER_COMMANDS_DIR, { recursive: true });
+    } catch (err) {
+      console.warn('[CustomCommandManager] Could not create user commands dir:', err);
+    }
+  }
+
+  private watchUserDir(): void {
+    try {
+      this.userWatcher = fs.watch(USER_COMMANDS_DIR, { persistent: false }, () => {
+        this.scheduleChangeNotify('user');
+      });
+      this.userWatcher.on('error', err => {
+        console.warn('[CustomCommandManager] User dir watcher error:', err);
+      });
+    } catch (err) {
+      console.warn('[CustomCommandManager] Could not watch user commands dir:', err);
+    }
+  }
+
+  private watchProjectDir(dir: string): void {
+    try {
+      fs.mkdirSync(dir, { recursive: true });
+      this.projectWatcher = fs.watch(dir, { persistent: false }, () => {
+        this.scheduleChangeNotify('project');
+      });
+      this.projectWatcher.on('error', err => {
+        console.warn('[CustomCommandManager] Project dir watcher error:', err);
+      });
+    } catch (err) {
+      console.warn('[CustomCommandManager] Could not watch project commands dir:', err);
+    }
+  }
+
+  /** Debounced (500ms) push to renderer after external file-system changes. */
+  private scheduleChangeNotify(changedScope: CommandScope): void {
+    if (this.debounceTimer) clearTimeout(this.debounceTimer);
+
+    this.debounceTimer = setTimeout(() => {
+      this.debounceTimer = null;
+      if (!this.emitter) return;
+
+      let commands: CustomCommand[];
+      if (changedScope === 'user') {
+        commands = this.loadFromDir(USER_COMMANDS_DIR, 'user');
+      } else {
+        const dir = this.currentProjectDir
+          ? path.join(this.currentProjectDir, '.claude', 'commands')
+          : null;
+        commands = dir ? this.loadFromDir(dir, 'project') : [];
+      }
+
+      this.emitter.emit('onCommandsChanged', { scope: changedScope, commands });
+    }, 500);
+  }
+
+  private loadFromDir(dir: string, scope: CommandScope): CustomCommand[] {
+    if (!fs.existsSync(dir)) return [];
+
+    const commands: CustomCommand[] = [];
+    try {
+      const entries = fs.readdirSync(dir, { withFileTypes: true });
+      for (const entry of entries) {
+        if (!entry.isFile() || !entry.name.endsWith('.md')) continue;
+
+        const filePath = path.join(dir, entry.name);
+
+        // Skip suspiciously large files
+        const stat = fs.statSync(filePath);
+        if (stat.size > MAX_FILE_SIZE_BYTES) {
+          console.warn(`[CustomCommandManager] Skipping oversized file: ${filePath}`);
+          continue;
+        }
+
+        const cmd = this.parseCommandFile(filePath, scope);
+        if (cmd) commands.push(cmd);
+      }
+    } catch (err) {
+      console.error(`[CustomCommandManager] Failed to scan directory ${dir}:`, err);
+    }
+
+    return commands;
+  }
+
+  private parseCommandFile(filePath: string, scope: CommandScope): CustomCommand | null {
+    try {
+      const content = fs.readFileSync(filePath, 'utf-8');
+      const stat = fs.statSync(filePath);
+      const slug = path.basename(filePath, '.md');
+
+      const { meta, body } = parseFrontmatter(content);
+
+      const description = typeof meta['description'] === 'string' ? meta['description'] : '';
+      const icon = typeof meta['icon'] === 'string' ? meta['icon'] : 'Terminal';
+
+      // Parse parameters
+      const rawParams = Array.isArray(meta['parameters']) ? meta['parameters'] : [];
+      const parameters: CommandParameter[] = (rawParams as unknown[])
+        .filter((p): p is Record<string, unknown> => typeof p === 'object' && p !== null)
+        .map(p => ({
+          name: typeof p['name'] === 'string' ? p['name'] : '',
+          description: typeof p['description'] === 'string' ? p['description'] : '',
+          required: p['required'] === true || p['required'] === 'true',
+          default: typeof p['default'] === 'string' && p['default'] !== ''
+            ? p['default']
+            : undefined,
+        }))
+        .filter(p => p.name.length > 0);
+
+      // Parse tags
+      const rawTags = Array.isArray(meta['tags']) ? meta['tags'] : [];
+      const tags = (rawTags as unknown[]).filter((t): t is string => typeof t === 'string');
+
+      return {
+        slug,
+        description,
+        body,
+        parameters,
+        scope,
+        filePath,
+        tags,
+        icon,
+        updatedAt: stat.mtimeMs,
+      };
+    } catch (err) {
+      console.warn(`[CustomCommandManager] Failed to parse ${filePath}:`, err);
+      return null;
+    }
+  }
+
+  private resolveDir(scope: 'project' | 'user', projectDir?: string): string {
+    if (scope === 'project') {
+      if (!projectDir) throw new Error('projectDir is required for project-scoped commands');
+      return path.join(projectDir, '.claude', 'commands');
+    }
+    return USER_COMMANDS_DIR;
+  }
+
+  private resolveFilePath(
+    slug: string,
+    scope: CommandScope,
+    projectDir?: string,
+  ): string | null {
+    if (scope === 'user') return path.join(USER_COMMANDS_DIR, `${slug}.md`);
+    if (scope === 'project' && projectDir) {
+      return path.join(projectDir, '.claude', 'commands', `${slug}.md`);
+    }
+    return null;
+  }
+
+  /** Atomic write via temp-file rename (same pattern as PromptTemplatesManager). */
+  private atomicWrite(filePath: string, content: string): void {
+    const tmpPath = `${filePath}.tmp`;
+    fs.writeFileSync(tmpPath, content, 'utf-8');
+    fs.renameSync(tmpPath, filePath);
+  }
+}

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -17,6 +17,7 @@ import { ModelHistoryManager } from './model-history-manager';
 import { GitManager } from './git-manager';
 import { PlaybookManager } from './playbook-manager';
 import { PlaybookExecutor } from './playbook-executor';
+import { CustomCommandManager } from './custom-command-manager';
 // NOTE: LaunchTunnel/sharing disabled — uncomment when LaunchTunnel integration is fixed
 // import { TunnelManager } from './tunnel-manager';
 import { ProviderRegistry } from './providers/provider-registry';
@@ -48,6 +49,7 @@ let modelHistoryManager: ModelHistoryManager | null = null;
 let gitManager: GitManager | null = null;
 let playbookManager: PlaybookManager | null = null;
 let playbookExecutor: PlaybookExecutor | null = null;
+let customCommandManager: CustomCommandManager | null = null;
 // let tunnelManager: TunnelManager | null = null; // LaunchTunnel disabled
 let providerRegistry: ProviderRegistry | null = null;
 // let sharingManager: SharingManager | null = null; // LaunchTunnel disabled
@@ -173,6 +175,9 @@ function createWindow(): void {
   playbookManager = new PlaybookManager();
   playbookExecutor = new PlaybookExecutor(sessionManager, checkpointManager, playbookManager);
 
+  // Initialize custom command manager (discovers .claude/commands/ files)
+  customCommandManager = new CustomCommandManager();
+
   // NOTE: LaunchTunnel/sharing disabled — uncomment when integration is fixed
   // tunnelManager = new TunnelManager();
   // tunnelManager.setMainWindow(mainWindow);
@@ -220,6 +225,7 @@ function createWindow(): void {
     // tunnelManager, // LaunchTunnel disabled
     providerRegistry,
     // sharingManager // LaunchTunnel disabled
+    customCommandManager,
   );
 
   // Initialize pool (delayed, async)
@@ -289,6 +295,10 @@ function createWindow(): void {
       playbookExecutor = null;
     }
     playbookManager = null;
+    if (customCommandManager) {
+      customCommandManager.destroy();
+      customCommandManager = null;
+    }
     if (gitManager) {
       gitManager.destroy();
       gitManager = null;

--- a/src/main/ipc-handlers.ts
+++ b/src/main/ipc-handlers.ts
@@ -16,6 +16,7 @@ import { ModelHistoryManager } from './model-history-manager';
 import { GitManager } from './git-manager';
 import { PlaybookManager } from './playbook-manager';
 import { PlaybookExecutor } from './playbook-executor';
+import { CustomCommandManager } from './custom-command-manager';
 // NOTE: LaunchTunnel/sharing disabled — uncomment when integration is fixed
 // import { TunnelManager } from './tunnel-manager';
 import { ProviderRegistry } from './providers/provider-registry';
@@ -46,11 +47,13 @@ export function setupIPCHandlers(
   // tunnelManager: TunnelManager, // LaunchTunnel disabled
   providerRegistry: ProviderRegistry,
   // sharingManager: SharingManager // LaunchTunnel disabled
+  customCommandManager: CustomCommandManager,
 ): void {
   // Connect managers to window
   sessionManager.setMainWindow(mainWindow);
   checkpointManager.setMainWindow(mainWindow);
   playbookExecutor.setEmitter(new IPCEmitter(mainWindow));
+  customCommandManager.setEmitter(new IPCEmitter(mainWindow));
 
   registry = new IPCRegistry();
 
@@ -65,6 +68,8 @@ export function setupIPCHandlers(
   });
 
   registry.handle('closeSession', async (_e, sessionId) => {
+    // Clean up session-only commands before closing
+    customCommandManager.cleanupSession(sessionId);
     return sessionManager.closeSession(sessionId);
   });
 
@@ -886,6 +891,35 @@ export function setupIPCHandlers(
   // registry.handle('getSharingSettings', async () => { ... });
   // registry.handle('updateSharingSettings', async (_e, updates) => { ... });
   // registry.handle('checkShareEligibility', async () => { ... });
+
+  // ── Custom Commands ──
+
+  registry.handle('listCustomCommands', async (_e, request) => {
+    return customCommandManager.listCommands(request);
+  });
+
+  registry.handle('getCustomCommand', async (_e, slug, scope, projectDir) => {
+    return customCommandManager.getCommand(slug, scope, projectDir);
+  });
+
+  registry.handle('createCustomCommand', async (_e, request) => {
+    try { return customCommandManager.createCommand(request); }
+    catch (err) { console.error('[cmd:create] Failed:', err); throw err; }
+  });
+
+  registry.handle('updateCustomCommand', async (_e, request) => {
+    try { return customCommandManager.updateCommand(request); }
+    catch (err) { console.error('[cmd:update] Failed:', err); throw err; }
+  });
+
+  registry.handle('deleteCustomCommand', async (_e, request) => {
+    try { return customCommandManager.deleteCommand(request); }
+    catch (err) { console.error('[cmd:delete] Failed:', err); throw err; }
+  });
+
+  registry.handle('validateCommandName', async (_e, name, scope, projectDir) => {
+    return customCommandManager.validateName(name, scope, projectDir);
+  });
 
   // ── Session I/O (send — fire and forget) ──
 

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -38,6 +38,8 @@ import { PlaybookProgressPanel } from './components/PlaybookProgressPanel';
 import { PlaybookPanel } from './components/PlaybookPanel';
 import { PlaybookEditor } from './components/PlaybookEditor';
 import { LayoutPicker } from './components/LayoutPicker';
+import { SidePanel } from './components/SidePanel';
+import { CustomCommandPanel } from './components/CustomCommandPanel';
 import { WelcomeWizard } from './components/WelcomeWizard';
 import { ShortcutsPanel } from './components/ui/ShortcutsPanel';
 import { ModelHistoryPanel } from './components/ModelHistoryPanel';
@@ -127,6 +129,9 @@ function App() {
   const git = useGit(atlasProjectPath);
   const [showGitPanel, setShowGitPanel] = useState(false);
   const [showWorktreePanel, setShowWorktreePanel] = useState(false);
+
+  // Commands panel
+  const [showCommandsPanel, setShowCommandsPanel] = useState(false);
 
   // NOTE: LaunchTunnel/sharing disabled
   // const [showTunnelPanel, setShowTunnelPanel] = useState(false);
@@ -771,6 +776,7 @@ function App() {
     setShowHistoryPanel(panel === 'history');
     setShowTeamPanel(panel === 'teams');
     setShowAtlasPanel(panel === 'atlas');
+    setShowCommandsPanel(panel === 'commands');
     // For playbooks, open the playbook picker
     if (panel === 'playbooks') pb.setIsPanelOpen(true);
     else pb.setIsPanelOpen(false);
@@ -1071,6 +1077,22 @@ function App() {
         projectPath={atlasProjectPath}
       />
 
+      {/* Commands panel */}
+      <SidePanel
+        isOpen={showCommandsPanel}
+        onClose={() => {
+          setShowCommandsPanel(false);
+          setActiveActivityPanel(null);
+        }}
+        title="Commands"
+        defaultWidth={320}
+      >
+        <CustomCommandPanel
+          projectDir={atlasProjectPath ?? undefined}
+          sessionId={activeSessionId}
+        />
+      </SidePanel>
+
       {/* NOTE: Tunnel panel and Share Management panel disabled — LaunchTunnel integration needs fixing */}
       {/* <TunnelPanel
         isOpen={showTunnelPanel}
@@ -1171,6 +1193,8 @@ function App() {
         onUpdateWorkspace={handleUpdateWorkspace}
         onDeleteWorkspace={handleDeleteWorkspace}
         onValidatePath={handleValidatePath}
+        projectDir={atlasProjectPath}
+        sessionId={activeSessionId}
       />
 
       {/* Budget panel */}

--- a/src/renderer/components/ActivityBar.tsx
+++ b/src/renderer/components/ActivityBar.tsx
@@ -15,6 +15,7 @@ import {
   Users,
   BookOpen,
   Radio,
+  Terminal,
   // Network, // LaunchTunnel disabled
   // Share2,  // LaunchTunnel disabled
   DollarSign,
@@ -25,7 +26,7 @@ import {
 } from 'lucide-react';
 
 // NOTE: 'tunnels' and 'sharing' disabled until LaunchTunnel integration is fixed
-export type ActivityPanelId = 'git' | 'history' | 'teams' | 'atlas' | 'playbooks' | /* 'tunnels' | 'sharing' | */ null;
+export type ActivityPanelId = 'git' | 'history' | 'teams' | 'atlas' | 'playbooks' | 'commands' | /* 'tunnels' | 'sharing' | */ null;
 
 interface ActivityBarProps {
   activePanel:         ActivityPanelId;
@@ -256,6 +257,7 @@ export function ActivityBar({
     ...(teamsEnabled ? [{ id: 'teams' as const, label: 'Agent Teams', Icon: Users }] : []),
     { id: 'atlas',     label: 'Atlas',       Icon: BookOpen  },
     { id: 'playbooks', label: 'Playbooks',   Icon: Radio     },
+    { id: 'commands',  label: 'Commands',    Icon: Terminal  },
     // NOTE: LaunchTunnel/sharing disabled
     // { id: 'tunnels',   label: 'Tunnels',     Icon: Network, badge: tunnelActive },
     // { id: 'sharing',   label: 'Sharing',     Icon: Share2,  badge: activeShareCount > 0 },

--- a/src/renderer/components/CustomCommandDialog.tsx
+++ b/src/renderer/components/CustomCommandDialog.tsx
@@ -1,0 +1,949 @@
+/**
+ * CustomCommandDialog — create or edit a custom slash command.
+ *
+ * Fields:
+ *   - Name (auto-generates the slug, locked in edit mode)
+ *   - Scope (project / user / session)
+ *   - Description (shown in command palette)
+ *   - Body (Markdown instruction text sent to Claude)
+ *   - Parameters (name, description, required, default)
+ *   - Tags (comma-separated)
+ *   - Icon (Lucide icon name)
+ *
+ * Validates name/slug uniqueness via `command:validate` IPC before saving.
+ */
+
+import { useState, useEffect, useCallback, useRef } from 'react';
+import type { CustomCommand, CommandParameter } from '../../shared/types/custom-command-types';
+import { slugifyCommandName } from '../../shared/types/custom-command-types';
+
+// ── Types ──────────────────────────────────────────────────────────────────
+
+type Scope = 'project' | 'user' | 'session';
+
+interface SaveData {
+  name: string;
+  description: string;
+  body: string;
+  scope: Scope;
+  parameters: CommandParameter[];
+  tags: string[];
+  icon: string;
+}
+
+interface CustomCommandDialogProps {
+  isOpen: boolean;
+  /** If provided, the dialog is in edit mode. */
+  editingCommand: CustomCommand | null;
+  /** Default scope for the "scope" dropdown in create mode. */
+  defaultScope: Scope;
+  onSave: (data: SaveData) => Promise<void>;
+  onClose: () => void;
+  /** Required for project-scope option. */
+  projectDir?: string;
+  /** Required for session-scope option. */
+  sessionId?: string;
+}
+
+// ── Parameter row ──────────────────────────────────────────────────────────
+
+interface ParamRowProps {
+  param: CommandParameter;
+  index: number;
+  onChange: (index: number, updated: CommandParameter) => void;
+  onRemove: (index: number) => void;
+}
+
+function ParamRow({ param, index, onChange, onRemove }: ParamRowProps) {
+  const update = (field: keyof CommandParameter, value: string | boolean) =>
+    onChange(index, { ...param, [field]: value });
+
+  return (
+    <div className="ccd-param-row">
+      <div className="ccd-param-row-top">
+        <input
+          className="ccd-input ccd-param-name"
+          type="text"
+          placeholder="name"
+          value={param.name}
+          onChange={e => update('name', e.target.value.replace(/[^a-z0-9_]/g, ''))}
+          spellCheck={false}
+        />
+        <input
+          className="ccd-input ccd-param-desc"
+          type="text"
+          placeholder="description shown to user"
+          value={param.description}
+          onChange={e => update('description', e.target.value)}
+        />
+        <label className="ccd-param-required">
+          <input
+            type="checkbox"
+            checked={param.required}
+            onChange={e => update('required', e.target.checked)}
+          />
+          <span>Required</span>
+        </label>
+        <button className="ccd-param-remove" onClick={() => onRemove(index)} title="Remove parameter">
+          <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5">
+            <path d="M18 6L6 18M6 6l12 12" strokeLinecap="round" />
+          </svg>
+        </button>
+      </div>
+      <div className="ccd-param-row-bottom">
+        <span className="ccd-param-default-label">Default:</span>
+        <input
+          className="ccd-input ccd-param-default"
+          type="text"
+          placeholder="(optional default value)"
+          value={param.default ?? ''}
+          onChange={e => update('default', e.target.value)}
+        />
+        <span className="ccd-param-placeholder-hint">
+          Use <code>{'{{' + param.name + '}}'}</code> in body
+        </span>
+      </div>
+    </div>
+  );
+}
+
+// ── Dialog ─────────────────────────────────────────────────────────────────
+
+export function CustomCommandDialog({
+  isOpen,
+  editingCommand,
+  defaultScope,
+  onSave,
+  onClose,
+  projectDir,
+  sessionId,
+}: CustomCommandDialogProps) {
+  const isEditing = editingCommand !== null;
+
+  // Form state
+  const [name, setName] = useState('');
+  const [slug, setSlug] = useState('');
+  const [scope, setScope] = useState<Scope>(defaultScope);
+  const [description, setDescription] = useState('');
+  const [body, setBody] = useState('');
+  const [parameters, setParameters] = useState<CommandParameter[]>([]);
+  const [tagsRaw, setTagsRaw] = useState('');
+  const [icon, setIcon] = useState('Terminal');
+
+  // Validation
+  const [nameError, setNameError] = useState('');
+  const [descError, setDescError] = useState('');
+  const [bodyError, setBodyError] = useState('');
+  const [isValidating, setIsValidating] = useState(false);
+  const [isSaving, setIsSaving] = useState(false);
+  const [saveError, setSaveError] = useState('');
+  const [showPreview, setShowPreview] = useState(false);
+
+  const nameInputRef = useRef<HTMLInputElement>(null);
+
+  // ── Initialize / reset on open ─────────────────────────────────────────
+
+  useEffect(() => {
+    if (!isOpen) return;
+
+    if (editingCommand) {
+      setName(editingCommand.slug); // slug is immutable in edit mode
+      setSlug(editingCommand.slug);
+      setScope(editingCommand.scope as Scope);
+      setDescription(editingCommand.description);
+      setBody(editingCommand.body);
+      setParameters(editingCommand.parameters.map(p => ({ ...p })));
+      setTagsRaw(editingCommand.tags.join(', '));
+      setIcon(editingCommand.icon || 'Terminal');
+    } else {
+      setName('');
+      setSlug('');
+      setScope(defaultScope);
+      setDescription('');
+      setBody('');
+      setParameters([]);
+      setTagsRaw('');
+      setIcon('Terminal');
+    }
+
+    setNameError('');
+    setDescError('');
+    setBodyError('');
+    setSaveError('');
+    setShowPreview(false);
+    setIsSaving(false);
+
+    // Auto-focus name on open
+    setTimeout(() => nameInputRef.current?.focus(), 50);
+  }, [isOpen, editingCommand, defaultScope]);
+
+  // ── Slug derivation (create mode only) ────────────────────────────────
+
+  const handleNameChange = useCallback((value: string) => {
+    setName(value);
+    setSlug(slugifyCommandName(value));
+    setNameError('');
+  }, []);
+
+  // ── Validate name (debounced, create mode only) ────────────────────────
+
+  useEffect(() => {
+    if (isEditing || !slug) return;
+
+    const timer = setTimeout(async () => {
+      setIsValidating(true);
+      try {
+        const result = await window.electronAPI.validateCommandName(
+          slug,
+          scope,
+          scope === 'project' ? projectDir : undefined,
+        );
+        if (!result.valid) {
+          setNameError(result.errors.join('. '));
+        } else {
+          setNameError('');
+        }
+      } catch {
+        // Non-blocking: validation failure doesn't prevent saving
+      } finally {
+        setIsValidating(false);
+      }
+    }, 400);
+
+    return () => clearTimeout(timer);
+  }, [slug, scope, isEditing, projectDir]);
+
+  // ── Parameters ─────────────────────────────────────────────────────────
+
+  const addParameter = useCallback(() => {
+    setParameters(prev => [
+      ...prev,
+      { name: '', description: '', required: false, default: undefined },
+    ]);
+  }, []);
+
+  const updateParameter = useCallback((index: number, updated: CommandParameter) => {
+    setParameters(prev => prev.map((p, i) => (i === index ? updated : p)));
+  }, []);
+
+  const removeParameter = useCallback((index: number) => {
+    setParameters(prev => prev.filter((_, i) => i !== index));
+  }, []);
+
+  // ── Body preview (resolve {{param}} placeholders) ──────────────────────
+
+  const previewBody = body.replace(/\{\{(\w+)\}\}/g, (_m, pName) => {
+    const param = parameters.find(p => p.name === pName);
+    return param?.default || `<${pName}>`;
+  });
+
+  // ── Submit ─────────────────────────────────────────────────────────────
+
+  const handleSave = useCallback(async () => {
+    // Local validation
+    let hasError = false;
+
+    if (!isEditing && !slug) {
+      setNameError('Command name is required');
+      hasError = true;
+    }
+    if (!description.trim()) {
+      setDescError('Description is required');
+      hasError = true;
+    }
+    if (!body.trim()) {
+      setBodyError('Body is required');
+      hasError = true;
+    }
+
+    // Validate parameters
+    const validParams = parameters.filter(p => p.name.trim() !== '');
+    const invalidParam = validParams.find(p => !/^[a-z0-9_]+$/.test(p.name));
+    if (invalidParam) {
+      setSaveError(`Parameter name "${invalidParam.name}" must be lowercase letters, digits, or underscores`);
+      hasError = true;
+    }
+
+    if (hasError || nameError) return;
+
+    const tags = tagsRaw
+      .split(',')
+      .map(t => t.trim())
+      .filter(t => t.length > 0);
+
+    setIsSaving(true);
+    setSaveError('');
+
+    try {
+      await onSave({
+        name: isEditing ? editingCommand!.slug : slug,
+        description: description.trim(),
+        body: body.trim(),
+        scope,
+        parameters: validParams,
+        tags,
+        icon,
+      });
+    } catch (err) {
+      setSaveError(err instanceof Error ? err.message : 'Failed to save command');
+    } finally {
+      setIsSaving(false);
+    }
+  }, [
+    isEditing,
+    editingCommand,
+    slug,
+    description,
+    body,
+    scope,
+    parameters,
+    tagsRaw,
+    icon,
+    nameError,
+    onSave,
+  ]);
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === 'Escape') { e.preventDefault(); onClose(); }
+      if (e.key === 'Enter' && (e.ctrlKey || e.metaKey)) { e.preventDefault(); handleSave(); }
+    },
+    [onClose, handleSave],
+  );
+
+  if (!isOpen) return null;
+
+  return (
+    <div className="ccd-overlay" onClick={e => e.target === e.currentTarget && onClose()}>
+      <div className="ccd-dialog" onKeyDown={handleKeyDown}>
+        {/* Header */}
+        <div className="ccd-header">
+          <div className="ccd-header-left">
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+              <polyline points="16 18 22 12 16 6" />
+              <polyline points="8 6 2 12 8 18" />
+            </svg>
+            <span className="ccd-title">
+              {isEditing ? `Edit /${editingCommand!.slug}` : 'New Custom Command'}
+            </span>
+          </div>
+          <button className="ccd-close" onClick={onClose} aria-label="Close">
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5">
+              <path d="M18 6L6 18M6 6l12 12" strokeLinecap="round" />
+            </svg>
+          </button>
+        </div>
+
+        {/* Body */}
+        <div className="ccd-body">
+          {/* Name (create only) */}
+          {!isEditing && (
+            <div className="ccd-field">
+              <label className="ccd-label">
+                Name <span className="ccd-required">*</span>
+              </label>
+              <div className="ccd-name-row">
+                <span className="ccd-name-slash">/</span>
+                <input
+                  ref={nameInputRef}
+                  className={`ccd-input ccd-name-input ${nameError ? 'error' : ''}`}
+                  type="text"
+                  placeholder="my-command"
+                  value={name}
+                  onChange={e => handleNameChange(e.target.value)}
+                  spellCheck={false}
+                  autoComplete="off"
+                />
+                {isValidating && <div className="ccd-validating" />}
+              </div>
+              {slug && slug !== name && (
+                <div className="ccd-slug-preview">slug: <code>/{slug}</code></div>
+              )}
+              {nameError && <div className="ccd-field-error">{nameError}</div>}
+            </div>
+          )}
+
+          {/* Scope */}
+          <div className="ccd-field">
+            <label className="ccd-label">Scope</label>
+            <div className="ccd-scope-options">
+              <label className={`ccd-scope-option ${scope === 'user' ? 'selected' : ''}`}>
+                <input
+                  type="radio"
+                  name="scope"
+                  value="user"
+                  checked={scope === 'user'}
+                  onChange={() => setScope('user')}
+                  disabled={isEditing}
+                />
+                <div>
+                  <div className="ccd-scope-label">User</div>
+                  <div className="ccd-scope-hint">~/.claude/commands/ · all projects</div>
+                </div>
+              </label>
+              {projectDir && (
+                <label className={`ccd-scope-option ${scope === 'project' ? 'selected' : ''}`}>
+                  <input
+                    type="radio"
+                    name="scope"
+                    value="project"
+                    checked={scope === 'project'}
+                    onChange={() => setScope('project')}
+                    disabled={isEditing}
+                  />
+                  <div>
+                    <div className="ccd-scope-label">Project</div>
+                    <div className="ccd-scope-hint">.claude/commands/ · git-shareable</div>
+                  </div>
+                </label>
+              )}
+              {sessionId && (
+                <label className={`ccd-scope-option ${scope === 'session' ? 'selected' : ''}`}>
+                  <input
+                    type="radio"
+                    name="scope"
+                    value="session"
+                    checked={scope === 'session'}
+                    onChange={() => setScope('session')}
+                    disabled={isEditing}
+                  />
+                  <div>
+                    <div className="ccd-scope-label">Session</div>
+                    <div className="ccd-scope-hint">in-memory · not saved to disk</div>
+                  </div>
+                </label>
+              )}
+            </div>
+          </div>
+
+          {/* Description */}
+          <div className="ccd-field">
+            <label className="ccd-label">
+              Description <span className="ccd-required">*</span>
+            </label>
+            <input
+              className={`ccd-input ${descError ? 'error' : ''}`}
+              type="text"
+              placeholder="What does this command do?"
+              value={description}
+              onChange={e => { setDescription(e.target.value); setDescError(''); }}
+              maxLength={200}
+            />
+            {descError && <div className="ccd-field-error">{descError}</div>}
+          </div>
+
+          {/* Body */}
+          <div className="ccd-field ccd-body-field">
+            <div className="ccd-body-header">
+              <label className="ccd-label">
+                Body <span className="ccd-required">*</span>
+                <span className="ccd-label-hint">· Markdown instruction text sent to Claude</span>
+              </label>
+              <button
+                className="ccd-preview-toggle"
+                onClick={() => setShowPreview(v => !v)}
+              >
+                {showPreview ? 'Edit' : 'Preview'}
+              </button>
+            </div>
+            {showPreview ? (
+              <pre className="ccd-preview">{previewBody || <em>(empty)</em>}</pre>
+            ) : (
+              <textarea
+                className={`ccd-textarea ${bodyError ? 'error' : ''}`}
+                rows={6}
+                placeholder="Describe what you want Claude to do…&#10;&#10;Use {{paramName}} to reference parameters."
+                value={body}
+                onChange={e => { setBody(e.target.value); setBodyError(''); }}
+                spellCheck={false}
+              />
+            )}
+            {bodyError && <div className="ccd-field-error">{bodyError}</div>}
+          </div>
+
+          {/* Parameters */}
+          <div className="ccd-field">
+            <div className="ccd-params-header">
+              <label className="ccd-label">Parameters</label>
+              <button className="ccd-btn-add-param" onClick={addParameter}>
+                <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5">
+                  <path d="M12 5v14M5 12h14" strokeLinecap="round" />
+                </svg>
+                Add parameter
+              </button>
+            </div>
+            {parameters.length === 0 ? (
+              <div className="ccd-params-empty">
+                No parameters — command runs immediately without user input.
+              </div>
+            ) : (
+              <div className="ccd-params-list">
+                {parameters.map((p, i) => (
+                  <ParamRow
+                    key={i}
+                    param={p}
+                    index={i}
+                    onChange={updateParameter}
+                    onRemove={removeParameter}
+                  />
+                ))}
+              </div>
+            )}
+          </div>
+
+          {/* Tags */}
+          <div className="ccd-field">
+            <label className="ccd-label">
+              Tags
+              <span className="ccd-label-hint"> · comma-separated, for search</span>
+            </label>
+            <input
+              className="ccd-input"
+              type="text"
+              placeholder="deploy, git, testing"
+              value={tagsRaw}
+              onChange={e => setTagsRaw(e.target.value)}
+            />
+          </div>
+
+          {/* Save error */}
+          {saveError && (
+            <div className="ccd-save-error">
+              <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                <circle cx="12" cy="12" r="10" />
+                <line x1="12" y1="8" x2="12" y2="12" />
+                <line x1="12" y1="16" x2="12.01" y2="16" />
+              </svg>
+              {saveError}
+            </div>
+          )}
+        </div>
+
+        {/* Footer */}
+        <div className="ccd-footer">
+          <button className="ccd-btn-cancel" onClick={onClose} disabled={isSaving}>
+            Cancel
+          </button>
+          <button
+            className="ccd-btn-save"
+            onClick={handleSave}
+            disabled={isSaving || isValidating || !!nameError}
+          >
+            {isSaving ? 'Saving…' : isEditing ? 'Save changes' : 'Create command'}
+            {!isSaving && <kbd>Ctrl+Enter</kbd>}
+          </button>
+        </div>
+      </div>
+
+      <style>{dialogStyles}</style>
+    </div>
+  );
+}
+
+// ── Styles ─────────────────────────────────────────────────────────────────
+
+const dialogStyles = `
+  .ccd-overlay {
+    position: fixed;
+    inset: 0;
+    background: rgba(0,0,0,0.55);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 1100;
+  }
+
+  .ccd-dialog {
+    width: 600px;
+    max-width: calc(100vw - 32px);
+    max-height: calc(100vh - 48px);
+    background: var(--surface-overlay);
+    border: 1px solid var(--border-default);
+    border-radius: 12px;
+    box-shadow: 0 20px 60px rgba(0,0,0,0.5);
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+    font-family: var(--font-ui, 'Inter', system-ui, sans-serif);
+  }
+
+  /* Header */
+  .ccd-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 14px 18px;
+    border-bottom: 1px solid var(--border-default);
+    flex-shrink: 0;
+  }
+
+  .ccd-header-left {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    color: var(--accent-primary);
+  }
+
+  .ccd-title {
+    font-size: 14px;
+    font-weight: 600;
+    color: var(--text-primary);
+  }
+
+  .ccd-close {
+    background: transparent;
+    border: none;
+    color: var(--text-tertiary);
+    cursor: pointer;
+    padding: 4px;
+    display: flex;
+    align-items: center;
+    border-radius: 4px;
+  }
+
+  .ccd-close:hover { color: var(--text-secondary); background: var(--border-default); }
+
+  /* Body */
+  .ccd-body {
+    flex: 1;
+    overflow-y: auto;
+    padding: 16px 18px;
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+  }
+
+  .ccd-field {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+  }
+
+  .ccd-label {
+    font-size: 12px;
+    font-weight: 500;
+    color: var(--text-secondary);
+  }
+
+  .ccd-label-hint {
+    font-weight: 400;
+    color: var(--text-tertiary);
+  }
+
+  .ccd-required {
+    color: var(--semantic-error);
+    margin-left: 2px;
+  }
+
+  .ccd-input {
+    background: color-mix(in srgb, var(--surface-overlay) 80%, black);
+    border: 1px solid var(--border-default);
+    border-radius: 6px;
+    color: var(--text-primary);
+    font-size: 13px;
+    font-family: inherit;
+    padding: 7px 10px;
+    outline: none;
+    transition: border-color 0.15s;
+  }
+
+  .ccd-input:focus { border-color: var(--accent-primary); }
+  .ccd-input.error { border-color: var(--semantic-error); }
+
+  .ccd-field-error {
+    font-size: 11px;
+    color: var(--semantic-error);
+  }
+
+  /* Name row */
+  .ccd-name-row {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+  }
+
+  .ccd-name-slash {
+    font-size: 16px;
+    font-weight: 700;
+    color: var(--accent-primary);
+    font-family: var(--font-mono, monospace);
+    line-height: 1;
+  }
+
+  .ccd-name-input {
+    flex: 1;
+    font-family: var(--font-mono, monospace) !important;
+  }
+
+  .ccd-validating {
+    width: 14px;
+    height: 14px;
+    border: 2px solid var(--border-default);
+    border-top-color: var(--accent-primary);
+    border-radius: 50%;
+    animation: ccd-spin 0.7s linear infinite;
+    flex-shrink: 0;
+  }
+
+  @keyframes ccd-spin { to { transform: rotate(360deg); } }
+
+  .ccd-slug-preview {
+    font-size: 11px;
+    color: var(--text-tertiary);
+  }
+
+  .ccd-slug-preview code {
+    font-family: var(--font-mono, monospace);
+    color: var(--accent-primary);
+  }
+
+  /* Scope */
+  .ccd-scope-options {
+    display: flex;
+    gap: 8px;
+  }
+
+  .ccd-scope-option {
+    flex: 1;
+    display: flex;
+    align-items: flex-start;
+    gap: 8px;
+    padding: 10px 12px;
+    border: 1px solid var(--border-default);
+    border-radius: 7px;
+    cursor: pointer;
+    transition: all 0.12s;
+  }
+
+  .ccd-scope-option input[type="radio"] { margin-top: 3px; flex-shrink: 0; accent-color: var(--accent-primary); }
+  .ccd-scope-option.selected { border-color: var(--accent-primary); background: color-mix(in srgb, var(--accent-primary) 8%, transparent); }
+  .ccd-scope-option:has(input:disabled) { opacity: 0.5; cursor: default; }
+
+  .ccd-scope-label { font-size: 12px; font-weight: 600; color: var(--text-primary); }
+  .ccd-scope-hint { font-size: 10.5px; color: var(--text-tertiary); margin-top: 1px; font-family: var(--font-mono, monospace); }
+
+  /* Body field */
+  .ccd-body-field { gap: 6px; }
+
+  .ccd-body-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+  }
+
+  .ccd-preview-toggle {
+    background: transparent;
+    border: 1px solid var(--border-default);
+    border-radius: 5px;
+    color: var(--text-tertiary);
+    font-size: 11px;
+    font-family: inherit;
+    padding: 3px 8px;
+    cursor: pointer;
+  }
+
+  .ccd-preview-toggle:hover { color: var(--text-secondary); }
+
+  .ccd-textarea {
+    background: color-mix(in srgb, var(--surface-overlay) 80%, black);
+    border: 1px solid var(--border-default);
+    border-radius: 6px;
+    color: var(--text-primary);
+    font-size: 13px;
+    font-family: var(--font-mono, 'JetBrains Mono', 'Fira Code', monospace);
+    padding: 8px 10px;
+    outline: none;
+    resize: vertical;
+    min-height: 100px;
+    transition: border-color 0.15s;
+    line-height: 1.5;
+  }
+
+  .ccd-textarea:focus { border-color: var(--accent-primary); }
+  .ccd-textarea.error { border-color: var(--semantic-error); }
+
+  .ccd-preview {
+    background: color-mix(in srgb, var(--surface-overlay) 80%, black);
+    border: 1px solid var(--border-default);
+    border-radius: 6px;
+    color: var(--text-tertiary);
+    font-size: 12px;
+    font-family: var(--font-mono, monospace);
+    padding: 8px 10px;
+    min-height: 80px;
+    max-height: 240px;
+    overflow-y: auto;
+    white-space: pre-wrap;
+    word-break: break-word;
+    line-height: 1.5;
+    margin: 0;
+  }
+
+  /* Parameters */
+  .ccd-params-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+  }
+
+  .ccd-btn-add-param {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    background: transparent;
+    border: 1px solid var(--border-default);
+    border-radius: 5px;
+    color: var(--text-tertiary);
+    font-size: 11px;
+    font-family: inherit;
+    padding: 4px 9px;
+    cursor: pointer;
+  }
+
+  .ccd-btn-add-param:hover { color: var(--accent-primary); border-color: var(--accent-primary); }
+
+  .ccd-params-empty {
+    font-size: 12px;
+    color: var(--text-tertiary);
+    padding: 8px 0;
+  }
+
+  .ccd-params-list {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+  }
+
+  .ccd-param-row {
+    background: color-mix(in srgb, var(--surface-overlay) 70%, black);
+    border: 1px solid var(--border-default);
+    border-radius: 6px;
+    padding: 8px 10px;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+  }
+
+  .ccd-param-row-top {
+    display: flex;
+    gap: 6px;
+    align-items: center;
+  }
+
+  .ccd-param-name {
+    width: 120px;
+    flex-shrink: 0;
+    font-family: var(--font-mono, monospace) !important;
+    font-size: 12px !important;
+  }
+
+  .ccd-param-desc { flex: 1; font-size: 12px !important; }
+
+  .ccd-param-required {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    font-size: 11px;
+    color: var(--text-tertiary);
+    cursor: pointer;
+    white-space: nowrap;
+  }
+
+  .ccd-param-required input { accent-color: var(--accent-primary); }
+
+  .ccd-param-remove {
+    background: transparent;
+    border: none;
+    color: var(--text-tertiary);
+    cursor: pointer;
+    padding: 3px;
+    display: flex;
+    align-items: center;
+    border-radius: 3px;
+  }
+
+  .ccd-param-remove:hover { color: var(--semantic-error); background: color-mix(in srgb, var(--semantic-error) 10%, transparent); }
+
+  .ccd-param-row-bottom {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+  }
+
+  .ccd-param-default-label {
+    font-size: 11px;
+    color: var(--text-tertiary);
+    white-space: nowrap;
+  }
+
+  .ccd-param-default { font-size: 12px !important; max-width: 160px; }
+
+  .ccd-param-placeholder-hint {
+    font-size: 10.5px;
+    color: var(--text-tertiary);
+    font-family: var(--font-mono, monospace);
+  }
+
+  /* Save error */
+  .ccd-save-error {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 8px 12px;
+    background: color-mix(in srgb, var(--semantic-error) 10%, transparent);
+    border: 1px solid color-mix(in srgb, var(--semantic-error) 30%, transparent);
+    border-radius: 6px;
+    color: var(--semantic-error);
+    font-size: 12px;
+  }
+
+  /* Footer */
+  .ccd-footer {
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    gap: 8px;
+    padding: 12px 18px;
+    border-top: 1px solid var(--border-default);
+    flex-shrink: 0;
+  }
+
+  .ccd-btn-cancel {
+    background: transparent;
+    border: 1px solid var(--border-default);
+    border-radius: 6px;
+    color: var(--text-secondary);
+    font-size: 12px;
+    font-family: inherit;
+    padding: 6px 14px;
+    cursor: pointer;
+  }
+
+  .ccd-btn-cancel:hover { background: var(--border-default); }
+  .ccd-btn-cancel:disabled { opacity: 0.5; cursor: default; }
+
+  .ccd-btn-save {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    background: var(--accent-primary);
+    border: none;
+    border-radius: 6px;
+    color: var(--surface-overlay, #0d0e14);
+    font-size: 12px;
+    font-weight: 600;
+    font-family: inherit;
+    padding: 6px 14px;
+    cursor: pointer;
+  }
+
+  .ccd-btn-save:hover { opacity: 0.9; }
+  .ccd-btn-save:disabled { opacity: 0.5; cursor: default; }
+
+  .ccd-btn-save kbd {
+    font-size: 10px;
+    padding: 1px 4px;
+    background: rgba(0,0,0,0.25);
+    border-radius: 3px;
+  }
+`;

--- a/src/renderer/components/CustomCommandPanel.tsx
+++ b/src/renderer/components/CustomCommandPanel.tsx
@@ -1,0 +1,883 @@
+/**
+ * CustomCommandPanel — list, discover, and manage custom slash commands.
+ *
+ * Displays all commands accessible in the current context (project + user +
+ * session scopes), with scope badges, parameter counts, and delete/edit actions.
+ *
+ * Designed to be embedded in SettingsDialog as a "Commands" tab, or surfaced
+ * as a standalone panel anywhere in the layout.
+ *
+ * Usage:
+ *   <CustomCommandPanel
+ *     projectDir={activeSessionDir}
+ *     sessionId={activeSessionId}
+ *   />
+ */
+
+import { useState, useCallback } from 'react';
+import { useCustomCommands } from '../hooks/useCustomCommands';
+import { CustomCommandDialog } from './CustomCommandDialog';
+import type { CustomCommand, CommandScope } from '../../shared/types/custom-command-types';
+
+interface CustomCommandPanelProps {
+  /** If provided, project-scoped commands are loaded from this directory. */
+  projectDir?: string;
+  /** If provided, session-only commands are included. */
+  sessionId?: string | null;
+  /** Optional CSS class for the root element. */
+  className?: string;
+}
+
+// ── Scope badge ────────────────────────────────────────────────────────────
+
+function ScopeBadge({ scope }: { scope: CommandScope }) {
+  const label = scope === 'project' ? 'project' : scope === 'user' ? 'user' : 'session';
+  const colorClass =
+    scope === 'project'
+      ? 'cc-badge-project'
+      : scope === 'user'
+      ? 'cc-badge-user'
+      : 'cc-badge-session';
+  return <span className={`cc-badge ${colorClass}`}>{label}</span>;
+}
+
+// ── Empty state ────────────────────────────────────────────────────────────
+
+function EmptyState({ onCreateClick }: { onCreateClick: () => void }) {
+  return (
+    <div className="cc-empty">
+      <div className="cc-empty-icon">
+        <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
+          <polyline points="16 18 22 12 16 6" />
+          <polyline points="8 6 2 12 8 18" />
+        </svg>
+      </div>
+      <p className="cc-empty-title">No custom commands yet</p>
+      <p className="cc-empty-desc">
+        Create a command to save reusable instructions for Claude.
+        Commands are stored as <code>.md</code> files in{' '}
+        <code>.claude/commands/</code> and work in standalone Claude CLI
+        sessions too.
+      </p>
+      <button className="cc-btn-primary" onClick={onCreateClick}>
+        New command
+      </button>
+    </div>
+  );
+}
+
+// ── Command row ────────────────────────────────────────────────────────────
+
+interface CommandRowProps {
+  command: CustomCommand;
+  onEdit: (cmd: CustomCommand) => void;
+  onDelete: (cmd: CustomCommand) => void;
+  isDeleting: boolean;
+}
+
+function CommandRow({ command, onEdit, onDelete, isDeleting }: CommandRowProps) {
+  return (
+    <div className="cc-row">
+      <div className="cc-row-main">
+        <div className="cc-row-name">
+          <span className="cc-row-slash">/</span>
+          <span className="cc-row-slug">{command.slug}</span>
+          <ScopeBadge scope={command.scope} />
+          {command.parameters.length > 0 && (
+            <span className="cc-row-params" title={`${command.parameters.length} parameter${command.parameters.length > 1 ? 's' : ''}`}>
+              {command.parameters.length}p
+            </span>
+          )}
+        </div>
+        <div className="cc-row-desc">
+          {command.description || <em className="cc-row-no-desc">No description</em>}
+        </div>
+        {command.tags.length > 0 && (
+          <div className="cc-row-tags">
+            {command.tags.map(tag => (
+              <span key={tag} className="cc-tag">{tag}</span>
+            ))}
+          </div>
+        )}
+      </div>
+      <div className="cc-row-actions">
+        <button
+          className="cc-btn-icon"
+          title="Edit command"
+          onClick={() => onEdit(command)}
+          disabled={isDeleting}
+        >
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+            <path d="M11 4H4a2 2 0 00-2 2v14a2 2 0 002 2h14a2 2 0 002-2v-7" />
+            <path d="M18.5 2.5a2.121 2.121 0 013 3L12 15l-4 1 1-4 9.5-9.5z" />
+          </svg>
+        </button>
+        {command.scope !== 'session' && (
+          <button
+            className="cc-btn-icon cc-btn-danger"
+            title="Delete command"
+            onClick={() => onDelete(command)}
+            disabled={isDeleting}
+          >
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+              <polyline points="3 6 5 6 21 6" />
+              <path d="M19 6l-1 14a2 2 0 01-2 2H8a2 2 0 01-2-2L5 6" />
+              <path d="M10 11v6M14 11v6" />
+              <path d="M9 6V4a1 1 0 011-1h4a1 1 0 011 1v2" />
+            </svg>
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ── Usage hint section ─────────────────────────────────────────────────────
+
+function UsageHint({ projectDir }: { projectDir?: string }) {
+  const projectPath = projectDir
+    ? `${projectDir.replace(/\\/g, '/')}/.claude/commands/`
+    : '.claude/commands/';
+  return (
+    <div className="cc-hint">
+      <div className="cc-hint-icon">
+        <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+          <circle cx="12" cy="12" r="10" />
+          <line x1="12" y1="8" x2="12" y2="12" />
+          <line x1="12" y1="16" x2="12.01" y2="16" />
+        </svg>
+      </div>
+      <div className="cc-hint-body">
+        <strong>Project commands</strong> are saved in{' '}
+        <code className="cc-hint-code">{projectPath}</code> — commit them to share with your
+        team. <strong>User commands</strong> are in{' '}
+        <code className="cc-hint-code">~/.claude/commands/</code> — available in all projects.
+        Both scopes are recognized by the Claude CLI too.
+        <br />
+        <span className="cc-hint-gitignore">
+          💡 Add <code className="cc-hint-code">.claude/commands/</code> to <code>.gitignore</code>{' '}
+          to keep commands local; or commit them to share with teammates.
+        </span>
+      </div>
+    </div>
+  );
+}
+
+// ── Panel ──────────────────────────────────────────────────────────────────
+
+export function CustomCommandPanel({ projectDir, sessionId, className }: CustomCommandPanelProps) {
+  const { commands, isLoading, error, loadCommands, createCommand, updateCommand, deleteCommand } =
+    useCustomCommands({ projectDir, sessionId });
+
+  const [isDialogOpen, setIsDialogOpen] = useState(false);
+  const [editingCommand, setEditingCommand] = useState<CustomCommand | null>(null);
+  const [deletingSlug, setDeletingSlug] = useState<string | null>(null);
+  const [deleteError, setDeleteError] = useState<string | null>(null);
+  const [filterScope, setFilterScope] = useState<CommandScope | 'all'>('all');
+  const [searchQuery, setSearchQuery] = useState('');
+
+  // ── Filtering ────────────────────────────────────────────────────────
+
+  const filtered = commands.filter(cmd => {
+    if (filterScope !== 'all' && cmd.scope !== filterScope) return false;
+    if (searchQuery) {
+      const q = searchQuery.toLowerCase();
+      return (
+        cmd.slug.includes(q) ||
+        cmd.description.toLowerCase().includes(q) ||
+        cmd.tags.some(t => t.toLowerCase().includes(q))
+      );
+    }
+    return true;
+  });
+
+  const projectCount = commands.filter(c => c.scope === 'project').length;
+  const userCount = commands.filter(c => c.scope === 'user').length;
+  const sessionCount = commands.filter(c => c.scope === 'session').length;
+
+  // ── Actions ──────────────────────────────────────────────────────────
+
+  const handleOpenCreate = useCallback(() => {
+    setEditingCommand(null);
+    setIsDialogOpen(true);
+  }, []);
+
+  const handleOpenEdit = useCallback((cmd: CustomCommand) => {
+    setEditingCommand(cmd);
+    setIsDialogOpen(true);
+  }, []);
+
+  const handleCloseDialog = useCallback(() => {
+    setIsDialogOpen(false);
+    setEditingCommand(null);
+  }, []);
+
+  const handleSave = useCallback(
+    async (data: {
+      name: string;
+      description: string;
+      body: string;
+      scope: 'project' | 'user' | 'session';
+      parameters: Array<{ name: string; description: string; required: boolean; default?: string }>;
+      tags: string[];
+      icon: string;
+    }) => {
+      if (editingCommand) {
+        await updateCommand({
+          slug: editingCommand.slug,
+          scope: editingCommand.scope,
+          description: data.description,
+          body: data.body,
+          parameters: data.parameters,
+          tags: data.tags,
+          icon: data.icon,
+          projectDir: editingCommand.scope === 'project' ? projectDir : undefined,
+          sessionId: editingCommand.scope === 'session' ? sessionId ?? undefined : undefined,
+        });
+      } else {
+        await createCommand({
+          name: data.name,
+          description: data.description,
+          body: data.body,
+          scope: data.scope,
+          parameters: data.parameters,
+          tags: data.tags,
+          icon: data.icon,
+          projectDir: data.scope === 'project' ? projectDir : undefined,
+          sessionId: data.scope === 'session' ? sessionId ?? undefined : undefined,
+        });
+      }
+      setIsDialogOpen(false);
+      setEditingCommand(null);
+    },
+    [editingCommand, createCommand, updateCommand, projectDir, sessionId],
+  );
+
+  const handleDelete = useCallback(
+    async (cmd: CustomCommand) => {
+      setDeletingSlug(cmd.slug);
+      setDeleteError(null);
+      try {
+        await deleteCommand({
+          slug: cmd.slug,
+          scope: cmd.scope,
+          projectDir: cmd.scope === 'project' ? projectDir : undefined,
+          sessionId: cmd.scope === 'session' ? sessionId ?? undefined : undefined,
+        });
+      } catch (err) {
+        setDeleteError(err instanceof Error ? err.message : 'Delete failed');
+      } finally {
+        setDeletingSlug(null);
+      }
+    },
+    [deleteCommand, projectDir, sessionId],
+  );
+
+  // ── Render ───────────────────────────────────────────────────────────
+
+  return (
+    <div className={`cc-panel ${className ?? ''}`}>
+      {/* Header */}
+      <div className="cc-header">
+        <div className="cc-header-left">
+          <h3 className="cc-title">Custom Commands</h3>
+          <div className="cc-counters">
+            {projectCount > 0 && (
+              <span className="cc-counter">
+                <span className="cc-counter-dot cc-counter-dot-project" />
+                {projectCount} project
+              </span>
+            )}
+            {userCount > 0 && (
+              <span className="cc-counter">
+                <span className="cc-counter-dot cc-counter-dot-user" />
+                {userCount} user
+              </span>
+            )}
+            {sessionCount > 0 && (
+              <span className="cc-counter">
+                <span className="cc-counter-dot cc-counter-dot-session" />
+                {sessionCount} session
+              </span>
+            )}
+          </div>
+        </div>
+        <div className="cc-header-right">
+          <button
+            className="cc-btn-refresh"
+            title="Reload commands from disk"
+            onClick={loadCommands}
+            disabled={isLoading}
+          >
+            <svg
+              width="13"
+              height="13"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              className={isLoading ? 'cc-spin' : ''}
+            >
+              <polyline points="23 4 23 10 17 10" />
+              <path d="M20.49 15a9 9 0 11-2.12-9.36L23 10" />
+            </svg>
+          </button>
+          <button className="cc-btn-primary" onClick={handleOpenCreate}>
+            <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5">
+              <path d="M12 5v14M5 12h14" strokeLinecap="round" />
+            </svg>
+            New command
+          </button>
+        </div>
+      </div>
+
+      {/* Toolbar (search + scope filter) */}
+      {commands.length > 0 && (
+        <div className="cc-toolbar">
+          <div className="cc-search-wrapper">
+            <svg className="cc-search-icon" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+              <circle cx="11" cy="11" r="8" />
+              <line x1="21" y1="21" x2="16.65" y2="16.65" />
+            </svg>
+            <input
+              className="cc-search"
+              type="text"
+              placeholder="Search commands…"
+              value={searchQuery}
+              onChange={e => setSearchQuery(e.target.value)}
+            />
+            {searchQuery && (
+              <button className="cc-search-clear" onClick={() => setSearchQuery('')}>
+                <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5">
+                  <path d="M18 6L6 18M6 6l12 12" strokeLinecap="round" />
+                </svg>
+              </button>
+            )}
+          </div>
+          <div className="cc-scope-filter">
+            {(['all', 'project', 'user', 'session'] as const).map(scope => (
+              <button
+                key={scope}
+                className={`cc-scope-btn ${filterScope === scope ? 'active' : ''}`}
+                onClick={() => setFilterScope(scope)}
+              >
+                {scope === 'all' ? 'All' : scope.charAt(0).toUpperCase() + scope.slice(1)}
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Error state */}
+      {error && (
+        <div className="cc-error">
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+            <circle cx="12" cy="12" r="10" />
+            <line x1="12" y1="8" x2="12" y2="12" />
+            <line x1="12" y1="16" x2="12.01" y2="16" />
+          </svg>
+          {error}
+        </div>
+      )}
+
+      {deleteError && (
+        <div className="cc-error">
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+            <circle cx="12" cy="12" r="10" />
+            <line x1="12" y1="8" x2="12" y2="12" />
+            <line x1="12" y1="16" x2="12.01" y2="16" />
+          </svg>
+          {deleteError}
+        </div>
+      )}
+
+      {/* Loading state */}
+      {isLoading && commands.length === 0 && (
+        <div className="cc-loading">
+          <div className="cc-spinner" />
+          Loading commands…
+        </div>
+      )}
+
+      {/* Empty state */}
+      {!isLoading && commands.length === 0 && !error && (
+        <EmptyState onCreateClick={handleOpenCreate} />
+      )}
+
+      {/* Command list */}
+      {filtered.length > 0 && (
+        <div className="cc-list">
+          {filtered.map(cmd => (
+            <CommandRow
+              key={`${cmd.scope}:${cmd.slug}`}
+              command={cmd}
+              onEdit={handleOpenEdit}
+              onDelete={handleDelete}
+              isDeleting={deletingSlug === cmd.slug}
+            />
+          ))}
+        </div>
+      )}
+
+      {/* No results after filtering */}
+      {!isLoading && commands.length > 0 && filtered.length === 0 && (
+        <div className="cc-no-results">No commands match "{searchQuery}"</div>
+      )}
+
+      {/* Usage hint */}
+      {commands.length > 0 && <UsageHint projectDir={projectDir} />}
+
+      {/* Create / Edit dialog */}
+      <CustomCommandDialog
+        isOpen={isDialogOpen}
+        editingCommand={editingCommand}
+        defaultScope={projectDir ? 'project' : 'user'}
+        onSave={handleSave}
+        onClose={handleCloseDialog}
+        projectDir={projectDir}
+        sessionId={sessionId ?? undefined}
+      />
+
+      <style>{panelStyles}</style>
+    </div>
+  );
+}
+
+// ── Styles ─────────────────────────────────────────────────────────────────
+
+const panelStyles = `
+  .cc-panel {
+    display: flex;
+    flex-direction: column;
+    gap: 0;
+    height: 100%;
+    min-height: 0;
+    font-family: var(--font-ui, 'Inter', system-ui, sans-serif);
+  }
+
+  /* Header */
+  .cc-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 16px 20px 12px;
+    border-bottom: 1px solid var(--border-default);
+    flex-shrink: 0;
+  }
+
+  .cc-header-left {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+  }
+
+  .cc-header-right {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+
+  .cc-title {
+    font-size: 14px;
+    font-weight: 600;
+    color: var(--text-primary);
+    margin: 0;
+  }
+
+  .cc-counters {
+    display: flex;
+    gap: 10px;
+  }
+
+  .cc-counter {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    font-size: 11px;
+    color: var(--text-tertiary);
+  }
+
+  .cc-counter-dot {
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+  }
+  .cc-counter-dot-project { background: var(--accent-primary); }
+  .cc-counter-dot-user { background: #a78bfa; }
+  .cc-counter-dot-session { background: var(--semantic-warning); }
+
+  /* Toolbar */
+  .cc-toolbar {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 10px 20px;
+    border-bottom: 1px solid var(--border-default);
+    flex-shrink: 0;
+  }
+
+  .cc-search-wrapper {
+    position: relative;
+    flex: 1;
+    min-width: 0;
+  }
+
+  .cc-search-icon {
+    position: absolute;
+    left: 9px;
+    top: 50%;
+    transform: translateY(-50%);
+    color: var(--text-tertiary);
+    pointer-events: none;
+  }
+
+  .cc-search {
+    width: 100%;
+    background: var(--surface-overlay);
+    border: 1px solid var(--border-default);
+    border-radius: 6px;
+    color: var(--text-primary);
+    font-size: 12px;
+    font-family: inherit;
+    padding: 5px 28px 5px 30px;
+    outline: none;
+    box-sizing: border-box;
+  }
+
+  .cc-search:focus {
+    border-color: var(--accent-primary);
+  }
+
+  .cc-search-clear {
+    position: absolute;
+    right: 7px;
+    top: 50%;
+    transform: translateY(-50%);
+    background: transparent;
+    border: none;
+    color: var(--text-tertiary);
+    cursor: pointer;
+    padding: 2px;
+    display: flex;
+    align-items: center;
+  }
+
+  .cc-search-clear:hover { color: var(--text-secondary); }
+
+  .cc-scope-filter {
+    display: flex;
+    gap: 2px;
+  }
+
+  .cc-scope-btn {
+    background: transparent;
+    border: 1px solid var(--border-default);
+    border-radius: 5px;
+    color: var(--text-tertiary);
+    font-size: 11px;
+    font-family: inherit;
+    padding: 4px 9px;
+    cursor: pointer;
+    transition: all 0.1s;
+  }
+
+  .cc-scope-btn:hover { color: var(--text-secondary); }
+  .cc-scope-btn.active {
+    background: color-mix(in srgb, var(--accent-primary) 15%, transparent);
+    border-color: var(--accent-primary);
+    color: var(--accent-primary);
+  }
+
+  /* Buttons */
+  .cc-btn-primary {
+    display: flex;
+    align-items: center;
+    gap: 5px;
+    background: var(--accent-primary);
+    border: none;
+    border-radius: 6px;
+    color: var(--surface-overlay, #0d0e14);
+    font-size: 12px;
+    font-weight: 600;
+    font-family: inherit;
+    padding: 6px 12px;
+    cursor: pointer;
+    white-space: nowrap;
+  }
+
+  .cc-btn-primary:hover { opacity: 0.9; }
+
+  .cc-btn-refresh {
+    background: transparent;
+    border: 1px solid var(--border-default);
+    border-radius: 6px;
+    color: var(--text-tertiary);
+    padding: 5px 8px;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+  }
+
+  .cc-btn-refresh:hover { color: var(--text-secondary); }
+  .cc-btn-refresh:disabled { opacity: 0.5; cursor: default; }
+
+  .cc-btn-icon {
+    background: transparent;
+    border: 1px solid transparent;
+    border-radius: 5px;
+    color: var(--text-tertiary);
+    padding: 4px;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    transition: all 0.1s;
+  }
+
+  .cc-btn-icon:hover {
+    border-color: var(--border-default);
+    color: var(--text-secondary);
+  }
+
+  .cc-btn-icon.cc-btn-danger:hover {
+    border-color: var(--semantic-error);
+    color: var(--semantic-error);
+    background: color-mix(in srgb, var(--semantic-error) 10%, transparent);
+  }
+
+  .cc-btn-icon:disabled { opacity: 0.4; cursor: default; }
+
+  /* List */
+  .cc-list {
+    flex: 1;
+    overflow-y: auto;
+    padding: 8px 0;
+  }
+
+  .cc-row {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    padding: 10px 20px;
+    border-bottom: 1px solid var(--border-default);
+    gap: 12px;
+    transition: background 0.1s;
+  }
+
+  .cc-row:last-child { border-bottom: none; }
+  .cc-row:hover { background: color-mix(in srgb, var(--accent-primary) 4%, transparent); }
+
+  .cc-row-main {
+    display: flex;
+    flex-direction: column;
+    gap: 3px;
+    flex: 1;
+    min-width: 0;
+  }
+
+  .cc-row-name {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    flex-wrap: wrap;
+  }
+
+  .cc-row-slash {
+    color: var(--accent-primary);
+    font-size: 13px;
+    font-weight: 700;
+    font-family: var(--font-mono, 'JetBrains Mono', 'Fira Code', monospace);
+  }
+
+  .cc-row-slug {
+    color: var(--text-primary);
+    font-size: 13px;
+    font-weight: 600;
+    font-family: var(--font-mono, 'JetBrains Mono', 'Fira Code', monospace);
+  }
+
+  .cc-row-params {
+    font-size: 10px;
+    padding: 1px 5px;
+    border-radius: 4px;
+    background: color-mix(in srgb, var(--text-tertiary) 15%, transparent);
+    color: var(--text-tertiary);
+    font-family: inherit;
+  }
+
+  .cc-row-desc {
+    font-size: 12px;
+    color: var(--text-secondary);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .cc-row-no-desc {
+    color: var(--text-tertiary);
+    font-style: italic;
+  }
+
+  .cc-row-tags {
+    display: flex;
+    gap: 4px;
+    flex-wrap: wrap;
+  }
+
+  .cc-tag {
+    font-size: 10px;
+    padding: 1px 6px;
+    border-radius: 4px;
+    background: color-mix(in srgb, var(--accent-primary) 12%, transparent);
+    color: var(--accent-primary);
+    font-family: inherit;
+  }
+
+  .cc-row-actions {
+    display: flex;
+    gap: 2px;
+    flex-shrink: 0;
+    margin-top: 2px;
+  }
+
+  /* Scope badges */
+  .cc-badge {
+    font-size: 10px;
+    padding: 1px 6px;
+    border-radius: 4px;
+    font-weight: 500;
+    font-family: inherit;
+    letter-spacing: 0.02em;
+  }
+
+  .cc-badge-project {
+    background: color-mix(in srgb, var(--accent-primary) 15%, transparent);
+    color: var(--accent-primary);
+  }
+
+  .cc-badge-user {
+    background: color-mix(in srgb, #a78bfa 15%, transparent);
+    color: #a78bfa;
+  }
+
+  .cc-badge-session {
+    background: color-mix(in srgb, var(--semantic-warning) 15%, transparent);
+    color: var(--semantic-warning);
+  }
+
+  /* States */
+  .cc-loading, .cc-no-results {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 24px 20px;
+    color: var(--text-tertiary);
+    font-size: 13px;
+  }
+
+  .cc-spinner {
+    width: 16px;
+    height: 16px;
+    border: 2px solid var(--border-default);
+    border-top-color: var(--accent-primary);
+    border-radius: 50%;
+    animation: cc-spin 0.7s linear infinite;
+    flex-shrink: 0;
+  }
+
+  @keyframes cc-spin { to { transform: rotate(360deg); } }
+
+  .cc-spin {
+    animation: cc-spin 0.7s linear infinite;
+  }
+
+  .cc-error {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin: 8px 20px;
+    padding: 8px 12px;
+    background: color-mix(in srgb, var(--semantic-error) 10%, transparent);
+    border: 1px solid color-mix(in srgb, var(--semantic-error) 30%, transparent);
+    border-radius: 6px;
+    color: var(--semantic-error);
+    font-size: 12px;
+    flex-shrink: 0;
+  }
+
+  /* Empty state */
+  .cc-empty {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    padding: 40px 32px;
+    text-align: center;
+    gap: 12px;
+    flex: 1;
+  }
+
+  .cc-empty-icon {
+    color: var(--text-tertiary);
+    opacity: 0.5;
+  }
+
+  .cc-empty-title {
+    font-size: 14px;
+    font-weight: 600;
+    color: var(--text-secondary);
+    margin: 0;
+  }
+
+  .cc-empty-desc {
+    font-size: 12px;
+    color: var(--text-tertiary);
+    max-width: 400px;
+    line-height: 1.6;
+    margin: 0;
+  }
+
+  .cc-empty code {
+    font-family: var(--font-mono, monospace);
+    font-size: 11px;
+    background: var(--surface-overlay);
+    padding: 1px 4px;
+    border-radius: 3px;
+  }
+
+  /* Hint */
+  .cc-hint {
+    display: flex;
+    gap: 9px;
+    padding: 10px 20px;
+    border-top: 1px solid var(--border-default);
+    background: color-mix(in srgb, var(--accent-primary) 4%, transparent);
+    flex-shrink: 0;
+  }
+
+  .cc-hint-icon {
+    color: var(--accent-primary);
+    flex-shrink: 0;
+    margin-top: 1px;
+  }
+
+  .cc-hint-body {
+    font-size: 11px;
+    color: var(--text-tertiary);
+    line-height: 1.6;
+  }
+
+  .cc-hint-code {
+    font-family: var(--font-mono, monospace);
+    font-size: 10.5px;
+    background: color-mix(in srgb, var(--border-default) 60%, transparent);
+    padding: 1px 4px;
+    border-radius: 3px;
+    color: var(--text-secondary);
+  }
+
+  .cc-hint-gitignore {
+    display: inline-block;
+    margin-top: 3px;
+    color: var(--text-tertiary);
+  }
+`;

--- a/src/renderer/components/CustomCommandParameterDialog.tsx
+++ b/src/renderer/components/CustomCommandParameterDialog.tsx
@@ -1,0 +1,399 @@
+/**
+ * CustomCommandParameterDialog — fill in parameters before invoking a custom command.
+ *
+ * When a command with required parameters is selected from the command palette,
+ * this dialog collects the values. The resolved body text is then injected into
+ * the terminal session as plain text (same mechanism as Prompt Templates).
+ *
+ * Usage:
+ *   <CustomCommandParameterDialog
+ *     isOpen={isOpen}
+ *     command={selectedCommand}
+ *     onInvoke={(resolvedBody) => sendToTerminal(resolvedBody)}
+ *     onCancel={() => setOpen(false)}
+ *   />
+ */
+
+import { useState, useEffect, useCallback, useRef } from 'react';
+import type { CustomCommand, CommandParameter } from '../../shared/types/custom-command-types';
+
+interface CustomCommandParameterDialogProps {
+  isOpen: boolean;
+  /** The command to invoke. */
+  command: CustomCommand | null;
+  /** Called with the resolved body text ({{param}} placeholders substituted). */
+  onInvoke: (resolvedBody: string) => void;
+  onCancel: () => void;
+}
+
+// ── Parameter resolution ───────────────────────────────────────────────────
+
+function resolveBody(body: string, values: Record<string, string>): string {
+  return body.replace(/\{\{(\w+)\}\}/g, (_m, name) => values[name] ?? `{{${name}}}`);
+}
+
+// ── Dialog ─────────────────────────────────────────────────────────────────
+
+export function CustomCommandParameterDialog({
+  isOpen,
+  command,
+  onInvoke,
+  onCancel,
+}: CustomCommandParameterDialogProps) {
+  const [values, setValues] = useState<Record<string, string>>({});
+  const [errors, setErrors] = useState<Record<string, string>>({});
+  const [showPreview, setShowPreview] = useState(false);
+  const firstInputRef = useRef<HTMLInputElement>(null);
+
+  // Reset form when command changes or dialog opens
+  useEffect(() => {
+    if (!isOpen || !command) return;
+
+    const defaults: Record<string, string> = {};
+    for (const p of command.parameters) {
+      defaults[p.name] = p.default ?? '';
+    }
+    setValues(defaults);
+    setErrors({});
+    setShowPreview(false);
+
+    // Focus first input
+    setTimeout(() => firstInputRef.current?.focus(), 60);
+  }, [isOpen, command]);
+
+  const setValue = useCallback((name: string, value: string) => {
+    setValues(prev => ({ ...prev, [name]: value }));
+    setErrors(prev => {
+      const next = { ...prev };
+      delete next[name];
+      return next;
+    });
+  }, []);
+
+  const validate = useCallback((): boolean => {
+    if (!command) return false;
+    const newErrors: Record<string, string> = {};
+    for (const p of command.parameters) {
+      if (p.required && !values[p.name]?.trim()) {
+        newErrors[p.name] = `${p.name} is required`;
+      }
+    }
+    setErrors(newErrors);
+    return Object.keys(newErrors).length === 0;
+  }, [command, values]);
+
+  const handleInvoke = useCallback(() => {
+    if (!command || !validate()) return;
+    const resolved = resolveBody(command.body, values);
+    onInvoke(resolved);
+  }, [command, values, validate, onInvoke]);
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === 'Escape') { e.preventDefault(); onCancel(); }
+      if (e.key === 'Enter' && (e.ctrlKey || e.metaKey)) { e.preventDefault(); handleInvoke(); }
+    },
+    [onCancel, handleInvoke],
+  );
+
+  if (!isOpen || !command) return null;
+
+  // Commands with no parameters should be invoked directly without this dialog
+  const params = command.parameters;
+  const resolvedPreview = resolveBody(command.body, values);
+
+  return (
+    <div className="ccpd-overlay" onClick={e => e.target === e.currentTarget && onCancel()}>
+      <div className="ccpd-dialog" onKeyDown={handleKeyDown}>
+        {/* Header */}
+        <div className="ccpd-header">
+          <div className="ccpd-header-icon">
+            <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+              <polyline points="16 18 22 12 16 6" />
+              <polyline points="8 6 2 12 8 18" />
+            </svg>
+          </div>
+          <div>
+            <div className="ccpd-title">/{command.slug}</div>
+            {command.description && (
+              <div className="ccpd-subtitle">{command.description}</div>
+            )}
+          </div>
+        </div>
+
+        {/* Parameters */}
+        {params.length > 0 && (
+          <div className="ccpd-body">
+            {params.map((param, index) => (
+              <ParameterField
+                key={param.name}
+                param={param}
+                value={values[param.name] ?? ''}
+                error={errors[param.name]}
+                inputRef={index === 0 ? firstInputRef : undefined}
+                onChange={val => setValue(param.name, val)}
+              />
+            ))}
+          </div>
+        )}
+
+        {/* Preview toggle */}
+        <div className="ccpd-preview-toggle-row">
+          <button
+            className="ccpd-preview-btn"
+            onClick={() => setShowPreview(v => !v)}
+          >
+            {showPreview ? 'Hide' : 'Show'} preview
+          </button>
+        </div>
+
+        {/* Preview */}
+        {showPreview && (
+          <div className="ccpd-preview-wrap">
+            <pre className="ccpd-preview">{resolvedPreview}</pre>
+          </div>
+        )}
+
+        {/* Footer */}
+        <div className="ccpd-footer">
+          <button className="ccpd-cancel" onClick={onCancel}>Cancel</button>
+          <button className="ccpd-invoke" onClick={handleInvoke}>
+            Run command
+            <kbd>Ctrl+Enter</kbd>
+          </button>
+        </div>
+      </div>
+
+      <style>{dialogStyles}</style>
+    </div>
+  );
+}
+
+// ── Parameter field ────────────────────────────────────────────────────────
+
+interface ParameterFieldProps {
+  param: CommandParameter;
+  value: string;
+  error?: string;
+  inputRef?: React.RefObject<HTMLInputElement>;
+  onChange: (value: string) => void;
+}
+
+function ParameterField({ param, value, error, inputRef, onChange }: ParameterFieldProps) {
+  return (
+    <div className="ccpd-field">
+      <label className="ccpd-label">
+        {param.name}
+        {param.required && <span className="ccpd-required"> *</span>}
+        {param.description && (
+          <span className="ccpd-label-hint"> — {param.description}</span>
+        )}
+      </label>
+      <input
+        ref={inputRef}
+        className={`ccpd-input ${error ? 'error' : ''}`}
+        type="text"
+        value={value}
+        placeholder={param.default ?? `Enter ${param.name}…`}
+        onChange={e => onChange(e.target.value)}
+        spellCheck={false}
+      />
+      {error && <div className="ccpd-field-error">{error}</div>}
+    </div>
+  );
+}
+
+// ── Styles ─────────────────────────────────────────────────────────────────
+
+const dialogStyles = `
+  .ccpd-overlay {
+    position: fixed;
+    inset: 0;
+    background: rgba(0,0,0,0.5);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 1200;
+  }
+
+  .ccpd-dialog {
+    width: 480px;
+    max-width: calc(100vw - 32px);
+    max-height: calc(100vh - 64px);
+    background: var(--surface-overlay);
+    border: 1px solid var(--border-default);
+    border-radius: 12px;
+    box-shadow: 0 16px 48px rgba(0,0,0,0.4);
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+    font-family: var(--font-ui, 'Inter', system-ui, sans-serif);
+  }
+
+  /* Header */
+  .ccpd-header {
+    display: flex;
+    align-items: flex-start;
+    gap: 10px;
+    padding: 14px 18px;
+    border-bottom: 1px solid var(--border-default);
+    flex-shrink: 0;
+  }
+
+  .ccpd-header-icon {
+    color: var(--accent-primary);
+    margin-top: 2px;
+    flex-shrink: 0;
+  }
+
+  .ccpd-title {
+    font-size: 14px;
+    font-weight: 700;
+    color: var(--text-primary);
+    font-family: var(--font-mono, monospace);
+  }
+
+  .ccpd-subtitle {
+    font-size: 12px;
+    color: var(--text-tertiary);
+    margin-top: 2px;
+  }
+
+  /* Body */
+  .ccpd-body {
+    padding: 14px 18px;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    overflow-y: auto;
+    flex-shrink: 0;
+  }
+
+  .ccpd-field {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+  }
+
+  .ccpd-label {
+    font-size: 12px;
+    font-weight: 500;
+    color: var(--text-secondary);
+  }
+
+  .ccpd-label-hint {
+    font-weight: 400;
+    color: var(--text-tertiary);
+  }
+
+  .ccpd-required {
+    color: var(--semantic-error);
+  }
+
+  .ccpd-input {
+    background: color-mix(in srgb, var(--surface-overlay) 70%, black);
+    border: 1px solid var(--border-default);
+    border-radius: 6px;
+    color: var(--text-primary);
+    font-size: 13px;
+    font-family: inherit;
+    padding: 7px 10px;
+    outline: none;
+    transition: border-color 0.15s;
+  }
+
+  .ccpd-input:focus { border-color: var(--accent-primary); }
+  .ccpd-input.error { border-color: var(--semantic-error); }
+
+  .ccpd-field-error {
+    font-size: 11px;
+    color: var(--semantic-error);
+  }
+
+  /* Preview */
+  .ccpd-preview-toggle-row {
+    padding: 4px 18px 8px;
+    flex-shrink: 0;
+  }
+
+  .ccpd-preview-btn {
+    background: transparent;
+    border: none;
+    color: var(--accent-primary);
+    font-size: 12px;
+    font-family: inherit;
+    cursor: pointer;
+    padding: 2px 0;
+  }
+
+  .ccpd-preview-btn:hover { text-decoration: underline; }
+
+  .ccpd-preview-wrap {
+    margin: 0 18px 12px;
+    border: 1px solid var(--border-default);
+    border-radius: 7px;
+    overflow: hidden;
+    flex-shrink: 0;
+    max-height: 200px;
+    overflow-y: auto;
+  }
+
+  .ccpd-preview {
+    font-size: 11.5px;
+    font-family: var(--font-mono, monospace);
+    color: var(--text-tertiary);
+    white-space: pre-wrap;
+    word-break: break-word;
+    padding: 10px 12px;
+    margin: 0;
+    line-height: 1.5;
+  }
+
+  /* Footer */
+  .ccpd-footer {
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    gap: 8px;
+    padding: 12px 18px;
+    border-top: 1px solid var(--border-default);
+    flex-shrink: 0;
+  }
+
+  .ccpd-cancel {
+    background: transparent;
+    border: 1px solid var(--border-default);
+    border-radius: 6px;
+    color: var(--text-secondary);
+    font-size: 12px;
+    font-family: inherit;
+    padding: 6px 14px;
+    cursor: pointer;
+  }
+
+  .ccpd-cancel:hover { background: var(--border-default); }
+
+  .ccpd-invoke {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    background: var(--accent-primary);
+    border: none;
+    border-radius: 6px;
+    color: var(--surface-overlay, #0d0e14);
+    font-size: 12px;
+    font-weight: 600;
+    font-family: inherit;
+    padding: 6px 14px;
+    cursor: pointer;
+  }
+
+  .ccpd-invoke:hover { opacity: 0.9; }
+
+  .ccpd-invoke kbd {
+    font-size: 10px;
+    padding: 1px 4px;
+    background: rgba(0,0,0,0.25);
+    border-radius: 3px;
+  }
+`;

--- a/src/renderer/components/Terminal.tsx
+++ b/src/renderer/components/Terminal.tsx
@@ -408,8 +408,15 @@ export function Terminal({ sessionId, isVisible, isFocused, providerId, readOnly
         // Allow Ctrl+Shift+M (model cycling) to pass through to app
         const isModelCycle = (e.ctrlKey || e.metaKey) && e.shiftKey && e.key === 'M';
 
-        // Allow Ctrl+Shift+C for terminal copy (browser-native)
+        // Ctrl+Shift+C: copy selected text from terminal
         const isCopy = (e.ctrlKey || e.metaKey) && e.shiftKey && e.key === 'C';
+        if (isCopy) {
+          const selection = xterm.getSelection();
+          if (selection) {
+            navigator.clipboard.writeText(selection);
+          }
+          return false;
+        }
 
         // Newline insertion: Ctrl+Enter, Shift+Enter, Alt+Enter, Cmd+Enter
         if (e.key === 'Enter' && (e.ctrlKey || e.shiftKey || e.altKey || e.metaKey)) {
@@ -420,7 +427,7 @@ export function Terminal({ sessionId, isVisible, isFocused, providerId, readOnly
           return false;
         }
 
-        if (isPaste || isShiftInsert || isModelCycle || isCopy) {
+        if (isPaste || isShiftInsert || isModelCycle) {
           return false; // Let browser/app handle → our window event listener picks it up
         }
       }

--- a/src/renderer/components/ui/SettingsDialog.tsx
+++ b/src/renderer/components/ui/SettingsDialog.tsx
@@ -4,6 +4,7 @@ import type { AtlasSettings, DomainSensitivity } from '../../../shared/types/atl
 import { PromptTemplate } from '../../../shared/types/prompt-templates';
 import { TemplateEditor } from '../TemplateEditor';
 import { DragDropSettings } from '../DragDropSettings';
+import { CustomCommandPanel } from '../CustomCommandPanel';
 
 interface SettingsDialogProps {
   isOpen: boolean;
@@ -13,6 +14,10 @@ interface SettingsDialogProps {
   onUpdateWorkspace: (id: string, name?: string, path?: string, permissionMode?: PermissionMode) => Promise<void>;
   onDeleteWorkspace: (id: string) => Promise<void>;
   onValidatePath: (path: string, excludeId?: string) => Promise<WorkspaceValidationResult>;
+  /** Active workspace/project directory — needed to load project-scoped commands. */
+  projectDir?: string | null;
+  /** Active session ID — needed to load session-scoped commands. */
+  sessionId?: string | null;
 }
 
 type EditingState = {
@@ -30,9 +35,11 @@ export function SettingsDialog({
   onUpdateWorkspace,
   onDeleteWorkspace,
   onValidatePath,
+  projectDir,
+  sessionId,
 }: SettingsDialogProps) {
   const [isAnimating, setIsAnimating] = useState(false);
-  const [activeTab, setActiveTab] = useState<'general' | 'workspaces' | 'templates' | 'dragdrop' | 'atlas'>('general');
+  const [activeTab, setActiveTab] = useState<'general' | 'workspaces' | 'templates' | 'dragdrop' | 'atlas' | 'commands'>('general');
   const [showAddForm, setShowAddForm] = useState(false);
   const [editing, setEditing] = useState<EditingState>(null);
   const [deleteConfirm, setDeleteConfirm] = useState<string | null>(null);
@@ -444,6 +451,16 @@ export function SettingsDialog({
               <line x1="16" y1="6" x2="16" y2="22" />
             </svg>
             Atlas
+          </button>
+          <button
+            className={`settings-tab ${activeTab === 'commands' ? 'active' : ''}`}
+            onClick={() => setActiveTab('commands')}
+          >
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+              <polyline points="16 18 22 12 16 6" />
+              <polyline points="8 6 2 12 8 18" />
+            </svg>
+            Commands
           </button>
         </div>
 
@@ -1099,6 +1116,15 @@ export function SettingsDialog({
               </div>
             </div>
           </div>
+          )}
+
+          {activeTab === 'commands' && (
+            <div className="settings-section">
+              <CustomCommandPanel
+                projectDir={projectDir ?? undefined}
+                sessionId={sessionId}
+              />
+            </div>
           )}
         </div>
         </div>{/* end flex wrapper */}

--- a/src/renderer/hooks/useCustomCommands.test.ts
+++ b/src/renderer/hooks/useCustomCommands.test.ts
@@ -1,0 +1,682 @@
+/**
+ * Tests for useCustomCommands hook
+ *
+ * Covers:
+ *   - Initial command loading
+ *   - CRUD operations (create, update, delete)
+ *   - Name validation
+ *   - Error handling
+ *   - File-system change listening
+ *   - State management
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { useCustomCommands } from './useCustomCommands';
+import type { CustomCommand, CommandCreateRequest } from '../../shared/types/custom-command-types';
+
+// Create a mock electronAPI
+const createMockElectronAPI = () => ({
+  listCustomCommands: vi.fn(),
+  createCustomCommand: vi.fn(),
+  updateCustomCommand: vi.fn(),
+  deleteCustomCommand: vi.fn(),
+  validateCommandName: vi.fn(),
+  onCommandsChanged: vi.fn(),
+});
+
+describe('useCustomCommands', () => {
+  let mockAPI: ReturnType<typeof createMockElectronAPI>;
+
+  beforeEach(() => {
+    mockAPI = createMockElectronAPI();
+    (window as any).electronAPI = mockAPI;
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // ── Initial Load Tests ──────────────────────────────────────────────────
+
+  describe('initial load', () => {
+    it('should load commands on mount', async () => {
+      const mockCommands: CustomCommand[] = [
+        {
+          slug: 'deploy',
+          description: 'Deploy app',
+          body: 'deploy',
+          parameters: [],
+          scope: 'user',
+          filePath: null,
+          tags: [],
+          icon: 'Terminal',
+          updatedAt: Date.now(),
+        },
+      ];
+
+      mockAPI.listCustomCommands.mockResolvedValue(mockCommands);
+
+      const { result } = renderHook(() => useCustomCommands());
+
+      expect(mockAPI.listCustomCommands).toHaveBeenCalled();
+
+      await waitFor(() => {
+        expect(result.current.commands).toEqual(mockCommands);
+      });
+    });
+
+    it('should pass projectDir and sessionId to list request', async () => {
+      mockAPI.listCustomCommands.mockResolvedValue([]);
+
+      const { result } = renderHook(() =>
+        useCustomCommands({
+          projectDir: '/home/user/project',
+          sessionId: 'session-123',
+        }),
+      );
+
+      await waitFor(() => {
+        expect(mockAPI.listCustomCommands).toHaveBeenCalledWith({
+          projectDir: '/home/user/project',
+          sessionId: 'session-123',
+        });
+      });
+    });
+
+    it('should set isLoading during initial load', async () => {
+      mockAPI.listCustomCommands.mockImplementation(
+        () =>
+          new Promise(resolve =>
+            setTimeout(() => resolve([]), 100),
+          ),
+      );
+
+      const { result } = renderHook(() => useCustomCommands());
+
+      // Initially loading
+      expect(result.current.isLoading).toBe(true);
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+    });
+
+    it('should handle load errors gracefully', async () => {
+      const error = new Error('Failed to load commands');
+      mockAPI.listCustomCommands.mockRejectedValue(error);
+
+      const { result } = renderHook(() => useCustomCommands());
+
+      await waitFor(() => {
+        expect(result.current.error).toContain('Failed to load');
+        expect(result.current.commands).toEqual([]);
+      });
+    });
+
+    it('should start with empty commands list', () => {
+      mockAPI.listCustomCommands.mockResolvedValue([]);
+
+      const { result } = renderHook(() => useCustomCommands());
+
+      expect(result.current.commands).toEqual([]);
+      expect(result.current.isLoading).toBe(true);
+      expect(result.current.error).toBeNull();
+    });
+  });
+
+  // ── File System Change Listening ────────────────────────────────────────
+
+  describe('file system change listening', () => {
+    it('should listen for command changes', async () => {
+      mockAPI.listCustomCommands.mockResolvedValue([]);
+      let unsubscribe: (() => void) | undefined;
+      let changeCallback: (() => void) | undefined;
+
+      mockAPI.onCommandsChanged.mockImplementation((cb: () => void) => {
+        changeCallback = cb;
+        unsubscribe = vi.fn();
+        return unsubscribe;
+      });
+
+      const { result } = renderHook(() => useCustomCommands());
+
+      await waitFor(() => {
+        expect(mockAPI.onCommandsChanged).toHaveBeenCalled();
+      });
+
+      expect(changeCallback).toBeDefined();
+      expect(unsubscribe).toBeDefined();
+    });
+
+    it('should reload commands when file system changes', async () => {
+      mockAPI.listCustomCommands.mockResolvedValue([]);
+      let changeCallback: (() => void) | undefined;
+
+      mockAPI.onCommandsChanged.mockImplementation((cb: () => void) => {
+        changeCallback = cb;
+        return vi.fn();
+      });
+
+      const { result } = renderHook(() => useCustomCommands());
+
+      await waitFor(() => {
+        expect(mockAPI.listCustomCommands).toHaveBeenCalledTimes(1);
+      });
+
+      const newCommand: CustomCommand = {
+        slug: 'new',
+        description: 'New',
+        body: 'body',
+        parameters: [],
+        scope: 'user',
+        filePath: '/path/new.md',
+        tags: [],
+        icon: 'Terminal',
+        updatedAt: Date.now(),
+      };
+
+      mockAPI.listCustomCommands.mockResolvedValue([newCommand]);
+
+      act(() => {
+        changeCallback?.();
+      });
+
+      await waitFor(() => {
+        expect(result.current.commands).toContainEqual(newCommand);
+      });
+    });
+
+    it('should unsubscribe from changes on unmount', async () => {
+      mockAPI.listCustomCommands.mockResolvedValue([]);
+      const unsubscribe = vi.fn();
+
+      mockAPI.onCommandsChanged.mockReturnValue(unsubscribe);
+
+      const { unmount } = renderHook(() => useCustomCommands());
+
+      await waitFor(() => {
+        expect(mockAPI.onCommandsChanged).toHaveBeenCalled();
+      });
+
+      unmount();
+
+      // Unsubscribe should have been called
+      expect(unsubscribe).toHaveBeenCalled();
+    });
+  });
+
+  // ── Create Command Tests ────────────────────────────────────────────────
+
+  describe('createCommand', () => {
+    it('should create a new command', async () => {
+      mockAPI.listCustomCommands.mockResolvedValue([]);
+
+      const newCommand: CustomCommand = {
+        slug: 'deploy',
+        description: 'Deploy app',
+        body: 'deploy script',
+        parameters: [],
+        scope: 'user',
+        filePath: '/path/deploy.md',
+        tags: [],
+        icon: 'Terminal',
+        updatedAt: Date.now(),
+      };
+
+      mockAPI.createCustomCommand.mockResolvedValue(newCommand);
+
+      const { result } = renderHook(() => useCustomCommands());
+
+      await waitFor(() => {
+        expect(result.current.commands).toEqual([]);
+      });
+
+      const request: CommandCreateRequest = {
+        name: 'Deploy',
+        description: 'Deploy app',
+        body: 'deploy script',
+        scope: 'user',
+      };
+
+      let createdCommand: CustomCommand | undefined;
+      await act(async () => {
+        createdCommand = await result.current.createCommand(request);
+      });
+
+      expect(createdCommand).toEqual(newCommand);
+      expect(mockAPI.createCustomCommand).toHaveBeenCalledWith(request);
+    });
+
+    it('should reload commands after creation', async () => {
+      mockAPI.listCustomCommands.mockResolvedValue([]);
+
+      const newCommand: CustomCommand = {
+        slug: 'deploy',
+        description: 'Deploy app',
+        body: 'deploy',
+        parameters: [],
+        scope: 'user',
+        filePath: '/path/deploy.md',
+        tags: [],
+        icon: 'Terminal',
+        updatedAt: Date.now(),
+      };
+
+      mockAPI.createCustomCommand.mockResolvedValue(newCommand);
+      mockAPI.listCustomCommands.mockResolvedValueOnce([newCommand]);
+
+      const { result } = renderHook(() => useCustomCommands());
+
+      await waitFor(() => {
+        expect(result.current.commands).toEqual([]);
+      });
+
+      await act(async () => {
+        await result.current.createCommand({
+          name: 'Deploy',
+          description: 'Deploy app',
+          body: 'deploy',
+          scope: 'user',
+        });
+      });
+
+      // Commands should be reloaded
+      expect(mockAPI.listCustomCommands).toHaveBeenCalledTimes(2);
+    });
+
+    it('should handle creation errors', async () => {
+      mockAPI.listCustomCommands.mockResolvedValue([]);
+      mockAPI.createCustomCommand.mockRejectedValue(new Error('Creation failed'));
+
+      const { result } = renderHook(() => useCustomCommands());
+
+      await act(async () => {
+        try {
+          await result.current.createCommand({
+            name: 'Deploy',
+            description: 'Deploy app',
+            body: 'deploy',
+            scope: 'user',
+          });
+        } catch (err) {
+          expect(err).toBeDefined();
+        }
+      });
+
+      expect(mockAPI.createCustomCommand).toHaveBeenCalled();
+    });
+  });
+
+  // ── Update Command Tests ────────────────────────────────────────────────
+
+  describe('updateCommand', () => {
+    it('should update an existing command', async () => {
+      const initialCommand: CustomCommand = {
+        slug: 'deploy',
+        description: 'Old description',
+        body: 'old body',
+        parameters: [],
+        scope: 'user',
+        filePath: '/path/deploy.md',
+        tags: [],
+        icon: 'Terminal',
+        updatedAt: Date.now(),
+      };
+
+      mockAPI.listCustomCommands.mockResolvedValue([initialCommand]);
+
+      const updatedCommand = {
+        ...initialCommand,
+        description: 'New description',
+        body: 'new body',
+      };
+
+      mockAPI.updateCustomCommand.mockResolvedValue(updatedCommand);
+
+      const { result } = renderHook(() => useCustomCommands());
+
+      await waitFor(() => {
+        expect(result.current.commands).toEqual([initialCommand]);
+      });
+
+      let updated: CustomCommand | undefined;
+      await act(async () => {
+        updated = await result.current.updateCommand({
+          slug: 'deploy',
+          scope: 'user',
+          description: 'New description',
+          body: 'new body',
+        });
+      });
+
+      expect(updated).toEqual(updatedCommand);
+      expect(mockAPI.updateCustomCommand).toHaveBeenCalled();
+    });
+
+    it('should reload commands after update', async () => {
+      const cmd: CustomCommand = {
+        slug: 'deploy',
+        description: 'Test',
+        body: 'body',
+        parameters: [],
+        scope: 'user',
+        filePath: '/path/deploy.md',
+        tags: [],
+        icon: 'Terminal',
+        updatedAt: Date.now(),
+      };
+
+      mockAPI.listCustomCommands.mockResolvedValue([cmd]);
+      mockAPI.updateCustomCommand.mockResolvedValue({
+        ...cmd,
+        description: 'Updated',
+      });
+
+      const { result } = renderHook(() => useCustomCommands());
+
+      await waitFor(() => {
+        expect(result.current.commands).toEqual([cmd]);
+      });
+
+      const initialCallCount = mockAPI.listCustomCommands.mock.calls.length;
+
+      await act(async () => {
+        await result.current.updateCommand({
+          slug: 'deploy',
+          scope: 'user',
+          description: 'Updated',
+        });
+      });
+
+      // Should have reloaded
+      expect(mockAPI.listCustomCommands.mock.calls.length).toBeGreaterThan(initialCallCount);
+    });
+  });
+
+  // ── Delete Command Tests ────────────────────────────────────────────────
+
+  describe('deleteCommand', () => {
+    it('should delete a command', async () => {
+      const cmd: CustomCommand = {
+        slug: 'deploy',
+        description: 'Deploy',
+        body: 'deploy',
+        parameters: [],
+        scope: 'user',
+        filePath: '/path/deploy.md',
+        tags: [],
+        icon: 'Terminal',
+        updatedAt: Date.now(),
+      };
+
+      mockAPI.listCustomCommands.mockResolvedValue([cmd]);
+      mockAPI.deleteCustomCommand.mockResolvedValue(undefined);
+
+      const { result } = renderHook(() => useCustomCommands());
+
+      await waitFor(() => {
+        expect(result.current.commands).toEqual([cmd]);
+      });
+
+      const initialCallCount = mockAPI.listCustomCommands.mock.calls.length;
+
+      await act(async () => {
+        await result.current.deleteCommand({
+          slug: 'deploy',
+          scope: 'user',
+        });
+      });
+
+      expect(mockAPI.deleteCustomCommand).toHaveBeenCalledWith({
+        slug: 'deploy',
+        scope: 'user',
+      });
+
+      // Should have reloaded (commands should be empty now)
+      expect(mockAPI.listCustomCommands.mock.calls.length).toBeGreaterThan(initialCallCount);
+    });
+
+    it('should handle delete errors', async () => {
+      mockAPI.listCustomCommands.mockResolvedValue([]);
+      mockAPI.deleteCustomCommand.mockRejectedValue(new Error('Delete failed'));
+
+      const { result } = renderHook(() => useCustomCommands());
+
+      await act(async () => {
+        try {
+          await result.current.deleteCommand({
+            slug: 'deploy',
+            scope: 'user',
+          });
+        } catch (err) {
+          expect(err).toBeDefined();
+        }
+      });
+    });
+  });
+
+  // ── Validation Tests ────────────────────────────────────────────────────
+
+  describe('validateName', () => {
+    it('should validate a command name', async () => {
+      mockAPI.listCustomCommands.mockResolvedValue([]);
+      mockAPI.validateCommandName.mockResolvedValue({
+        valid: true,
+        errors: [],
+        suggestedSlug: 'deploy-staging',
+      });
+
+      const { result } = renderHook(() => useCustomCommands());
+
+      let validation;
+      await act(async () => {
+        validation = await result.current.validateName('Deploy Staging', 'user');
+      });
+
+      expect(validation?.valid).toBe(true);
+      expect(validation?.suggestedSlug).toBe('deploy-staging');
+      // validateName can be called with or without optional projectDir
+      expect(mockAPI.validateCommandName).toHaveBeenCalled();
+      const call = mockAPI.validateCommandName.mock.calls[0];
+      expect(call[0]).toBe('Deploy Staging');
+      expect(call[1]).toBe('user');
+    });
+
+    it('should return validation errors', async () => {
+      mockAPI.listCustomCommands.mockResolvedValue([]);
+      mockAPI.validateCommandName.mockResolvedValue({
+        valid: false,
+        errors: ['Command already exists'],
+        suggestedSlug: 'deploy',
+      });
+
+      const { result } = renderHook(() => useCustomCommands());
+
+      let validation;
+      await act(async () => {
+        validation = await result.current.validateName('deploy', 'user');
+      });
+
+      expect(validation?.valid).toBe(false);
+      expect(validation?.errors).toContain('Command already exists');
+    });
+
+    it('should pass projectDir parameter to validation', async () => {
+      mockAPI.listCustomCommands.mockResolvedValue([]);
+      mockAPI.validateCommandName.mockResolvedValue({
+        valid: true,
+        errors: [],
+        suggestedSlug: 'deploy-staging',
+      });
+
+      const { result } = renderHook(() =>
+        useCustomCommands(),
+      );
+
+      await act(async () => {
+        // Call validateName with explicit projectDir parameter
+        await result.current.validateName('Deploy Staging', 'project', '/home/user/project');
+      });
+
+      // The projectDir parameter should be passed through to the API
+      expect(mockAPI.validateCommandName).toHaveBeenCalledWith('Deploy Staging', 'project', '/home/user/project');
+    });
+  });
+
+  // ── Manual Reload Tests ────────────────────────────────────────────────
+
+  describe('loadCommands', () => {
+    it('should manually reload commands', async () => {
+      const cmd: CustomCommand = {
+        slug: 'test',
+        description: 'Test',
+        body: 'test',
+        parameters: [],
+        scope: 'user',
+        filePath: '/path/test.md',
+        tags: [],
+        icon: 'Terminal',
+        updatedAt: Date.now(),
+      };
+
+      mockAPI.listCustomCommands.mockResolvedValue([]);
+
+      const { result } = renderHook(() => useCustomCommands());
+
+      await waitFor(() => {
+        expect(result.current.commands).toEqual([]);
+      });
+
+      const initialCallCount = mockAPI.listCustomCommands.mock.calls.length;
+
+      mockAPI.listCustomCommands.mockResolvedValue([cmd]);
+
+      await act(async () => {
+        await result.current.loadCommands();
+      });
+
+      expect(mockAPI.listCustomCommands.mock.calls.length).toBeGreaterThan(initialCallCount);
+      expect(result.current.commands).toEqual([cmd]);
+    });
+
+    it('should set isLoading during manual reload', async () => {
+      mockAPI.listCustomCommands.mockImplementation(
+        () =>
+          new Promise(resolve =>
+            setTimeout(() => resolve([]), 100),
+          ),
+      );
+
+      const { result } = renderHook(() => useCustomCommands());
+
+      await act(async () => {
+        const loadPromise = result.current.loadCommands();
+
+        // Should be loading immediately
+        expect(result.current.isLoading).toBe(true);
+
+        await loadPromise;
+      });
+
+      // Should be done loading
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    it('should handle errors during manual reload', async () => {
+      mockAPI.listCustomCommands.mockRejectedValue(new Error('Reload failed'));
+
+      const { result } = renderHook(() => useCustomCommands());
+
+      await act(async () => {
+        await result.current.loadCommands();
+      });
+
+      expect(result.current.error).toContain('Reload failed');
+    });
+  });
+
+  // ── Options Change Tests ────────────────────────────────────────────────
+
+  describe('options changes', () => {
+    it('should reload when projectDir changes', async () => {
+      mockAPI.listCustomCommands.mockResolvedValue([]);
+
+      const { result, rerender } = renderHook(
+        (options) => useCustomCommands(options),
+        {
+          initialProps: { projectDir: '/path/1' },
+        },
+      );
+
+      await waitFor(() => {
+        expect(result.current.commands).toEqual([]);
+      });
+
+      const initialCallCount = mockAPI.listCustomCommands.mock.calls.length;
+
+      rerender({ projectDir: '/path/2' });
+
+      // Should have reloaded with new projectDir
+      await waitFor(() => {
+        expect(mockAPI.listCustomCommands.mock.calls.length).toBeGreaterThan(initialCallCount);
+      });
+    });
+
+    it('should reload when sessionId changes', async () => {
+      mockAPI.listCustomCommands.mockResolvedValue([]);
+
+      const { result, rerender } = renderHook(
+        (options) => useCustomCommands(options),
+        {
+          initialProps: { sessionId: 'session-1' },
+        },
+      );
+
+      await waitFor(() => {
+        expect(result.current.commands).toEqual([]);
+      });
+
+      const initialCallCount = mockAPI.listCustomCommands.mock.calls.length;
+
+      rerender({ sessionId: 'session-2' });
+
+      // Should have reloaded
+      await waitFor(() => {
+        expect(mockAPI.listCustomCommands.mock.calls.length).toBeGreaterThan(initialCallCount);
+      });
+    });
+  });
+
+  // ── Error Handling Tests ────────────────────────────────────────────────
+
+  describe('error handling', () => {
+    it('should clear error after successful load', async () => {
+      mockAPI.listCustomCommands.mockRejectedValueOnce(new Error('Initial error'));
+
+      const { result } = renderHook(() => useCustomCommands());
+
+      await waitFor(() => {
+        expect(result.current.error).toContain('Initial error');
+      });
+
+      mockAPI.listCustomCommands.mockResolvedValue([]);
+
+      await act(async () => {
+        await result.current.loadCommands();
+      });
+
+      expect(result.current.error).toBeNull();
+    });
+
+    it('should handle unknown error type', async () => {
+      mockAPI.listCustomCommands.mockRejectedValue('Unknown error');
+
+      const { result } = renderHook(() => useCustomCommands());
+
+      await waitFor(() => {
+        expect(result.current.error).toBeTruthy();
+      });
+    });
+  });
+});

--- a/src/renderer/hooks/useCustomCommands.ts
+++ b/src/renderer/hooks/useCustomCommands.ts
@@ -1,0 +1,140 @@
+/**
+ * useCustomCommands — React hook for the Custom Commands domain.
+ *
+ * Loads commands from the main process, listens for external file-system changes
+ * (pushed via `command:changed` IPC event), and provides CRUD operations.
+ *
+ * Usage:
+ *   const { commands, createCommand, deleteCommand } = useCustomCommands({
+ *     projectDir: '/path/to/project',
+ *     sessionId: activeSessionId,
+ *   });
+ */
+
+import { useState, useEffect, useCallback } from 'react';
+import type {
+  CustomCommand,
+  CommandScope,
+  CommandCreateRequest,
+  CommandUpdateRequest,
+  CommandDeleteRequest,
+  CommandListRequest,
+  CommandValidation,
+} from '../../shared/types/custom-command-types';
+
+export interface UseCustomCommandsOptions {
+  /** If provided, project-scoped commands are loaded from <projectDir>/.claude/commands/ */
+  projectDir?: string;
+  /** If provided, session-only commands are included from the in-memory store. */
+  sessionId?: string | null;
+}
+
+export interface UseCustomCommandsReturn {
+  /** All commands merged across project, user, and session scopes. */
+  commands: CustomCommand[];
+  /** True while the initial load (or a reload triggered by file-system changes) is in progress. */
+  isLoading: boolean;
+  /** Last error message, or null if everything is fine. */
+  error: string | null;
+  /** Manually reload all commands. */
+  loadCommands: () => Promise<void>;
+  /** Create a new command and refresh the list. */
+  createCommand: (request: CommandCreateRequest) => Promise<CustomCommand>;
+  /** Update an existing command and refresh the list. */
+  updateCommand: (request: CommandUpdateRequest) => Promise<CustomCommand>;
+  /** Delete a command and refresh the list. */
+  deleteCommand: (request: CommandDeleteRequest) => Promise<void>;
+  /** Validate a command name (slug check, forbidden names, uniqueness). */
+  validateName: (
+    name: string,
+    scope: CommandScope,
+    projectDir?: string,
+  ) => Promise<CommandValidation>;
+}
+
+export function useCustomCommands(
+  options: UseCustomCommandsOptions = {},
+): UseCustomCommandsReturn {
+  const { projectDir, sessionId } = options;
+
+  const [commands, setCommands] = useState<CustomCommand[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const loadCommands = useCallback(async () => {
+    setIsLoading(true);
+    setError(null);
+    try {
+      const request: CommandListRequest = {
+        projectDir: projectDir || undefined,
+        sessionId: sessionId || undefined,
+      };
+      const cmds = await window.electronAPI.listCustomCommands(request);
+      setCommands(cmds);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : 'Failed to load custom commands';
+      setError(msg);
+      console.error('[useCustomCommands] Failed to load:', err);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [projectDir, sessionId]);
+
+  // Initial load
+  useEffect(() => {
+    loadCommands();
+  }, [loadCommands]);
+
+  // Listen for file-system changes pushed from the main process (fs.watch debounced)
+  useEffect(() => {
+    const unsub = window.electronAPI.onCommandsChanged(() => {
+      // Re-fetch everything so scope-merging logic runs fresh
+      loadCommands();
+    });
+    return unsub;
+  }, [loadCommands]);
+
+  const createCommand = useCallback(
+    async (request: CommandCreateRequest): Promise<CustomCommand> => {
+      const cmd = await window.electronAPI.createCustomCommand(request);
+      await loadCommands();
+      return cmd;
+    },
+    [loadCommands],
+  );
+
+  const updateCommand = useCallback(
+    async (request: CommandUpdateRequest): Promise<CustomCommand> => {
+      const cmd = await window.electronAPI.updateCustomCommand(request);
+      await loadCommands();
+      return cmd;
+    },
+    [loadCommands],
+  );
+
+  const deleteCommand = useCallback(
+    async (request: CommandDeleteRequest): Promise<void> => {
+      await window.electronAPI.deleteCustomCommand(request);
+      await loadCommands();
+    },
+    [loadCommands],
+  );
+
+  const validateName = useCallback(
+    (name: string, scope: CommandScope, pDir?: string): Promise<CommandValidation> => {
+      return window.electronAPI.validateCommandName(name, scope, pDir);
+    },
+    [],
+  );
+
+  return {
+    commands,
+    isLoading,
+    error,
+    loadCommands,
+    createCommand,
+    updateCommand,
+    deleteCommand,
+    validateName,
+  };
+}

--- a/src/shared/ipc-contract.ts
+++ b/src/shared/ipc-contract.ts
@@ -121,6 +121,16 @@ import type {
 } from './types/provider-types';
 
 import type {
+  CustomCommand,
+  CommandListRequest,
+  CommandCreateRequest,
+  CommandUpdateRequest,
+  CommandDeleteRequest,
+  CommandValidation,
+  CommandScope,
+} from './types/custom-command-types';
+
+import type {
   ShareInfo,
   ShareOperationResult,
   SharingSettings,
@@ -428,6 +438,17 @@ export interface IPCContractMap {
   onShareMetadata:         EventContract<'sharing:metadata',         ShareMetadataEvent>;
   onDeepLinkJoin:          EventContract<'sharing:deepLinkJoin',     { shareCode: string }>;
 
+  // ── Custom Commands (invoke) ──
+  listCustomCommands:  InvokeContract<'command:list',     [CommandListRequest],                  CustomCommand[]>;
+  getCustomCommand:    InvokeContract<'command:get',      [string, CommandScope, string?],       CustomCommand | null>;
+  createCustomCommand: InvokeContract<'command:create',   [CommandCreateRequest],                CustomCommand>;
+  updateCustomCommand: InvokeContract<'command:update',   [CommandUpdateRequest],                CustomCommand>;
+  deleteCustomCommand: InvokeContract<'command:delete',   [CommandDeleteRequest],                boolean>;
+  validateCommandName: InvokeContract<'command:validate', [string, CommandScope, string?],       CommandValidation>;
+
+  // ── Custom Command events (main→renderer) ──
+  onCommandsChanged:   EventContract<'command:changed',   { scope: CommandScope; commands: CustomCommand[] }>;
+
   // ── App info (invoke) ──
   getVersionInfo:      InvokeContract<'app:getVersionInfo', [],                                  AppVersionInfo>;
 }
@@ -696,6 +717,15 @@ export const channels: { [K in keyof IPCContractMap]: ChannelOf<K> } = {
   onShareMetadata:         'sharing:metadata',
   onDeepLinkJoin:          'sharing:deepLinkJoin',
 
+  // Custom Commands
+  listCustomCommands:  'command:list',
+  getCustomCommand:    'command:get',
+  createCustomCommand: 'command:create',
+  updateCustomCommand: 'command:update',
+  deleteCustomCommand: 'command:delete',
+  validateCommandName: 'command:validate',
+  onCommandsChanged:   'command:changed',
+
   // App info
   getVersionInfo:      'app:getVersionInfo',
 };
@@ -934,6 +964,15 @@ export const contractKinds: { [K in keyof IPCContractMap]: KindOf<K> } = {
   onShareOutput:           'event',
   onShareMetadata:         'event',
   onDeepLinkJoin:          'event',
+
+  // Custom Commands
+  listCustomCommands:  'invoke',
+  getCustomCommand:    'invoke',
+  createCustomCommand: 'invoke',
+  updateCustomCommand: 'invoke',
+  deleteCustomCommand: 'invoke',
+  validateCommandName: 'invoke',
+  onCommandsChanged:   'event',
 
   getVersionInfo:      'invoke',
 };

--- a/src/shared/types/command-types.ts
+++ b/src/shared/types/command-types.ts
@@ -2,7 +2,7 @@
  * Command types for enhanced command palette
  */
 
-export type CommandCategory = 'sessions' | 'view' | 'templates' | 'panels' | 'settings' | 'help';
+export type CommandCategory = 'sessions' | 'view' | 'templates' | 'panels' | 'settings' | 'help' | 'custom-commands';
 
 export interface Command {
   id: string;

--- a/src/shared/types/custom-command-types.security.test.ts
+++ b/src/shared/types/custom-command-types.security.test.ts
@@ -1,0 +1,621 @@
+/**
+ * Security tests for custom-command-types helpers
+ *
+ * Tests the following security fixes:
+ * 1. YAML Injection Prevention: serializeCommandFile() sanitizes newlines
+ *    in description, parameter names, descriptions, and defaults to prevent
+ *    frontmatter delimiter injection that could close the YAML block early
+ *    and inject arbitrary content.
+ *
+ * These are pure function tests with no mocking — they test the actual
+ * serialization logic directly.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  serializeCommandFile,
+  isValidCommandSlug,
+} from './custom-command-types';
+import type { CommandParameter } from './custom-command-types';
+
+describe('YAML Security — serializeCommandFile()', () => {
+  // ──────────────────────────────────────────────────────────────────────────
+  // BASIC SANITIZATION TESTS
+  // ──────────────────────────────────────────────────────────────────────────
+
+  describe('description field newline sanitization', () => {
+    it('should replace LF (\\n) with space in description', () => {
+      const result = serializeCommandFile(
+        'Line 1\nLine 2',
+        'body content',
+      );
+
+      // The description should be on a single line in the frontmatter
+      const lines = result.split('\n');
+      const descLine = lines.find(l => l.startsWith('description:'));
+
+      expect(descLine).toBe('description: Line 1 Line 2');
+    });
+
+    it('should replace CR (\\r) with space in description', () => {
+      const result = serializeCommandFile(
+        'Line 1\rLine 2',
+        'body content',
+      );
+
+      const lines = result.split('\n');
+      const descLine = lines.find(l => l.startsWith('description:'));
+
+      // CR should be converted to space
+      expect(descLine).toBe('description: Line 1 Line 2');
+    });
+
+    it('should replace CRLF (\\r\\n) with space in description', () => {
+      const result = serializeCommandFile(
+        'Line 1\r\nLine 2',
+        'body content',
+      );
+
+      const lines = result.split('\n');
+      const descLine = lines.find(l => l.startsWith('description:'));
+
+      // CRLF gets two replacements: \r->space and \n->space, so we get two spaces
+      expect(descLine).toMatch(/^description:\s+Line 1\s+Line 2$/);
+    });
+
+    it('should handle multiple consecutive newlines in description', () => {
+      const result = serializeCommandFile(
+        'Start\n\n\nMiddle\n\nEnd',
+        'body',
+      );
+
+      const lines = result.split('\n');
+      const descLine = lines.find(l => l.startsWith('description:'));
+
+      // Multiple newlines should all be converted to spaces
+      expect(descLine).toBe('description: Start   Middle  End');
+    });
+
+    it('should handle description with only newlines', () => {
+      const result = serializeCommandFile(
+        '\n\n\n',
+        'body',
+      );
+
+      const lines = result.split('\n');
+      const descLine = lines.find(l => l.startsWith('description:'));
+
+      // Should become spaces
+      expect(descLine).toContain('description:');
+    });
+  });
+
+  describe('parameter name sanitization', () => {
+    it('should replace LF in parameter name with space', () => {
+      const params: CommandParameter[] = [
+        {
+          name: 'env\niroment',
+          description: 'Environment',
+          required: true,
+        },
+      ];
+
+      const result = serializeCommandFile('Desc', 'body', params);
+
+      expect(result).toContain('name: env iroment');
+      expect(result).not.toContain('name: env\niroment');
+    });
+
+    it('should replace CR in parameter name with space', () => {
+      const params: CommandParameter[] = [
+        {
+          name: 'var\riable',
+          description: 'Variable',
+          required: true,
+        },
+      ];
+
+      const result = serializeCommandFile('Desc', 'body', params);
+
+      expect(result).toContain('name: var iable');
+    });
+
+    it('should handle parameter name with multiple newlines', () => {
+      const params: CommandParameter[] = [
+        {
+          name: 'param\n\nname',
+          description: 'Test',
+          required: false,
+        },
+      ];
+
+      const result = serializeCommandFile('Desc', 'body', params);
+
+      expect(result).toContain('name: param  name');
+    });
+  });
+
+  describe('parameter description sanitization', () => {
+    it('should replace LF in parameter description with space', () => {
+      const params: CommandParameter[] = [
+        {
+          name: 'env',
+          description: 'Deploy to\nstaging environment',
+          required: true,
+        },
+      ];
+
+      const result = serializeCommandFile('Desc', 'body', params);
+
+      const lines = result.split('\n');
+      const paramDescLine = lines.find(l => l.includes('Deploy to'));
+
+      expect(paramDescLine).toBe('    description: Deploy to staging environment');
+    });
+
+    it('should replace CR in parameter description with space', () => {
+      const params: CommandParameter[] = [
+        {
+          name: 'target',
+          description: 'Target\rhost',
+          required: false,
+        },
+      ];
+
+      const result = serializeCommandFile('Desc', 'body', params);
+
+      expect(result).toContain('description: Target host');
+    });
+
+    it('should handle parameter description with multiple newlines', () => {
+      const params: CommandParameter[] = [
+        {
+          name: 'script',
+          description: 'Run script\n\nwith args',
+          required: true,
+        },
+      ];
+
+      const result = serializeCommandFile('Desc', 'body', params);
+
+      expect(result).toContain('description: Run script  with args');
+    });
+  });
+
+  describe('parameter default value sanitization', () => {
+    it('should replace LF in parameter default with space', () => {
+      const params: CommandParameter[] = [
+        {
+          name: 'env',
+          description: 'Environment',
+          required: false,
+          default: 'staging\nproduction',
+        },
+      ];
+
+      const result = serializeCommandFile('Desc', 'body', params);
+
+      expect(result).toContain('default: "staging production"');
+    });
+
+    it('should replace CR in parameter default with space', () => {
+      const params: CommandParameter[] = [
+        {
+          name: 'mode',
+          description: 'Mode',
+          required: false,
+          default: 'fast\rslow',
+        },
+      ];
+
+      const result = serializeCommandFile('Desc', 'body', params);
+
+      expect(result).toContain('default: "fast slow"');
+    });
+
+    it('should replace CRLF in parameter default with space', () => {
+      const params: CommandParameter[] = [
+        {
+          name: 'opt',
+          description: 'Option',
+          required: false,
+          default: 'val1\r\nval2',
+        },
+      ];
+
+      const result = serializeCommandFile('Desc', 'body', params);
+
+      // CRLF (\r\n) gets sanitized: \r becomes space, \n becomes space
+      // The key thing is the newlines are gone and it's on one line
+      expect(result).toMatch(/default:\s*"val1\s+val2"/);
+    });
+
+    it('should handle parameter default with multiple newlines', () => {
+      const params: CommandParameter[] = [
+        {
+          name: 'config',
+          description: 'Config',
+          required: false,
+          default: 'start\n\nmiddle\n\nend',
+        },
+      ];
+
+      const result = serializeCommandFile('Desc', 'body', params);
+
+      expect(result).toContain('default: "start  middle  end"');
+    });
+
+    it('should quote default value (for YAML safety)', () => {
+      const params: CommandParameter[] = [
+        {
+          name: 'value',
+          description: 'Value',
+          required: false,
+          default: 'simple-value',
+        },
+      ];
+
+      const result = serializeCommandFile('Desc', 'body', params);
+
+      // Default should be quoted even without special chars
+      expect(result).toContain('default: "simple-value"');
+    });
+
+    it('should quote empty string default', () => {
+      const params: CommandParameter[] = [
+        {
+          name: 'optional',
+          description: 'Optional param',
+          required: false,
+          default: '',
+        },
+      ];
+
+      const result = serializeCommandFile('Desc', 'body', params);
+
+      expect(result).toContain('default: ""');
+    });
+  });
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // YAML INJECTION ATTACK TESTS
+  // ──────────────────────────────────────────────────────────────────────────
+
+  describe('YAML Injection Prevention', () => {
+    it('should prevent closing frontmatter via description newline injection', () => {
+      // Attacker tries: description: "Normal"\n---\nmalicious: true\n---
+      const injection = 'Normal\n---\nmalicious: true';
+
+      const result = serializeCommandFile(injection, 'body');
+
+      // Count the number of "---" lines
+      const frontmatterCount = (result.match(/^---$/gm) || []).length;
+
+      // Should have exactly 2: opening and closing (not 4 from injection)
+      // This is the key security check: frontmatter is not closed prematurely
+      expect(frontmatterCount).toBe(2);
+
+      // Verify the structure: injected "---" is converted to spaces, not a new YAML section
+      const lines = result.split('\n');
+      const frontmatterEnd = lines.findIndex((l, i) => i > 0 && l === '---');
+      const frontmatter = lines.slice(0, frontmatterEnd).join('\n');
+
+      // Should not have a separate "malicious:" field in frontmatter
+      expect(frontmatter).not.toMatch(/^\s*malicious:\s*true$/m);
+    });
+
+    it('should prevent injecting new YAML fields via parameter description', () => {
+      const params: CommandParameter[] = [
+        {
+          name: 'env',
+          description: 'Test\n---\nadmin: true\n---',
+          required: false,
+        },
+      ];
+
+      const result = serializeCommandFile('Desc', 'body', params);
+
+      // Frontmatter should still be valid (exactly 2 ---)
+      const count = (result.match(/^---$/gm) || []).length;
+      expect(count).toBe(2);
+
+      // Verify no separate "admin:" field exists in the frontmatter
+      const lines = result.split('\n');
+      const frontmatterEnd = lines.findIndex((l, i) => i > 0 && l === '---');
+      const frontmatter = lines.slice(0, frontmatterEnd).join('\n');
+
+      // Should not have "admin:" as a top-level YAML field
+      expect(frontmatter).not.toMatch(/^\s*admin:\s*true$/m);
+    });
+
+    it('should prevent injecting new YAML fields via parameter name', () => {
+      const params: CommandParameter[] = [
+        {
+          name: 'exploit\n---\nbackdoor',
+          description: 'Try injection',
+          required: false,
+        },
+      ];
+
+      const result = serializeCommandFile('Desc', 'body', params);
+
+      const count = (result.match(/^---$/gm) || []).length;
+      expect(count).toBe(2);
+
+      // Should not have the injected field
+      expect(result).not.toMatch(/^backdoor/m);
+    });
+
+    it('should prevent injecting new YAML fields via parameter default', () => {
+      const params: CommandParameter[] = [
+        {
+          name: 'param',
+          description: 'Param',
+          required: false,
+          default: 'value\n---\nsecret: exposed',
+        },
+      ];
+
+      const result = serializeCommandFile('Desc', 'body', params);
+
+      const count = (result.match(/^---$/gm) || []).length;
+      expect(count).toBe(2);
+
+      // Verify no separate "secret:" field exists in the frontmatter
+      const lines = result.split('\n');
+      const frontmatterEnd = lines.findIndex((l, i) => i > 0 && l === '---');
+      const frontmatter = lines.slice(0, frontmatterEnd).join('\n');
+
+      expect(frontmatter).not.toMatch(/^\s*secret:\s*exposed$/m);
+    });
+
+    it('should prevent multi-line injection in description', () => {
+      const injection = `Deploy to prod
+---
+destroy: everything
+hack: the-system
+---`;
+
+      const result = serializeCommandFile(injection, 'body');
+
+      const count = (result.match(/^---$/gm) || []).length;
+      expect(count).toBe(2);
+
+      // Verify no separate "destroy:" or "hack:" fields exist as top-level YAML
+      const lines = result.split('\n');
+      const frontmatterEnd = lines.findIndex((l, i) => i > 0 && l === '---');
+      const frontmatter = lines.slice(0, frontmatterEnd).join('\n');
+
+      expect(frontmatter).not.toMatch(/^\s*destroy:/m);
+      expect(frontmatter).not.toMatch(/^\s*hack:/m);
+    });
+
+    it('should prevent injection across multiple parameters', () => {
+      const params: CommandParameter[] = [
+        {
+          name: 'first\n---\ninjected',
+          description: 'First',
+          required: true,
+        },
+        {
+          name: 'second',
+          description: 'Second\n---\nalso-injected',
+          required: false,
+        },
+      ];
+
+      const result = serializeCommandFile('Desc', 'body', params);
+
+      const count = (result.match(/^---$/gm) || []).length;
+      expect(count).toBe(2);
+
+      expect(result).not.toMatch(/injected:/);
+      expect(result).not.toMatch(/also-injected:/);
+    });
+  });
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // LEGITIMATE MULTILINE CONTENT TESTS
+  // ──────────────────────────────────────────────────────────────────────────
+
+  describe('Legitimate multiline content preservation', () => {
+    it('should preserve newlines in command body (after frontmatter)', () => {
+      const body = `#!/bin/bash
+# Deploy script
+echo "Starting deploy..."
+cd /app && npm run build
+npm run test
+npm run deploy`;
+
+      const result = serializeCommandFile('Deploy', body);
+
+      // Body should retain all its newlines
+      expect(result).toContain('#!/bin/bash');
+      expect(result).toContain('# Deploy script');
+      expect(result).toContain('echo "Starting deploy..."');
+      expect(result).toContain('cd /app && npm run build');
+      expect(result).toContain('npm run test');
+      expect(result).toContain('npm run deploy');
+    });
+
+    it('should preserve complex bash scripts with multiple lines', () => {
+      const body = `if [ -z "$1" ]; then
+  echo "Usage: $0 <version>"
+  exit 1
+fi
+
+version=$1
+echo "Building version $version..."
+npm run build -- --version $version`;
+
+      const result = serializeCommandFile('Build', body);
+
+      // All lines should be preserved in body
+      expect(result).toContain('if [ -z "$1" ]; then');
+      expect(result).toContain('echo "Usage: $0 <version>"');
+      expect(result).toContain('version=$1');
+    });
+
+    it('should allow parameter templating syntax in body', () => {
+      const body = 'git commit -m "{{message}}" --author="{{author}}"';
+
+      const result = serializeCommandFile('Commit', body);
+
+      expect(result).toContain('{{message}}');
+      expect(result).toContain('{{author}}');
+    });
+  });
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // EDGE CASE TESTS
+  // ──────────────────────────────────────────────────────────────────────────
+
+  describe('Edge cases and corner cases', () => {
+    it('should handle parameter with no default', () => {
+      const params: CommandParameter[] = [
+        {
+          name: 'required-param',
+          description: 'This is required',
+          required: true,
+          // no default
+        },
+      ];
+
+      const result = serializeCommandFile('Desc', 'body', params);
+
+      // Should NOT include default line if undefined
+      const lines = result.split('\n');
+      const paramSection = result.substring(
+        result.indexOf('parameters:'),
+        result.indexOf('---', result.indexOf('parameters:'))
+      );
+
+      expect(paramSection).not.toContain('default:');
+    });
+
+    it('should handle many parameters with mixed newlines', () => {
+      const params: CommandParameter[] = [
+        {
+          name: 'p1\ninjected',
+          description: 'First\nline',
+          required: true,
+          default: 'val\ninjected',
+        },
+        {
+          name: 'p2',
+          description: 'Normal',
+          required: false,
+        },
+        {
+          name: 'p3\r\ninjected',
+          description: 'Third\rline',
+          required: false,
+          default: 'default\nvalue',
+        },
+      ];
+
+      const result = serializeCommandFile('Desc', 'body', params);
+
+      // Should have exactly 2 --- (not more from injections)
+      const count = (result.match(/^---$/gm) || []).length;
+      expect(count).toBe(2);
+
+      // All newlines in frontmatter should be sanitized
+      const lines = result.split('\n');
+      const frontmatterEnd = lines.findIndex((l, i) => i > 0 && l === '---');
+      const frontmatter = lines.slice(0, frontmatterEnd).join('\n');
+
+      // Check that no injection patterns remain in frontmatter
+      expect(frontmatter).not.toMatch(/\n---\n/);
+    });
+
+    it('should handle empty description', () => {
+      const result = serializeCommandFile('', 'body');
+
+      expect(result).toContain('description:');
+      expect(result).toContain('---');
+    });
+
+    it('should handle very long description with newlines', () => {
+      const longDesc = 'Start ' + 'line\n'.repeat(100) + ' end';
+
+      const result = serializeCommandFile(longDesc, 'body');
+
+      // Should still have valid frontmatter
+      const count = (result.match(/^---$/gm) || []).length;
+      expect(count).toBe(2);
+    });
+
+    it('should handle description with mixed whitespace and newlines', () => {
+      const desc = '  Start  \n  \n  Middle  \r  \nEnd  ';
+
+      const result = serializeCommandFile(desc, 'body');
+
+      const lines = result.split('\n');
+      const descLine = lines.find(l => l.startsWith('description:'));
+
+      // Should be sanitized but preserve intended spacing
+      expect(descLine).toBeDefined();
+      expect(descLine).toContain('Start');
+      expect(descLine).toContain('Middle');
+      expect(descLine).toContain('End');
+    });
+  });
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // YAML STRUCTURE VALIDATION
+  // ──────────────────────────────────────────────────────────────────────────
+
+  describe('YAML structure integrity after sanitization', () => {
+    it('should always produce valid YAML frontmatter structure', () => {
+      const injection = 'Desc\n---\nmalicious: true';
+      const params: CommandParameter[] = [
+        {
+          name: 'param\n---\ninjected',
+          description: 'Desc\n---\nmore-injection',
+          required: false,
+          default: 'val\n---\nanother',
+        },
+      ];
+
+      const result = serializeCommandFile(injection, 'body', params);
+
+      // Must start with ---
+      expect(result.startsWith('---')).toBe(true);
+
+      // Must have closing ---
+      const lines = result.split('\n');
+      const firstClose = lines.findIndex((l, i) => i > 0 && l === '---');
+      expect(firstClose).toBeGreaterThan(0);
+
+      // Everything after closing --- is body
+      const bodyStart = firstClose + 2; // skip blank line
+      expect(bodyStart < lines.length).toBe(true);
+    });
+
+    it('should have valid YAML in frontmatter (no injected fields)', () => {
+      const injection = 'Test\n---\nadmin: true\nsecret: exposed';
+      const result = serializeCommandFile(injection, 'body');
+
+      const lines = result.split('\n');
+      const closingIndex = lines.findIndex((l, i) => i > 0 && l === '---');
+      const frontmatter = lines.slice(1, closingIndex);
+
+      // Valid keys should exist
+      expect(frontmatter.some(l => l.startsWith('description:'))).toBe(true);
+
+      // Injected keys should NOT exist
+      expect(frontmatter.some(l => l.startsWith('admin:'))).toBe(false);
+      expect(frontmatter.some(l => l.startsWith('secret:'))).toBe(false);
+    });
+
+    it('should produce consistent structure with/without parameters', () => {
+      const result1 = serializeCommandFile('Desc', 'body');
+      const result2 = serializeCommandFile('Desc', 'body', []);
+
+      // Both should have exactly 2 --- delimiters
+      expect((result1.match(/^---$/gm) || []).length).toBe(2);
+      expect((result2.match(/^---$/gm) || []).length).toBe(2);
+    });
+  });
+});

--- a/src/shared/types/custom-command-types.test.ts
+++ b/src/shared/types/custom-command-types.test.ts
@@ -1,0 +1,447 @@
+/**
+ * Tests for custom-command-types helpers
+ *
+ * Covers:
+ *   - slugifyCommandName() edge cases and transformations
+ *   - isValidCommandSlug() validation
+ *   - serializeCommandFile() format correctness
+ *   - Boundary conditions and special characters
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  slugifyCommandName,
+  isValidCommandSlug,
+  serializeCommandFile,
+  FORBIDDEN_COMMAND_SLUGS,
+  MAX_SLUG_LENGTH,
+  MAX_DESCRIPTION_LENGTH,
+  MAX_COMMAND_FILE_SIZE,
+} from './custom-command-types';
+import type { CommandParameter } from './custom-command-types';
+
+describe('custom-command-types helpers', () => {
+  // ── slugifyCommandName Tests ────────────────────────────────────────────
+
+  describe('slugifyCommandName()', () => {
+    it('should convert to lowercase', () => {
+      expect(slugifyCommandName('DEPLOY')).toBe('deploy');
+      expect(slugifyCommandName('DeployStaging')).toBe('deploystaging');
+    });
+
+    it('should convert spaces to hyphens', () => {
+      expect(slugifyCommandName('Deploy Staging')).toBe('deploy-staging');
+      expect(slugifyCommandName('Run Tests Now')).toBe('run-tests-now');
+    });
+
+    it('should handle underscores as delimiters', () => {
+      expect(slugifyCommandName('run_tests')).toBe('run-tests');
+      expect(slugifyCommandName('deploy_to_production')).toBe('deploy-to-production');
+    });
+
+    it('should handle mixed delimiters', () => {
+      expect(slugifyCommandName('Run_Tests Now!')).toBe('run-tests-now');
+      expect(slugifyCommandName('my-test_script')).toBe('my-test-script');
+    });
+
+    it('should remove special characters', () => {
+      expect(slugifyCommandName('test!@#$%')).toBe('test');
+      expect(slugifyCommandName('run-test@#!')).toBe('run-test');
+      expect(slugifyCommandName('my(test)')).toBe('my-test');
+    });
+
+    it('should keep numbers', () => {
+      expect(slugifyCommandName('test123')).toBe('test123');
+      expect(slugifyCommandName('123test')).toBe('123test');
+      expect(slugifyCommandName('test-123-script')).toBe('test-123-script');
+    });
+
+    it('should trim leading and trailing hyphens', () => {
+      expect(slugifyCommandName('  test  ')).toBe('test');
+      expect(slugifyCommandName('-test-')).toBe('test');
+      expect(slugifyCommandName('---test---')).toBe('test');
+    });
+
+    it('should collapse multiple consecutive delimiters', () => {
+      expect(slugifyCommandName('test   script')).toBe('test-script');
+      expect(slugifyCommandName('test___script')).toBe('test-script');
+      expect(slugifyCommandName('test   ___   script')).toBe('test-script');
+    });
+
+    it('should handle empty string', () => {
+      expect(slugifyCommandName('')).toBe('');
+    });
+
+    it('should handle only special characters', () => {
+      expect(slugifyCommandName('!@#$%^&*()')).toBe('');
+      expect(slugifyCommandName('---___')).toBe('');
+    });
+
+    it('should handle only whitespace', () => {
+      expect(slugifyCommandName('   ')).toBe('');
+    });
+
+    it('should not truncate (manager handles that)', () => {
+      const longName = 'a'.repeat(100);
+      const result = slugifyCommandName(longName);
+
+      // slugifyCommandName doesn't truncate — manager's private slugify() does that
+      expect(result.length).toBeGreaterThan(MAX_SLUG_LENGTH);
+      expect(result).toBe('a'.repeat(100));
+    });
+
+    it('should handle real-world examples', () => {
+      const testCases = [
+        { input: 'Deploy Staging', expected: 'deploy-staging' },
+        { input: 'Run Tests', expected: 'run-tests' },
+        { input: 'My Deploy Script', expected: 'my-deploy-script' },
+        { input: 'run_tests!', expected: 'run-tests' },
+        { input: '  fix bug  ', expected: 'fix-bug' },
+        { input: 'Build & Deploy', expected: 'build-deploy' },
+        { input: 'test (v2)', expected: 'test-v2' },
+      ];
+
+      for (const { input, expected } of testCases) {
+        expect(slugifyCommandName(input)).toBe(expected);
+      }
+    });
+  });
+
+  // ── isValidCommandSlug Tests ────────────────────────────────────────────
+
+  describe('isValidCommandSlug()', () => {
+    it('should accept valid kebab-case slugs', () => {
+      expect(isValidCommandSlug('deploy-staging')).toBe(true);
+      expect(isValidCommandSlug('run-tests')).toBe(true);
+      expect(isValidCommandSlug('my-test-script')).toBe(true);
+    });
+
+    it('should accept slugs with numbers', () => {
+      expect(isValidCommandSlug('test123')).toBe(true);
+      expect(isValidCommandSlug('123test')).toBe(true);
+      expect(isValidCommandSlug('test-123-script')).toBe(true);
+    });
+
+    it('should accept single-character slug', () => {
+      expect(isValidCommandSlug('a')).toBe(true);
+      expect(isValidCommandSlug('x')).toBe(true);
+      expect(isValidCommandSlug('1')).toBe(true);
+    });
+
+    it('should reject empty slug', () => {
+      expect(isValidCommandSlug('')).toBe(false);
+    });
+
+    it('should reject slugs longer than MAX_SLUG_LENGTH', () => {
+      const longSlug = 'a'.repeat(MAX_SLUG_LENGTH + 1);
+      expect(isValidCommandSlug(longSlug)).toBe(false);
+    });
+
+    it('should reject reserved command slugs', () => {
+      for (const reserved of FORBIDDEN_COMMAND_SLUGS) {
+        expect(isValidCommandSlug(reserved)).toBe(false);
+      }
+    });
+
+    it('should reject all specific reserved names', () => {
+      const reserved = ['help', 'init', 'config', 'login', 'logout', 'version', 'update'];
+      for (const name of reserved) {
+        expect(isValidCommandSlug(name)).toBe(false);
+      }
+    });
+
+    it('should reject uppercase letters', () => {
+      expect(isValidCommandSlug('Deploy')).toBe(false);
+      expect(isValidCommandSlug('DEPLOY')).toBe(false);
+    });
+
+    it('should reject underscores', () => {
+      expect(isValidCommandSlug('test_script')).toBe(false);
+    });
+
+    it('should reject special characters', () => {
+      expect(isValidCommandSlug('test!')).toBe(false);
+      expect(isValidCommandSlug('test@script')).toBe(false);
+      expect(isValidCommandSlug('test#cmd')).toBe(false);
+    });
+
+    it('should reject leading/trailing hyphens', () => {
+      expect(isValidCommandSlug('-test')).toBe(false);
+      expect(isValidCommandSlug('test-')).toBe(false);
+      expect(isValidCommandSlug('-test-')).toBe(false);
+    });
+
+    it('should reject leading/trailing numbers as single char', () => {
+      // Single digit should be valid
+      expect(isValidCommandSlug('1')).toBe(true);
+    });
+
+    it('should accept MAX_SLUG_LENGTH exactly', () => {
+      const maxSlug = 'a'.repeat(MAX_SLUG_LENGTH);
+      expect(isValidCommandSlug(maxSlug)).toBe(true);
+    });
+
+    it('should reject whitespace', () => {
+      expect(isValidCommandSlug('test script')).toBe(false);
+      expect(isValidCommandSlug('test\tscript')).toBe(false);
+    });
+  });
+
+  // ── serializeCommandFile Tests ──────────────────────────────────────────
+
+  describe('serializeCommandFile()', () => {
+    it('should create valid markdown with YAML frontmatter', () => {
+      const result = serializeCommandFile('Test Command', 'This is the body');
+
+      expect(result).toContain('---');
+      expect(result).toContain('description: Test Command');
+      expect(result).toContain('This is the body');
+
+      // Should start and end with proper delimiters
+      expect(result.startsWith('---')).toBe(true);
+    });
+
+    it('should include simple description', () => {
+      const result = serializeCommandFile('Deploy to Staging', 'npm run deploy:staging');
+
+      expect(result).toContain('description: Deploy to Staging');
+    });
+
+    it('should trim body whitespace', () => {
+      const result = serializeCommandFile('Test', '  \n  body content  \n  ');
+
+      expect(result).toContain('body content');
+      expect(result.endsWith('body content')).toBe(true);
+    });
+
+    it('should include parameters in correct format', () => {
+      const params: CommandParameter[] = [
+        {
+          name: 'environment',
+          description: 'Target environment',
+          required: true,
+          default: 'staging',
+        },
+        {
+          name: 'verbose',
+          description: 'Enable verbose output',
+          required: false,
+        },
+      ];
+
+      const result = serializeCommandFile('Deploy', 'deploy --env={{environment}}', params);
+
+      expect(result).toContain('parameters:');
+      expect(result).toContain('- name: environment');
+      expect(result).toContain('description: Target environment');
+      expect(result).toContain('required: true');
+      expect(result).toContain('default: "staging"');
+      expect(result).toContain('- name: verbose');
+      expect(result).toContain('required: false');
+    });
+
+    it('should not include parameters section if empty', () => {
+      const result1 = serializeCommandFile('Test', 'body');
+      const result2 = serializeCommandFile('Test', 'body', []);
+
+      expect(result1).not.toContain('parameters:');
+      expect(result2).not.toContain('parameters:');
+    });
+
+    it('should include tags in correct format', () => {
+      const tags = ['deploy', 'production', 'ci-cd'];
+
+      const result = serializeCommandFile('Deploy', 'deploy', undefined, tags);
+
+      expect(result).toContain('tags:');
+      expect(result).toContain('- deploy');
+      expect(result).toContain('- production');
+      expect(result).toContain('- ci-cd');
+    });
+
+    it('should not include tags section if empty', () => {
+      const result1 = serializeCommandFile('Test', 'body');
+      const result2 = serializeCommandFile('Test', 'body', undefined, []);
+
+      expect(result1).not.toContain('tags:');
+      expect(result2).not.toContain('tags:');
+    });
+
+    it('should include icon if provided', () => {
+      const result = serializeCommandFile('Test', 'body', undefined, undefined, 'Hammer');
+
+      expect(result).toContain('icon: Hammer');
+    });
+
+    it('should include Terminal icon only if explicitly provided', () => {
+      const result1 = serializeCommandFile('Test', 'body');
+
+      expect(result1).not.toContain('icon:');
+
+      // When 'Terminal' is explicitly provided, it IS included
+      const result2 = serializeCommandFile('Test', 'body', undefined, undefined, 'Terminal');
+      expect(result2).toContain('icon: Terminal');
+    });
+
+    it('should handle special characters in description', () => {
+      const result = serializeCommandFile(
+        'Test: Deploy (v2) & Run',
+        'body',
+      );
+
+      expect(result).toContain('description: Test: Deploy (v2) & Run');
+    });
+
+    it('should handle multiline body correctly', () => {
+      const body = `npm run build
+npm run test
+npm run deploy`;
+
+      const result = serializeCommandFile('Multi', body);
+
+      expect(result).toContain('npm run build');
+      expect(result).toContain('npm run test');
+      expect(result).toContain('npm run deploy');
+    });
+
+    it('should maintain body without modification (except trim)', () => {
+      const body = `if [ "$?" -eq 0 ]; then
+  echo "Success"
+else
+  exit 1
+fi`;
+
+      const result = serializeCommandFile('Bash Script', body);
+
+      expect(result).toContain('if [ "$?" -eq 0 ]; then');
+      expect(result).toContain('echo "Success"');
+    });
+
+    it('should handle parameter without default value', () => {
+      const params: CommandParameter[] = [
+        {
+          name: 'message',
+          description: 'Commit message',
+          required: true,
+        },
+      ];
+
+      const result = serializeCommandFile('Commit', 'git commit -m "{{message}}"', params);
+
+      expect(result).toContain('- name: message');
+      expect(result).toContain('required: true');
+      expect(result).not.toContain('default:'); // Should not include undefined default
+    });
+
+    it('should handle empty string default value', () => {
+      const params: CommandParameter[] = [
+        {
+          name: 'suffix',
+          description: 'Optional suffix',
+          required: false,
+          default: '',
+        },
+      ];
+
+      const result = serializeCommandFile('Test', 'body', params);
+
+      // Empty default should be included
+      expect(result).toContain('default:');
+    });
+
+    it('should create complete valid markdown format', () => {
+      const description = 'Full Example';
+      const body = 'echo "Hello World"';
+      const params: CommandParameter[] = [
+        { name: 'name', description: 'Your name', required: true, default: 'World' },
+      ];
+      const tags = ['example', 'greeting'];
+      const icon = 'Smile';
+
+      const result = serializeCommandFile(description, body, params, tags, icon);
+
+      const lines = result.split('\n');
+
+      // Verify structure
+      expect(lines[0]).toBe('---');
+      expect(lines[1]).toBe('description: Full Example');
+
+      // Find closing --- of frontmatter
+      const closingIndex = lines.findIndex((line, i) => i > 0 && line === '---');
+      expect(closingIndex).toBeGreaterThan(0);
+
+      // After closing ---, should have blank line then body
+      const bodyStartIndex = closingIndex + 2;
+      expect(bodyStartIndex < lines.length).toBe(true);
+    });
+  });
+
+  // ── Constants Tests ─────────────────────────────────────────────────────
+
+  describe('constants', () => {
+    it('should have defined FORBIDDEN_COMMAND_SLUGS', () => {
+      expect(FORBIDDEN_COMMAND_SLUGS).toBeDefined();
+      expect(Array.isArray(FORBIDDEN_COMMAND_SLUGS)).toBe(true);
+      expect(FORBIDDEN_COMMAND_SLUGS.length).toBeGreaterThan(0);
+    });
+
+    it('should have reasonable MAX_SLUG_LENGTH', () => {
+      expect(MAX_SLUG_LENGTH).toBeGreaterThan(10);
+      expect(MAX_SLUG_LENGTH).toBeLessThan(200);
+    });
+
+    it('should have reasonable MAX_DESCRIPTION_LENGTH', () => {
+      expect(MAX_DESCRIPTION_LENGTH).toBeGreaterThan(50);
+      expect(MAX_DESCRIPTION_LENGTH).toBeLessThan(1000);
+    });
+
+    it('should have reasonable MAX_COMMAND_FILE_SIZE', () => {
+      expect(MAX_COMMAND_FILE_SIZE).toBeGreaterThan(1000); // At least 1KB
+      expect(MAX_COMMAND_FILE_SIZE).toBeLessThan(1000000); // Less than 1MB
+    });
+  });
+
+  // ── Integration Tests (combining multiple functions) ────────────────────
+
+  describe('integration', () => {
+    it('should slugify and then validate', () => {
+      const name = 'My New Command!';
+      const slug = slugifyCommandName(name);
+      const isValid = isValidCommandSlug(slug);
+
+      expect(isValid).toBe(true);
+    });
+
+    it('should reject reserved names when slugified', () => {
+      const reservedNames = ['Help', 'HELP', 'Help!', 'help-me'];
+
+      for (const name of reservedNames) {
+        const slug = slugifyCommandName(name);
+        if (slug === 'help') {
+          expect(isValidCommandSlug(slug)).toBe(false);
+        }
+      }
+    });
+
+    it('should create valid file for any reasonable input', () => {
+      const inputs = [
+        { name: 'My Test', desc: 'Test description', body: 'echo test' },
+        { name: 'Deploy!', desc: 'Deploy app', body: 'npm run deploy' },
+        { name: 'RUN_TESTS', desc: 'Run tests', body: 'npm test' },
+      ];
+
+      for (const input of inputs) {
+        const file = serializeCommandFile(input.desc, input.body);
+
+        // Should always start with ---
+        expect(file.startsWith('---')).toBe(true);
+        // Should have closing ---
+        expect(file.includes('---\n')).toBe(true);
+        // Should contain description
+        expect(file).toContain('description:');
+        // Should contain body
+        expect(file).toContain(input.body);
+      }
+    });
+  });
+});

--- a/src/shared/types/custom-command-types.ts
+++ b/src/shared/types/custom-command-types.ts
@@ -1,0 +1,234 @@
+/**
+ * Custom Command types — shared between main and renderer.
+ *
+ * Commands are persisted as Markdown files with YAML frontmatter in:
+ *   - Project scope: <project-root>/.claude/commands/*.md
+ *   - User scope:    ~/.claude/commands/*.md
+ *   - Session scope: in-memory only (not written to disk)
+ *
+ * This aligns with Claude Code's native custom command convention so that
+ * commands created in OmniDesk are also recognized by standalone CLI sessions.
+ */
+
+// ── Scope ──────────────────────────────────────────────────────────────────
+
+export type CommandScope = 'project' | 'user' | 'session';
+
+// ── Parameter definition ───────────────────────────────────────────────────
+
+export interface CommandParameter {
+  /** Alphanumeric + underscore. Used as {{name}} in the command body. */
+  name: string;
+  /** Shown to the user when prompted for a value. */
+  description: string;
+  /** Whether this parameter must be provided before running. Default: false */
+  required: boolean;
+  /** Default value used when the parameter is not supplied. */
+  default?: string;
+}
+
+// ── Custom command ─────────────────────────────────────────────────────────
+
+export interface CustomCommand {
+  /** Derived from the filename without extension (e.g. "deploy-staging"). */
+  slug: string;
+  /** Human-readable description from frontmatter. Shown in the command palette. */
+  description: string;
+  /** The Markdown body — the actual instruction sent to Claude when the command is invoked. */
+  body: string;
+  /** Parameter definitions for this command. */
+  parameters: CommandParameter[];
+  /** Where this command lives. */
+  scope: CommandScope;
+  /** Absolute path to the .md file. Null for session-only commands. */
+  filePath: string | null;
+  /** Tags for search/filtering in the OmniDesk UI. */
+  tags: string[];
+  /** Lucide icon name. Defaults to "Terminal". */
+  icon: string;
+  /** File modification time (milliseconds since epoch). */
+  updatedAt: number;
+}
+
+// ── IPC request / response types ───────────────────────────────────────────
+
+export interface CommandListRequest {
+  /** If provided, also scan <projectDir>/.claude/commands/ for project-scoped commands. */
+  projectDir?: string;
+  /** If provided, include in-memory session-only commands for this session. */
+  sessionId?: string;
+}
+
+export interface CommandCreateRequest {
+  /** Desired command name — will be slugified automatically. */
+  name: string;
+  /** Human-readable description (max 200 chars). */
+  description: string;
+  /** The instruction body (Markdown). Supports {{paramName}} placeholders. */
+  body: string;
+  /** Where to save the command. */
+  scope: 'project' | 'user' | 'session';
+  /** Optional parameter definitions. */
+  parameters?: CommandParameter[];
+  /** Optional tags for search/filtering. */
+  tags?: string[];
+  /** Optional Lucide icon name. Defaults to "Terminal". */
+  icon?: string;
+  /** Required when scope is "session". */
+  sessionId?: string;
+  /** Required when scope is "project". */
+  projectDir?: string;
+}
+
+export interface CommandUpdateRequest {
+  /** Slug of the command to update. */
+  slug: string;
+  /** Scope — used to locate the correct file or in-memory store. */
+  scope: CommandScope;
+  /** Updated description (optional). */
+  description?: string;
+  /** Updated body (optional). */
+  body?: string;
+  /** Updated parameters (optional, replaces the full list). */
+  parameters?: CommandParameter[];
+  /** Updated tags (optional, replaces the full list). */
+  tags?: string[];
+  /** Updated icon (optional). */
+  icon?: string;
+  /** Required when scope is "session". */
+  sessionId?: string;
+  /** Required when scope is "project". */
+  projectDir?: string;
+}
+
+export interface CommandDeleteRequest {
+  /** Slug of the command to delete. */
+  slug: string;
+  /** Scope — used to locate the correct file or in-memory store. */
+  scope: CommandScope;
+  /** Required when scope is "session". */
+  sessionId?: string;
+  /** Required when scope is "project". */
+  projectDir?: string;
+}
+
+export interface CommandValidation {
+  /** Whether the name/slug is valid and unique. */
+  valid: boolean;
+  /** Human-readable error messages. Empty when valid. */
+  errors: string[];
+  /** The slugified form of the provided name. */
+  suggestedSlug: string;
+}
+
+// ── Constants ───────────────────────────────────────────────────────────────
+
+/**
+ * Claude Code built-in command names that cannot be used as custom command slugs.
+ * Must be validated at creation time to prevent shadowing built-in behaviour.
+ */
+export const FORBIDDEN_COMMAND_SLUGS: readonly string[] = [
+  'help',
+  'init',
+  'config',
+  'login',
+  'logout',
+  'version',
+  'update',
+] as const;
+
+/** Maximum slug length (characters, not including the .md extension). */
+export const MAX_SLUG_LENGTH = 60;
+
+/** Maximum frontmatter description length (characters). */
+export const MAX_DESCRIPTION_LENGTH = 200;
+
+/**
+ * Files larger than this are skipped during directory scanning.
+ * Prevents accidental large-file ingestion from `.claude/commands/`.
+ */
+export const MAX_COMMAND_FILE_SIZE = 51200; // 50 KB
+
+// ── Pure helpers (safe in both main and renderer) ──────────────────────────
+
+/**
+ * Convert any user-supplied string into a valid command slug.
+ *
+ * @example
+ * slugifyCommandName('My Deploy Script')  // → 'my-deploy-script'
+ * slugifyCommandName('run_tests!')        // → 'run-tests'
+ * slugifyCommandName('  fix bug  ')       // → 'fix-bug'
+ */
+export function slugifyCommandName(name: string): string {
+  return name
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-|-$/g, '');
+}
+
+/**
+ * Return true when the slug is syntactically valid as a custom command name.
+ * Does NOT check for filesystem collisions — that requires an async lookup.
+ */
+export function isValidCommandSlug(slug: string): boolean {
+  if (!slug || slug.length === 0 || slug.length > MAX_SLUG_LENGTH) return false;
+  if ((FORBIDDEN_COMMAND_SLUGS as readonly string[]).includes(slug)) return false;
+  // Must be kebab-case: lowercase letters/digits with interior hyphens.
+  // A single-character slug (e.g. "x") is allowed.
+  return /^[a-z0-9]([a-z0-9-]*[a-z0-9])?$/.test(slug);
+}
+
+/**
+ * Strip CR and LF from a scalar YAML value so a user-supplied newline cannot
+ * close the frontmatter block early and inject arbitrary text into the body.
+ */
+function sanitizeScalar(value: string): string {
+  return value.replace(/[\r\n]/g, ' ');
+}
+
+/**
+ * Serialize command metadata + body into the canonical `.md` file format.
+ *
+ * @example
+ * serializeCommandFile('Run tests', 'Run npm test and report failures');
+ * // ---
+ * // description: Run tests
+ * // ---
+ * //
+ * // Run npm test and report failures
+ */
+export function serializeCommandFile(
+  description: string,
+  body: string,
+  parameters?: CommandParameter[],
+  tags?: string[],
+  icon?: string,
+): string {
+  const lines: string[] = ['---', `description: ${sanitizeScalar(description)}`];
+
+  if (parameters && parameters.length > 0) {
+    lines.push('parameters:');
+    for (const p of parameters) {
+      lines.push(`  - name: ${sanitizeScalar(p.name)}`);
+      lines.push(`    description: ${sanitizeScalar(p.description)}`);
+      lines.push(`    required: ${p.required}`);
+      if (p.default !== undefined) {
+        lines.push(`    default: "${sanitizeScalar(p.default)}"`);
+      }
+    }
+  }
+
+  if (tags && tags.length > 0) {
+    lines.push('tags:');
+    for (const t of tags) {
+      lines.push(`  - ${t}`);
+    }
+  }
+
+  if (icon) {
+    lines.push(`icon: ${icon}`);
+  }
+
+  lines.push('---', '', body.trim());
+  return lines.join('\n');
+}


### PR DESCRIPTION
Adds user-defined and project-scoped custom commands that appear in the command palette. Includes command manager, IPC handlers, parameter dialog, settings panel, and security/unit tests. Also fixes Ctrl+Shift+C terminal copy by reading xterm selection directly instead of relying on browser-native copy.