### PR TITLE
feat(terminal): Kitty keyboard protocol support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,13 +10,13 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
+        "@xterm/addon-fit": "^0.10.0",
+        "@xterm/addon-web-links": "^0.11.0",
+        "@xterm/xterm": "^5.5.0",
         "electron-updater": "^6.8.3",
         "lucide-react": "^0.563.0",
         "node-pty": "^1.2.0-beta.11",
-        "uuid": "^9.0.0",
-        "xterm": "^5.3.0",
-        "xterm-addon-fit": "^0.8.0",
-        "xterm-addon-web-links": "^0.9.0"
+        "uuid": "^9.0.0"
       },
       "devDependencies": {
         "@playwright/test": "^1.58.2",
@@ -2965,6 +2965,30 @@
       "engines": {
         "node": ">=10.0.0"
       }
+    },
+    "node_modules/@xterm/addon-fit": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@xterm/addon-fit/-/addon-fit-0.10.0.tgz",
+      "integrity": "sha512-UFYkDm4HUahf2lnEyHvio51TNGiLK66mqP2JoATy7hRZeXaGMRDr00JiSF7m63vR5WKATF605yEggJKsw0JpMQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@xterm/xterm": "^5.0.0"
+      }
+    },
+    "node_modules/@xterm/addon-web-links": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@xterm/addon-web-links/-/addon-web-links-0.11.0.tgz",
+      "integrity": "sha512-nIHQ38pQI+a5kXnRaTgwqSHnX7KE6+4SVoceompgHL26unAxdfP6IPqUTSYPQgSwM56hsElfoNrrW5V7BUED/Q==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@xterm/xterm": "^5.0.0"
+      }
+    },
+    "node_modules/@xterm/xterm": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/@xterm/xterm/-/xterm-5.5.0.tgz",
+      "integrity": "sha512-hqJHYaQb5OptNunnyAnkHyM8aCjZ1MEIDTQu1iIbbTD/xops91NB5yq1ZK/dC2JDbVWtF23zUtl9JE2NqwT87A==",
+      "license": "MIT"
     },
     "node_modules/7zip-bin": {
       "version": "5.2.0",
@@ -9415,33 +9439,6 @@
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/xterm": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/xterm/-/xterm-5.3.0.tgz",
-      "integrity": "sha512-8QqjlekLUFTrU6x7xck1MsPzPA571K5zNqWm0M0oroYEWVOptZ0+ubQSkQ3uxIEhcIHRujJy6emDWX4A7qyFzg==",
-      "deprecated": "This package is now deprecated. Move to @xterm/xterm instead.",
-      "license": "MIT"
-    },
-    "node_modules/xterm-addon-fit": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/xterm-addon-fit/-/xterm-addon-fit-0.8.0.tgz",
-      "integrity": "sha512-yj3Np7XlvxxhYF/EJ7p3KHaMt6OdwQ+HDu573Vx1lRXsVxOcnVJs51RgjZOouIZOczTsskaS+CpXspK81/DLqw==",
-      "deprecated": "This package is now deprecated. Move to @xterm/addon-fit instead.",
-      "license": "MIT",
-      "peerDependencies": {
-        "xterm": "^5.0.0"
-      }
-    },
-    "node_modules/xterm-addon-web-links": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/xterm-addon-web-links/-/xterm-addon-web-links-0.9.0.tgz",
-      "integrity": "sha512-LIzi4jBbPlrKMZF3ihoyqayWyTXAwGfu4yprz1aK2p71e9UKXN6RRzVONR0L+Zd+Ik5tPVI9bwp9e8fDTQh49Q==",
-      "deprecated": "This package is now deprecated. Move to @xterm/addon-web-links instead.",
-      "license": "MIT",
-      "peerDependencies": {
-        "xterm": "^5.0.0"
-      }
     },
     "node_modules/y18n": {
       "version": "5.0.8",

--- a/package.json
+++ b/package.json
@@ -32,9 +32,9 @@
     "lucide-react": "^0.563.0",
     "node-pty": "^1.2.0-beta.11",
     "uuid": "^9.0.0",
-    "xterm": "^5.3.0",
-    "xterm-addon-fit": "^0.8.0",
-    "xterm-addon-web-links": "^0.9.0"
+    "@xterm/xterm": "^5.5.0",
+    "@xterm/addon-fit": "^0.10.0",
+    "@xterm/addon-web-links": "^0.11.0"
   },
   "devDependencies": {
     "@playwright/test": "^1.58.2",

--- a/src/renderer/components/Terminal.tsx
+++ b/src/renderer/components/Terminal.tsx
@@ -434,7 +434,14 @@ export function Terminal({ sessionId, isVisible, isFocused, providerId, readOnly
       initializedRef.current = false;
     };
     // Use stable deps only — handleResize is accessed via ref to avoid
-    // re-running the entire init effect on visibility changes
+    // re-running the entire init effect on visibility changes.
+    // `getKittyFlags` and `readOnly` are read inside the handler closures but
+    // intentionally omitted from deps: getKittyFlags reads LIVE state via the
+    // stable kittyStateRef, and readOnly is effectively constant per mounted
+    // session in the current shell (observer mode is dormant — SingleTerminalSlot
+    // never passes readOnlySessionIds, so every Terminal mounts readOnly=false).
+    // If observer↔host control transfer is ever wired without a remount, switch
+    // readOnly to a ref (mirror handleResizeRef) so the handlers read it live.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [sessionId, onInput, onReady]);
 

--- a/src/renderer/components/Terminal.tsx
+++ b/src/renderer/components/Terminal.tsx
@@ -1,13 +1,13 @@
 import { useEffect, useRef, useCallback, useState } from 'react';
-import { Terminal as XTerm } from 'xterm';
-import { FitAddon } from 'xterm-addon-fit';
-import { WebLinksAddon } from 'xterm-addon-web-links';
+import { Terminal as XTerm } from '@xterm/xterm';
+import { FitAddon } from '@xterm/addon-fit';
+import { WebLinksAddon } from '@xterm/addon-web-links';
 import { ConfirmDialog } from './ui/ConfirmDialog';
 import { ClaudeReadinessProgress } from './ui/ClaudeReadinessProgress';
 import { FileInfo, DragDropSettings, DragDropInsertMode, PathFormat } from '../../shared/ipc-types';
 import type { ProviderId } from '../../shared/types/provider-types';
 import { isClaudeReady as checkClaudeReadyPatterns, findClaudeOutputStart } from '../../shared/claude-detector';
-import 'xterm/css/xterm.css';
+import '@xterm/xterm/css/xterm.css';
 
 // Utility function to format paths for terminal (renderer-side implementation)
 function formatPathForTerminal(filePath: string, format: PathFormat): string {

--- a/src/renderer/components/Terminal.tsx
+++ b/src/renderer/components/Terminal.tsx
@@ -7,6 +7,7 @@ import { ClaudeReadinessProgress } from './ui/ClaudeReadinessProgress';
 import { FileInfo, DragDropSettings, DragDropInsertMode, PathFormat } from '../../shared/ipc-types';
 import type { ProviderId } from '../../shared/types/provider-types';
 import { isClaudeReady as checkClaudeReadyPatterns, findClaudeOutputStart } from '../../shared/claude-detector';
+import { KittyKeyboardState } from '../terminal/kitty-keyboard';
 import '@xterm/xterm/css/xterm.css';
 
 // Utility function to format paths for terminal (renderer-side implementation)
@@ -571,10 +572,19 @@ export function MultiTerminal({
   const isReadyRef = useRef<Map<string, boolean>>(new Map());
   // Buffer for output that arrives before the terminal xterm instance is registered
   const pendingOutputRef = useRef<Map<string, string[]>>(new Map());
+  const kittyStateRef = useRef<Map<string, KittyKeyboardState>>(new Map());
 
   // Set up output listener
   useEffect(() => {
     const cleanup = onOutput((sessionId: string, data: string) => {
+      // Kitty keyboard protocol: track flags + answer the capability query.
+      let kitty = kittyStateRef.current.get(sessionId);
+      if (!kitty) { kitty = new KittyKeyboardState(); kittyStateRef.current.set(sessionId, kitty); }
+      const reply = kitty.processOutput(data);
+      if (reply && !readOnlySessionIds.includes(sessionId)) {
+        onInput(sessionId, reply);
+      }
+
       const terminal = terminalsRef.current.get(sessionId);
       if (!terminal) {
         // Terminal not yet registered — buffer the output for later
@@ -652,7 +662,7 @@ export function MultiTerminal({
     });
 
     return cleanup;
-  }, [onOutput]);
+  }, [onOutput, onInput, readOnlySessionIds]);
 
   const handleReady = useCallback((sessionId: string, terminal: XTerm, checkClaudeReady: (data: string) => void) => {
     terminalsRef.current.set(sessionId, terminal);
@@ -722,6 +732,7 @@ export function MultiTerminal({
         outputBuffersRef.current.delete(id);
         isReadyRef.current.delete(id);
         pendingOutputRef.current.delete(id);
+        kittyStateRef.current.delete(id);
       }
     }
   }, [sessionIds]);
@@ -743,6 +754,7 @@ export function MultiTerminal({
           onInput={onInput}
           onResize={onResize}
           onReady={handleReady}
+          getKittyFlags={() => kittyStateRef.current.get(sessionId)?.flags ?? 0}
         />
       ))}
 

--- a/src/renderer/components/Terminal.tsx
+++ b/src/renderer/components/Terminal.tsx
@@ -7,7 +7,7 @@ import { ClaudeReadinessProgress } from './ui/ClaudeReadinessProgress';
 import { FileInfo, DragDropSettings, DragDropInsertMode, PathFormat } from '../../shared/ipc-types';
 import type { ProviderId } from '../../shared/types/provider-types';
 import { isClaudeReady as checkClaudeReadyPatterns, findClaudeOutputStart } from '../../shared/claude-detector';
-import { KittyKeyboardState } from '../terminal/kitty-keyboard';
+import { KittyKeyboardState, encodeKittyKey } from '../terminal/kitty-keyboard';
 import '@xterm/xterm/css/xterm.css';
 
 // Utility function to format paths for terminal (renderer-side implementation)
@@ -52,6 +52,7 @@ interface TerminalProps {
   isFocused: boolean; // Terminal has keyboard focus
   providerId?: ProviderId; // For provider-aware loading overlay copy
   readOnly?: boolean;  // Observer mode: disables input forwarding, shows overlay
+  getKittyFlags?: () => number;
   onInput: (sessionId: string, data: string) => void;
   onResize: (sessionId: string, cols: number, rows: number) => void;
   onReady: (sessionId: string, terminal: XTerm, checkClaudeReady: (data: string) => void) => void;
@@ -63,7 +64,7 @@ function providerIdToName(providerId?: ProviderId): string | undefined {
   return undefined;
 }
 
-export function Terminal({ sessionId, isVisible, isFocused, providerId, readOnly = false, onInput, onResize, onReady }: TerminalProps) {
+export function Terminal({ sessionId, isVisible, isFocused, providerId, readOnly = false, getKittyFlags, onInput, onResize, onReady }: TerminalProps) {
   const terminalRef = useRef<HTMLDivElement>(null);
   const xtermRef = useRef<XTerm | null>(null);
   const fitAddonRef = useRef<FitAddon | null>(null);
@@ -363,56 +364,53 @@ export function Terminal({ sessionId, isVisible, isFocused, providerId, readOnly
     // Allow browser-native paste (Ctrl+V / Cmd+V / Shift+Insert) and app shortcuts
     // Without this, xterm.js consumes these keys instead of letting the app handle them
     xterm.attachCustomKeyEventHandler((e) => {
+      const flags = getKittyFlags?.() ?? 0;
+
+      // Kitty keyboard protocol active: encode and send directly, bypass xterm.
+      if (flags !== 0 && !readOnly) {
+        const encoded = encodeKittyKey(e, flags);
+        if (encoded !== null) {
+          e.preventDefault();
+          onInput(sessionId, encoded);
+          return false;
+        }
+        // encoded === null -> fall through to legacy handling below.
+      }
+
       if (e.type === 'keydown') {
         const isPaste = (e.ctrlKey || e.metaKey) && e.key === 'v';
         const isShiftInsert = e.shiftKey && e.key === 'Insert';
-
-        // Allow Ctrl+Shift+M (model cycling) to pass through to app
         const isModelCycle = (e.ctrlKey || e.metaKey) && e.shiftKey && e.key === 'M';
 
-        // Ctrl+Shift+C: copy selected text from terminal
         const isCopy = (e.ctrlKey || e.metaKey) && e.shiftKey && e.key === 'C';
         if (isCopy) {
           const selection = xterm.getSelection();
-          if (selection) {
-            navigator.clipboard.writeText(selection);
-          }
+          if (selection) navigator.clipboard.writeText(selection);
           return false;
         }
 
-        // Newline insertion: Ctrl+Enter, Shift+Enter, Alt+Enter, Cmd+Enter
+        // Newline insertion (legacy renderer only — Kitty path handled above).
         if (e.key === 'Enter' && (e.ctrlKey || e.shiftKey || e.altKey || e.metaKey)) {
           e.preventDefault();
-          if (!readOnly) {
-            onInput(sessionId, '\n');
-          }
+          if (!readOnly) onInput(sessionId, '\n');
           return false;
         }
 
-        if (isPaste || isShiftInsert || isModelCycle) {
-          return false; // Let browser/app handle → our window event listener picks it up
-        }
+        if (isPaste || isShiftInsert || isModelCycle) return false;
       }
       return true;
     });
 
     // Handle terminal input
     xterm.onData((data) => {
-      // CRITICAL: Always intercept Ctrl+C — even in read-only/observer mode.
-      // Never forward \x03 to the PTY (it exits Claude immediately).
-      if (data === '\x03') {
-        if (!readOnly) {
-          // Host: show close confirm dialog
-          setShowCloseConfirm(true);
-        }
-        // Observer: silently swallow — do NOT forward to PTY
+      const flags = getKittyFlags?.() ?? 0;
+      // Legacy-mode Ctrl+C guard only. Under Kitty flags, Ctrl+C is CSI 99;5u
+      // already sent by the key handler and must not trigger the close dialog.
+      if (data === '\x03' && flags === 0) {
+        if (!readOnly) setShowCloseConfirm(true);
         return;
       }
-
-      // In read-only mode, discard all other input (observer watching only)
       if (readOnly) return;
-
-      // Normal input handling
       onInput(sessionId, data);
     });
 

--- a/src/renderer/terminal/kitty-keyboard.test.ts
+++ b/src/renderer/terminal/kitty-keyboard.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from 'vitest';
+import { KittyKeyboardState } from './kitty-keyboard';
+
+describe('KittyKeyboardState', () => {
+  it('starts with no flags', () => {
+    expect(new KittyKeyboardState().flags).toBe(0);
+  });
+
+  it('push (CSI > flags u) sets active flags', () => {
+    const s = new KittyKeyboardState();
+    expect(s.processOutput('\x1b[>1u')).toBe('');
+    expect(s.flags).toBe(1);
+  });
+
+  it('set (CSI = flags ; mode u), mode 1 replaces', () => {
+    const s = new KittyKeyboardState();
+    s.processOutput('\x1b[>1u');
+    s.processOutput('\x1b[=5;1u');
+    expect(s.flags).toBe(5);
+  });
+
+  it('set mode 2 ORs bits, mode 3 clears bits', () => {
+    const s = new KittyKeyboardState();
+    s.processOutput('\x1b[>1u');     // 1
+    s.processOutput('\x1b[=4;2u');   // OR 4 -> 5
+    expect(s.flags).toBe(5);
+    s.processOutput('\x1b[=1;3u');   // clear 1 -> 4
+    expect(s.flags).toBe(4);
+  });
+
+  it('pop (CSI < u) restores the previous pushed entry', () => {
+    const s = new KittyKeyboardState();
+    s.processOutput('\x1b[>1u');
+    s.processOutput('\x1b[>8u');
+    expect(s.flags).toBe(8);
+    s.processOutput('\x1b[<u');
+    expect(s.flags).toBe(1);
+  });
+
+  it('query (CSI ? u) returns CSI ? <flags> u for the current flags', () => {
+    const s = new KittyKeyboardState();
+    expect(s.processOutput('\x1b[?u')).toBe('\x1b[?0u');
+    s.processOutput('\x1b[>9u');
+    expect(s.processOutput('\x1b[?u')).toBe('\x1b[?9u');
+  });
+
+  it('main and alternate screens keep separate stacks', () => {
+    const s = new KittyKeyboardState();
+    s.processOutput('\x1b[>1u');        // main flags = 1
+    s.processOutput('\x1b[?1049h');     // enter alt screen
+    expect(s.flags).toBe(0);            // alt stack empty
+    s.processOutput('\x1b[>8u');        // alt flags = 8
+    expect(s.flags).toBe(8);
+    s.processOutput('\x1b[?1049l');     // leave alt screen
+    expect(s.flags).toBe(1);            // main stack restored
+  });
+
+  it('reassembles sequences split across chunks', () => {
+    const s = new KittyKeyboardState();
+    expect(s.processOutput('\x1b[>')).toBe('');
+    s.processOutput('1u');
+    expect(s.flags).toBe(1);
+  });
+
+  it('ignores unrelated output and passes it by without effect', () => {
+    const s = new KittyKeyboardState();
+    s.processOutput('hello \x1b[31mworld\x1b[0m\r\n');
+    expect(s.flags).toBe(0);
+  });
+
+  it('reset() clears both stacks and screen state', () => {
+    const s = new KittyKeyboardState();
+    s.processOutput('\x1b[>9u');
+    s.reset();
+    expect(s.flags).toBe(0);
+  });
+});

--- a/src/renderer/terminal/kitty-keyboard.test.ts
+++ b/src/renderer/terminal/kitty-keyboard.test.ts
@@ -74,6 +74,14 @@ describe('KittyKeyboardState', () => {
     s.reset();
     expect(s.flags).toBe(0);
   });
+
+  it('caps the carry buffer against a pathological unterminated CSI and still recovers', () => {
+    const s = new KittyKeyboardState();
+    s.processOutput('\x1b[>' + '1'.repeat(5000)); // no final byte — must not grow carry without bound
+    // A subsequent well-formed sequence is still parsed correctly:
+    expect(s.processOutput('\x1b[>1u')).toBe('');
+    expect(s.flags).toBe(1);
+  });
 });
 
 // Minimal KeyboardEvent-like stub (jsdom provides KeyboardEvent, but we set .code too).

--- a/src/renderer/terminal/kitty-keyboard.test.ts
+++ b/src/renderer/terminal/kitty-keyboard.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { KittyKeyboardState } from './kitty-keyboard';
+import { KittyKeyboardState, encodeKittyKey, KITTY_DISAMBIGUATE, KITTY_REPORT_EVENTS, KITTY_REPORT_ALL_KEYS } from './kitty-keyboard';
 
 describe('KittyKeyboardState', () => {
   it('starts with no flags', () => {
@@ -73,5 +73,76 @@ describe('KittyKeyboardState', () => {
     s.processOutput('\x1b[>9u');
     s.reset();
     expect(s.flags).toBe(0);
+  });
+});
+
+// Minimal KeyboardEvent-like stub (jsdom provides KeyboardEvent, but we set .code too).
+function key(init: Partial<KeyboardEvent> & { code?: string }): KeyboardEvent {
+  return { type: 'keydown', key: '', code: '', ctrlKey: false, shiftKey: false,
+           altKey: false, metaKey: false, ...init } as KeyboardEvent;
+}
+
+describe('encodeKittyKey', () => {
+  it('returns null when no flags are active', () => {
+    expect(encodeKittyKey(key({ key: 'a', code: 'KeyA' }), 0)).toBeNull();
+  });
+
+  it('disambiguate: plain text key passes through to xterm', () => {
+    expect(encodeKittyKey(key({ key: 'a', code: 'KeyA' }), KITTY_DISAMBIGUATE)).toBeNull();
+  });
+
+  it('disambiguate: Ctrl+C -> CSI 99 ; 5 u', () => {
+    expect(encodeKittyKey(key({ key: 'c', code: 'KeyC', ctrlKey: true }), KITTY_DISAMBIGUATE))
+      .toBe('\x1b[99;5u');
+  });
+
+  it('disambiguate: Escape -> CSI 27 u', () => {
+    expect(encodeKittyKey(key({ key: 'Escape', code: 'Escape' }), KITTY_DISAMBIGUATE))
+      .toBe('\x1b[27u');
+  });
+
+  it('disambiguate: Alt+a -> CSI 97 ; 3 u', () => {
+    expect(encodeKittyKey(key({ key: 'a', code: 'KeyA', altKey: true }), KITTY_DISAMBIGUATE))
+      .toBe('\x1b[97;3u');
+  });
+
+  it('disambiguate: Enter/Tab/Backspace pass through', () => {
+    const f = KITTY_DISAMBIGUATE;
+    expect(encodeKittyKey(key({ key: 'Enter', code: 'Enter' }), f)).toBeNull();
+    expect(encodeKittyKey(key({ key: 'Tab', code: 'Tab' }), f)).toBeNull();
+    expect(encodeKittyKey(key({ key: 'Backspace', code: 'Backspace' }), f)).toBeNull();
+  });
+
+  it('disambiguate: arrows pass through to xterm', () => {
+    expect(encodeKittyKey(key({ key: 'ArrowUp', code: 'ArrowUp' }), KITTY_DISAMBIGUATE)).toBeNull();
+  });
+
+  it('report-all-keys: plain a -> CSI 97 u', () => {
+    expect(encodeKittyKey(key({ key: 'a', code: 'KeyA' }), KITTY_DISAMBIGUATE | KITTY_REPORT_ALL_KEYS))
+      .toBe('\x1b[97u');
+  });
+
+  it('report-all-keys: Enter -> CSI 13 u', () => {
+    expect(encodeKittyKey(key({ key: 'Enter', code: 'Enter' }), KITTY_DISAMBIGUATE | KITTY_REPORT_ALL_KEYS))
+      .toBe('\x1b[13u');
+  });
+
+  it('uses the UNSHIFTED codepoint: Shift+a -> CSI 97 ; 2 u (report-all)', () => {
+    expect(encodeKittyKey(
+      key({ key: 'A', code: 'KeyA', shiftKey: true }),
+      KITTY_DISAMBIGUATE | KITTY_REPORT_ALL_KEYS,
+    )).toBe('\x1b[97;2u');
+  });
+
+  it('release events only when report-events flag set', () => {
+    const up = key({ type: 'keyup', key: 'a', code: 'KeyA' });
+    expect(encodeKittyKey(up, KITTY_DISAMBIGUATE | KITTY_REPORT_ALL_KEYS)).toBeNull();
+    expect(encodeKittyKey(up, KITTY_DISAMBIGUATE | KITTY_REPORT_ALL_KEYS | KITTY_REPORT_EVENTS))
+      .toBe('\x1b[97;1:3u');
+  });
+
+  it('bare modifier keys are not encoded (v1 passthrough)', () => {
+    expect(encodeKittyKey(key({ key: 'Shift', code: 'ShiftLeft', shiftKey: true }),
+      KITTY_DISAMBIGUATE | KITTY_REPORT_ALL_KEYS)).toBeNull();
   });
 });

--- a/src/renderer/terminal/kitty-keyboard.ts
+++ b/src/renderer/terminal/kitty-keyboard.ts
@@ -5,6 +5,7 @@ export const KITTY_REPORT_ALL_KEYS = 8;
 export const KITTY_REPORT_TEXT = 16;
 
 const MAX_STACK = 16; // cap stack size (spec: cap to avoid DoS)
+const MAX_CARRY = 4096; // drop a pathologically long unterminated CSI to bound memory
 
 // Matches a complete CSI sequence: ESC [ <private> <params> <final>.
 // Private marker is one of < > = ? (optional); params are digits ; :; final is a letter or ~.
@@ -45,7 +46,10 @@ export class KittyKeyboardState {
     // Hold any trailing incomplete escape (ESC, ESC[, or ESC[<params> with no final byte).
     const tail = buf.slice(lastEnd);
     const partial = /\x1b\[?[<>=?]?[0-9;:]*$/.exec(tail);
-    this.carry = partial ? partial[0] : (tail.endsWith('\x1b') ? '\x1b' : '');
+    this.carry = partial ? partial[0] : '';
+    // A real protocol sequence is short; a multi-KB unterminated CSI is garbage —
+    // drop it so a hostile/garbled stream can't grow carry without bound.
+    if (this.carry.length > MAX_CARRY) this.carry = '';
     return response;
   }
 

--- a/src/renderer/terminal/kitty-keyboard.ts
+++ b/src/renderer/terminal/kitty-keyboard.ts
@@ -1,0 +1,97 @@
+export const KITTY_DISAMBIGUATE = 1;
+export const KITTY_REPORT_EVENTS = 2;
+export const KITTY_REPORT_ALTERNATE = 4;
+export const KITTY_REPORT_ALL_KEYS = 8;
+export const KITTY_REPORT_TEXT = 16;
+
+const MAX_STACK = 16; // cap stack size (spec: cap to avoid DoS)
+
+// Matches a complete CSI sequence: ESC [ <private> <params> <final>.
+// Private marker is one of < > = ? (optional); params are digits ; :; final is a letter or ~.
+const CSI_RE = /\x1b\[([<>=?]?)([0-9;:]*)([A-Za-z~])/g;
+
+export class KittyKeyboardState {
+  private mainStack: number[] = [];
+  private altStack: number[] = [];
+  private onAltScreen = false;
+  private carry = ''; // trailing partial escape sequence held across chunks
+
+  get flags(): number {
+    const stack = this.onAltScreen ? this.altStack : this.mainStack;
+    return stack.length ? stack[stack.length - 1] : 0;
+  }
+
+  reset(): void {
+    this.mainStack = [];
+    this.altStack = [];
+    this.onAltScreen = false;
+    this.carry = '';
+  }
+
+  /** Consume one PTY output chunk; return bytes to send back to the PTY (query reply) or ''. */
+  processOutput(data: string): string {
+    const buf = this.carry + data;
+    let response = '';
+    let lastEnd = 0;
+
+    CSI_RE.lastIndex = 0;
+    let m: RegExpExecArray | null;
+    while ((m = CSI_RE.exec(buf)) !== null) {
+      const [seq, priv, params, final] = m;
+      lastEnd = m.index + seq.length;
+      response += this.dispatch(priv, params, final);
+    }
+
+    // Hold any trailing incomplete escape (ESC, ESC[, or ESC[<params> with no final byte).
+    const tail = buf.slice(lastEnd);
+    const partial = /\x1b\[?[<>=?]?[0-9;:]*$/.exec(tail);
+    this.carry = partial ? partial[0] : (tail.endsWith('\x1b') ? '\x1b' : '');
+    return response;
+  }
+
+  private dispatch(priv: string, params: string, final: string): string {
+    const stack = this.onAltScreen ? this.altStack : this.mainStack;
+
+    // Alt-screen enter/leave: CSI ? 1049 h / l
+    if (priv === '?' && (final === 'h' || final === 'l') && params === '1049') {
+      this.onAltScreen = final === 'h';
+      return '';
+    }
+
+    if (final !== 'u') return ''; // not a keyboard-protocol sequence
+
+    const nums = params.split(/[;:]/).filter((p) => p !== '').map(Number);
+
+    if (priv === '>') {
+      // push: CSI > flags u (flags default 0)
+      const flags = nums.length ? nums[0] : 0;
+      stack.push(flags & 31);
+      if (stack.length > MAX_STACK) stack.shift();
+      return '';
+    }
+    if (priv === '<') {
+      // pop: CSI < number u (default 1)
+      const count = nums.length ? nums[0] : 1;
+      for (let i = 0; i < count && stack.length; i++) stack.pop();
+      return '';
+    }
+    if (priv === '=') {
+      // set: CSI = flags ; mode u (mode default 1)
+      const flags = (nums.length ? nums[0] : 0) & 31;
+      const mode = nums.length > 1 ? nums[1] : 1;
+      const cur = stack.length ? stack[stack.length - 1] : 0;
+      let next = cur;
+      if (mode === 1) next = flags;              // set given, reset others
+      else if (mode === 2) next = cur | flags;   // OR
+      else if (mode === 3) next = cur & ~flags;  // clear
+      if (stack.length) stack[stack.length - 1] = next;
+      else stack.push(next);
+      return '';
+    }
+    if (priv === '?') {
+      // query: CSI ? u -> reply CSI ? <flags> u
+      return `\x1b[?${this.flags}u`;
+    }
+    return '';
+  }
+}

--- a/src/renderer/terminal/kitty-keyboard.ts
+++ b/src/renderer/terminal/kitty-keyboard.ts
@@ -95,3 +95,85 @@ export class KittyKeyboardState {
     return '';
   }
 }
+
+const NAMED_CODEPOINTS: Record<string, number> = {
+  Escape: 27, Enter: 13, Tab: 9, Backspace: 127,
+};
+
+// Keys xterm.js already emits as correct legacy CSI sequences in every mode.
+const XTERM_NATIVE_KEYS = new Set<string>([
+  'ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight',
+  'Home', 'End', 'PageUp', 'PageDown', 'Insert', 'Delete',
+  'F1', 'F2', 'F3', 'F4', 'F5', 'F6', 'F7', 'F8', 'F9', 'F10', 'F11', 'F12',
+]);
+
+const BARE_MODIFIER_KEYS = new Set<string>([
+  'Shift', 'Control', 'Alt', 'Meta', 'CapsLock', 'NumLock',
+]);
+
+// US-layout map from physical key code to its UNSHIFTED character codepoint,
+// for punctuation whose .key changes with Shift. Letters/digits derived from .code.
+const CODE_TO_UNSHIFTED: Record<string, number> = {
+  Backquote: 96, Minus: 45, Equal: 61, BracketLeft: 91, BracketRight: 93,
+  Backslash: 92, Semicolon: 59, Quote: 39, Comma: 44, Period: 46, Slash: 47,
+  Space: 32,
+};
+
+function unshiftedCodepoint(e: KeyboardEvent): number | null {
+  if (/^Key[A-Z]$/.test(e.code)) return e.code.charCodeAt(3) + 32; // KeyA -> 'a'
+  if (/^Digit[0-9]$/.test(e.code)) return e.code.charCodeAt(5);    // Digit5 -> '5'
+  if (e.code in CODE_TO_UNSHIFTED) return CODE_TO_UNSHIFTED[e.code];
+  if (e.key.length === 1) return e.key.toLowerCase().codePointAt(0) ?? null; // fallback
+  return null;
+}
+
+function kittyModifierBits(e: KeyboardEvent): number {
+  let m = 0;
+  if (e.shiftKey) m |= 1;
+  if (e.altKey) m |= 2;
+  if (e.ctrlKey) m |= 4;
+  if (e.metaKey) m |= 8;
+  return m;
+}
+
+function buildCsiU(cp: number, modBits: number, isRelease: boolean, reportEvents: boolean): string {
+  const modField = modBits + 1;
+  const needEvent = reportEvents && isRelease;
+  let seq = `\x1b[${cp}`;
+  if (modField !== 1 || needEvent) {
+    seq += `;${modField}`;
+    if (needEvent) seq += ':3';
+  }
+  return seq + 'u';
+}
+
+/** Returns CSI-u bytes to send to the PTY, or null to let xterm emit its normal output. */
+export function encodeKittyKey(e: KeyboardEvent, flags: number): string | null {
+  if (flags === 0) return null;
+  const reportEvents = (flags & KITTY_REPORT_EVENTS) !== 0;
+  const reportAll = (flags & KITTY_REPORT_ALL_KEYS) !== 0;
+
+  const isRelease = e.type === 'keyup';
+  if (isRelease && !reportEvents) return null; // releases only when requested
+
+  if (BARE_MODIFIER_KEYS.has(e.key)) return null; // v1: don't encode modifier-only keys
+  if (XTERM_NATIVE_KEYS.has(e.key)) return null;  // xterm legacy CSI is already correct
+
+  const named = e.key in NAMED_CODEPOINTS;
+  const cp = named ? NAMED_CODEPOINTS[e.key] : unshiftedCodepoint(e);
+  if (cp === null) return null; // unknown special key — let xterm handle it
+
+  const modBits = kittyModifierBits(e);
+  const hasCtrlAltSuper = (modBits & (2 | 4 | 8)) !== 0;
+
+  if (!reportAll) {
+    // Escape is always disambiguated to CSI 27 u.
+    if (e.key === 'Escape') return buildCsiU(cp, modBits, isRelease, reportEvents);
+    // Enter/Tab/Backspace keep legacy bytes unless modified.
+    if (named && !hasCtrlAltSuper) return null;
+    // Plain/Shifted text keys keep legacy text; only Ctrl/Alt/Super combos are encoded.
+    if (!hasCtrlAltSuper) return null;
+  }
+
+  return buildCsiU(cp, modBits, isRelease, reportEvents);
+}


### PR DESCRIPTION
## Why

Claude Code's new fullscreen renderer drives keyboard input via the **Kitty keyboard protocol**, which xterm.js does not implement. Inside OmniDesk this caused keystrokes to be silently dropped after enabling the renderer — the terminal looked loaded but wouldn't accept typing.

Root cause and design rationale: `plans/fix-xterm-kitty-keyboard-input.findings.md`. Implementation plan: `plans/kitty-keyboard-protocol.plan.md`.

## What

A protocol shim around xterm.js (no fork, no new IPC, no main-process changes):

- **Upgrade** deprecated `xterm`/`xterm-addon-*` → maintained `@xterm/xterm` 5.5.
- **`src/renderer/terminal/kitty-keyboard.ts`** (new, pure, dependency-free):
  - `KittyKeyboardState` — parses the PTY output stream for the keyboard-flag control sequences (push/set/pop), maintains separate main/alt-screen flag stacks, and answers the `CSI ? u` capability query. Reassembles sequences split across output chunks; the carry buffer is capped against pathological unterminated CSIs.
  - `encodeKittyKey` — translates DOM key events into `CSI u` sequences when flags are active, using the unshifted codepoint and the spec's modifier/event-type encoding. Arrows/F-keys/navigation and (in non-report-all mode) plain text pass through to xterm's existing legacy output.
- **`Terminal.tsx`** — output tap parses flags + replies to the query via the existing `onInput → session:input` path; the key handler encodes via `encodeKittyKey` when flags are active and falls through to the existing handlers otherwise.

Legacy behavior is **byte-for-byte unchanged when no Kitty flags are active**: Ctrl+C close-dialog interception, Ctrl/Shift/Alt/Cmd+Enter newline insertion, paste, Ctrl+Shift+C copy, Ctrl+Shift+M model-cycle, and read-only/observer gating. Ctrl+C never forwards `\x03` to the PTY in legacy mode.

## Tests

- 23 unit tests for the parser + encoder (real escape-sequence vectors, no mocks), incl. push/set-modes/pop/query, main↔alt stacks, chunk-split reassembly, carry cap, and the encoder's modifier/codepoint/event-type rules.
- Full suite: **362/362 passing**; `tsc` + `vite` build clean.
- Reviewed per-task and across the whole branch; the final review found no Critical/blocking issues.

## ⚠️ Pre-merge checklist (manual — not yet done)

- [ ] **Live verification against the real fullscreen renderer.** Build + launch the app, run `claude`, enable the new fullscreen renderer, and confirm typing/arrows/Enter/Backspace/Escape work and Ctrl+C is handled by the TUI (not the OmniDesk close dialog). This is the one thing automated tests can't cover; please run before merging.

## Known v1 scope (intentional, documented in the plan)

- Non-US punctuation layouts fall back to `e.key`; bare modifier-key events and `report-associated-text` (flag 16) are not emitted. None affect typing in the common case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)