### PR TITLE
fix: run in main checkout when picking the current branch in Existing…

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -8,7 +8,7 @@ import {
   RepoActivityBar, SessionRail, MainView, RepoSwitcher,
   AddRepoSheet, NewSessionSheet, Palette, RightInspector,
   TitleBar, StatusBar,
-  sessionsForRepo, liveCount,
+  sessionsForRepo, liveCount, resolveSessionWorktree,
   type ViewMode, type PaletteAction, type NewSessionForm,
 } from './components/shell';
 import type { ActiveSelection } from './components/shell/RepoActivityBar';
@@ -235,36 +235,19 @@ function App() {
     const repo = repos.find(r => r.id === form.repoId);
     if (!repo) throw new Error('Repository not found');
 
-    // Resolve the workingDirectory + worktree request per mode:
-    //   - new      → create a new branch (forked off baseBranch || HEAD) in its own worktree
-    //   - existing → check out an existing branch in a fresh worktree (or fall through to main if it's HEAD)
-    //   - share    → run directly in the donor session's workingDirectory (no worktree creation)
-    //   - current  → run directly in the main repo checkout
-    let worktree:
-      | { mainRepoPath: string; branch: string; isNewBranch: boolean; baseBranch?: string }
-      | undefined;
-    let cwd = repo.path;
-
-    if (form.worktreeMode === 'new' && form.branch) {
-      worktree = {
-        mainRepoPath: repo.path,
-        branch: form.branch,
-        isNewBranch: true,
-        baseBranch: form.baseBranch || undefined,
-      };
-    } else if (form.worktreeMode === 'existing' && form.branch) {
-      worktree = {
-        mainRepoPath: repo.path,
-        branch: form.branch,
-        isNewBranch: false,
-      };
-    } else if (form.worktreeMode === 'share' && form.shareSessionId) {
+    // Resolve the workingDirectory + worktree request per mode (see
+    // resolveSessionWorktree). Share mode needs the donor session's cwd, so
+    // look that up here before delegating the decision.
+    let shareWorkingDirectory: string | undefined;
+    if (form.worktreeMode === 'share' && form.shareSessionId) {
       const donor = sessions.find(s => s.id === form.shareSessionId);
       if (!donor || !donor.workingDirectory) {
         throw new Error("Couldn't find the session you're sharing with.");
       }
-      cwd = donor.workingDirectory;
+      shareWorkingDirectory = donor.workingDirectory;
     }
+
+    const { cwd, worktree } = resolveSessionWorktree(form, repo, shareWorkingDirectory);
 
     const start = async (override?: { isNewBranch: boolean } | null): Promise<void> => {
       const wt = worktree && override !== null

--- a/src/renderer/components/shell/index.ts
+++ b/src/renderer/components/shell/index.ts
@@ -2,8 +2,8 @@
 export { P4Icon, type P4IconName } from './P4Icon';
 export {
   colorBg, colorFg, initials, agentLetter, agentColor,
-  STATUS_META, colorFromString, formatLastActive,
-  type RepoColor, type SessionStatus, type StatusMeta,
+  STATUS_META, colorFromString, formatLastActive, resolveSessionWorktree,
+  type RepoColor, type SessionStatus, type StatusMeta, type WorktreeRequest,
 } from './shell-utils';
 
 export { RepoActivityBar, isPathPrefix } from './RepoActivityBar';

--- a/src/renderer/components/shell/shell-utils.test.ts
+++ b/src/renderer/components/shell/shell-utils.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest';
+import { resolveSessionWorktree } from './shell-utils';
+
+describe('resolveSessionWorktree', () => {
+  const repo = { path: 'C:/repos/omnidesk', branch: 'main' };
+
+  it('new mode creates a new-branch worktree forked off baseBranch', () => {
+    const r = resolveSessionWorktree(
+      { worktreeMode: 'new', branch: 'feat/x', baseBranch: 'develop' },
+      repo,
+    );
+    expect(r.cwd).toBe(repo.path);
+    expect(r.worktree).toEqual({
+      mainRepoPath: repo.path,
+      branch: 'feat/x',
+      isNewBranch: true,
+      baseBranch: 'develop',
+    });
+  });
+
+  it('existing mode on a DIFFERENT branch creates a worktree', () => {
+    const r = resolveSessionWorktree(
+      { worktreeMode: 'existing', branch: 'feature-a' },
+      repo,
+    );
+    expect(r.cwd).toBe(repo.path);
+    expect(r.worktree).toEqual({
+      mainRepoPath: repo.path,
+      branch: 'feature-a',
+      isNewBranch: false,
+    });
+  });
+
+  // Regression: picking the repo's CURRENT branch in "Existing" mode must not
+  // request a worktree — git forbids a second worktree on the checked-out
+  // branch ("'main' is already used by worktree at ..."). Run in main instead.
+  it('existing mode on the CURRENT branch runs in the main checkout, no worktree', () => {
+    const r = resolveSessionWorktree(
+      { worktreeMode: 'existing', branch: 'main' },
+      repo,
+    );
+    expect(r.cwd).toBe(repo.path);
+    expect(r.worktree).toBeUndefined();
+  });
+
+  it('share mode runs in the donor working directory', () => {
+    const r = resolveSessionWorktree(
+      { worktreeMode: 'share' },
+      repo,
+      'C:/repos/omnidesk-worktrees/feature-a',
+    );
+    expect(r.cwd).toBe('C:/repos/omnidesk-worktrees/feature-a');
+    expect(r.worktree).toBeUndefined();
+  });
+
+  it('current mode runs in the main checkout, no worktree', () => {
+    const r = resolveSessionWorktree({ worktreeMode: 'current' }, repo);
+    expect(r.cwd).toBe(repo.path);
+    expect(r.worktree).toBeUndefined();
+  });
+});

--- a/src/renderer/components/shell/shell-utils.ts
+++ b/src/renderer/components/shell/shell-utils.ts
@@ -79,6 +79,66 @@ export const colorFromString = (input: string): RepoColor => {
   return palette[Math.abs(hash) % palette.length];
 };
 
+/** Worktree creation request handed to the main process for a new session. */
+export interface WorktreeRequest {
+  mainRepoPath: string;
+  branch: string;
+  isNewBranch: boolean;
+  baseBranch?: string;
+}
+
+/** Resolve the working directory + worktree request for a new session.
+ *
+ *  Existing mode on the repo's CURRENT branch must NOT create a worktree: git
+ *  forbids a second worktree on an already-checked-out branch (it fails with
+ *  "'<branch>' is already used by worktree at ..."), and a separate worktree
+ *  would be pointless anyway. Run in the main checkout instead — exactly what
+ *  the New Session sheet previews for this case. */
+export function resolveSessionWorktree(
+  form: {
+    worktreeMode: 'new' | 'existing' | 'share' | 'current';
+    branch?: string;
+    baseBranch?: string;
+  },
+  repo: { path: string; branch?: string },
+  shareWorkingDirectory?: string | null,
+): { cwd: string; worktree?: WorktreeRequest } {
+  const mainRepoPath = repo.path;
+
+  switch (form.worktreeMode) {
+    case 'new':
+      if (form.branch) {
+        return {
+          cwd: mainRepoPath,
+          worktree: {
+            mainRepoPath,
+            branch: form.branch,
+            isNewBranch: true,
+            baseBranch: form.baseBranch || undefined,
+          },
+        };
+      }
+      return { cwd: mainRepoPath };
+
+    case 'existing':
+      if (form.branch && form.branch !== repo.branch) {
+        return {
+          cwd: mainRepoPath,
+          worktree: { mainRepoPath, branch: form.branch, isNewBranch: false },
+        };
+      }
+      // Current branch (or none picked) → run in the main checkout, no worktree.
+      return { cwd: mainRepoPath };
+
+    case 'share':
+      return { cwd: shareWorkingDirectory || mainRepoPath };
+
+    case 'current':
+    default:
+      return { cwd: mainRepoPath };
+  }
+}
+
 /** Format a Date or epoch ms as "Nh ago", "Nd ago", etc. — used in rail meta. */
 export const formatLastActive = (date: Date | number | undefined): string => {
   if (!date) return '—';


### PR DESCRIPTION
… mode

Picking the repo's current branch in the New Session sheet's "Existing" worktree mode requested a second worktree on the already-checked-out branch, which git forbids ("'<branch>' is already used by worktree at ...'"). The dialog already previewed the main checkout for this case, so the backend contradicted what the UI promised.

Extract the worktree decision into a pure resolveSessionWorktree helper: Existing mode now creates a worktree only when the chosen branch differs from repo.branch; the current branch (or none picked) runs in the main checkout with no worktree. Add regression tests covering all four worktree modes.