### PR TITLE
fix: thread launchMode through the renderer-to-IPC chain

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -622,10 +622,11 @@ function App() {
     workingDirectory: string,
     permissionMode: 'standard' | 'skip-permissions',
     worktree?: import('../shared/types/git-types').WorktreeCreateRequest,
-    providerId?: import('../shared/types/provider-types').ProviderId
+    providerId?: import('../shared/types/provider-types').ProviderId,
+    launchMode?: import('../shared/ipc-types').LaunchMode,
   ) => {
     try {
-      await createSession(name, workingDirectory, permissionMode, worktree, providerId);
+      await createSession(name, workingDirectory, permissionMode, worktree, providerId, launchMode);
     } catch (err) {
       console.error('Failed to create session:', err);
     }

--- a/src/renderer/components/ui/TabBar.tsx
+++ b/src/renderer/components/ui/TabBar.tsx
@@ -18,7 +18,7 @@ interface TabBarProps {
   activeSessionId:             string | null;
   onSelectSession:             (id: string) => void;
   onCloseSession:              (id: string) => void;
-  onCreateSession:             (name: string, workingDirectory: string, permissionMode: 'standard' | 'skip-permissions', worktree?: import('../../../shared/types/git-types').WorktreeCreateRequest, providerId?: import('../../../shared/types/provider-types').ProviderId) => void;
+  onCreateSession:             (name: string, workingDirectory: string, permissionMode: 'standard' | 'skip-permissions', worktree?: import('../../../shared/types/git-types').WorktreeCreateRequest, providerId?: import('../../../shared/types/provider-types').ProviderId, launchMode?: import('../../../shared/ipc-types').LaunchMode) => void;
   onRenameSession:             (id: string, name: string) => void;
   onRestartSession:            (id: string) => void;
   onDuplicateSession:          (id: string) => void;

--- a/src/renderer/hooks/useSessionManager.test.ts
+++ b/src/renderer/hooks/useSessionManager.test.ts
@@ -50,6 +50,33 @@ describe('useSessionManager', () => {
     });
   });
 
+  it('createSession forwards launchMode to electronAPI.createSession', async () => {
+    // Regression test for the renderer wiring of launchMode. The
+    // NewSessionDialog → onSubmit → onCreateSession → handleCreateSession →
+    // useSessionManager.createSession → IPC body chain has historically dropped
+    // `launchMode` at the renderer boundary even after SessionManager (main)
+    // was patched to read it. This test asserts the IPC body actually carries
+    // the field, locking the full chain in place.
+    api.listSessions.mockResolvedValue({ sessions: [], activeSessionId: null });
+    api.createSession.mockResolvedValue({ id: 's-new', name: 'New', workingDirectory: '/test', permissionMode: 'standard', status: 'running', createdAt: Date.now() });
+    api.getSettings.mockResolvedValue({ version: 1, workspaces: [], defaultModel: 'sonnet' });
+
+    const { result } = renderHook(() => useSessionManager());
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    await act(async () => {
+      await result.current.createSession('Agents Session', '/test', 'standard', undefined, undefined, 'agents');
+    });
+
+    expect(api.createSession).toHaveBeenCalledWith(expect.objectContaining({
+      name: 'Agents Session',
+      workingDirectory: '/test',
+      permissionMode: 'standard',
+      model: 'sonnet',
+      launchMode: 'agents',
+    }));
+  });
+
   it('closeSession calls electronAPI.closeSession', async () => {
     api.listSessions.mockResolvedValue({
       sessions: [{ id: 's1', name: 'S1', workingDirectory: '/', permissionMode: 'standard', status: 'running', createdAt: Date.now() }],

--- a/src/renderer/hooks/useSessionManager.ts
+++ b/src/renderer/hooks/useSessionManager.ts
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
-import { SessionMetadata, SessionOutput, SessionExitEvent } from '../../shared/ipc-types';
+import { SessionMetadata, SessionOutput, SessionExitEvent, LaunchMode } from '../../shared/ipc-types';
 import type { ProviderId } from '../../shared/types/provider-types';
 import { TabData } from '../components/ui/Tab';
 
@@ -7,7 +7,7 @@ export interface UseSessionManagerReturn {
   sessions: TabData[];
   activeSessionId: string | null;
   isLoading: boolean;
-  createSession: (name: string, workingDirectory: string, permissionMode: 'standard' | 'skip-permissions', worktree?: import('../../shared/types/git-types').WorktreeCreateRequest, providerId?: ProviderId) => Promise<void>;
+  createSession: (name: string, workingDirectory: string, permissionMode: 'standard' | 'skip-permissions', worktree?: import('../../shared/types/git-types').WorktreeCreateRequest, providerId?: ProviderId, launchMode?: LaunchMode) => Promise<void>;
   closeSession: (sessionId: string) => Promise<void>;
   switchSession: (sessionId: string) => Promise<void>;
   renameSession: (sessionId: string, newName: string) => Promise<void>;
@@ -104,7 +104,8 @@ export function useSessionManager(): UseSessionManagerReturn {
     workingDirectory: string,
     permissionMode: 'standard' | 'skip-permissions',
     worktree?: import('../../shared/types/git-types').WorktreeCreateRequest,
-    providerId?: ProviderId
+    providerId?: ProviderId,
+    launchMode?: LaunchMode,
   ) => {
     try {
       // Read default model from settings
@@ -118,6 +119,7 @@ export function useSessionManager(): UseSessionManagerReturn {
         model: defaultModel,
         worktree,
         providerId,
+        launchMode,
       });
     } catch (err) {
       console.error('Failed to create session:', err);


### PR DESCRIPTION
## Summary

Fixes a v1.4.0 bug where the per-session launch mode picker had no effect on the spawned process. Selecting `claude agents` (or `claude` over the bypass default) in the dialog always produced `claude --dangerously-skip-permissions` because `launchMode` was silently dropped at three renderer function boundaries before reaching the IPC body.

## The chain that was broken

```
NewSessionDialog.onSubmit(..., launchMode)  ← passes 6 args
  → TabBar.onCreateSession                   ← prop typed as 5  ❌
  → App.handleCreateSession                  ← 5 params         ❌
  → useSessionManager.createSession          ← 5 params         ❌
  → window.electronAPI.createSession({...})  ← no launchMode key ❌
  → IPC body
  → SessionManager.createSession             ← reads but always gets undefined
  → ClaudeProvider.buildCommand              ← falls back to permissionMode
  → claude --dangerously-skip-permissions    ← always
```

JavaScript variadic args made every dropped 6th arg silent — no type error, no runtime warning. The previous ousterhout review (whole-feature design review on the original v1.4.0 PR) flagged the equivalent gap inside `SessionManager` (review F1, fixed in that PR's plan item #5) but stopped at the IPC boundary on the main side and never followed the renderer chain backward.

## Fix

Thread `launchMode?: LaunchMode` through all three renderer hops + the IPC body. The field stays optional so callers that don't pass it (quick-start shortcuts, duplicate-session) keep their legacy behavior driven by `permissionMode`.

## Regression test

New test in `useSessionManager.test.ts`:

```ts
it('createSession forwards launchMode to electronAPI.createSession', ...)
```

Asserts the IPC body actually contains `launchMode: 'agents'` when callers pass it. RED before the fix (the call body was missing the key); GREEN after.

This is the layer the previous testing strategy systematically missed — per-component tests verified the dialog's `onSubmit` shape; per-manager tests verified what `SessionManager` does with the field; nothing exercised the renderer chain end-to-end into the IPC mock.

## Test plan

- [x] `npx vitest run --pool=forks --config vitest.workspace.ts src/renderer/hooks/useSessionManager.test.ts` — 7/7 passing
- [x] `npx tsc --noEmit` (renderer+shared) — exit 0
- [x] `npx tsc -p tsconfig.main.json --noEmit` — exit 0
- [x] `npm run build:electron` — exit 0
- [x] `npm run build` — exit 0
- [x] `npm run test:ci` — 48 files / 788 tests passing
- [ ] Manual: pick `claude agents` in the picker → terminal launches `claude agents` (not `--dangerously-skip-permissions`)

## Release plan

After merge: tag **v1.4.1** patch release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
