### PR TITLE
fix(shell-sessions): render shell terminal output

### DIFF
--- a/src/renderer/components/Terminal.tsx
+++ b/src/renderer/components/Terminal.tsx
@@ -8,7 +8,7 @@ import { FileInfo, DragDropSettings, DragDropInsertMode, PathFormat } from '../.
 import type { ProviderId } from '../../shared/types/provider-types';
 import { isClaudeReady as checkClaudeReadyPatterns, findClaudeOutputStart } from '../../shared/claude-detector';
 import { KittyKeyboardState, encodeKittyKey } from '../terminal/kitty-keyboard';
-import { shouldShowCloseDialog, isNewlineChord } from '../terminal/shell-key-rules';
+import { shouldShowCloseDialog, isNewlineChord, isOutputReady } from '../terminal/shell-key-rules';
 import type { SessionKind } from '../../shared/ipc-types';
 import '@xterm/xterm/css/xterm.css';
 
@@ -588,6 +588,11 @@ export function MultiTerminal({
   // Buffer for output that arrives before the terminal xterm instance is registered
   const pendingOutputRef = useRef<Map<string, string[]>>(new Map());
   const kittyStateRef = useRef<Map<string, KittyKeyboardState>>(new Map());
+  // Latest sessionKindMap, read via ref so the onOutput/handleReady closures
+  // (whose deps don't include the prop) never see a stale map for a session
+  // created after they were memoized.
+  const sessionKindMapRef = useRef(sessionKindMap);
+  sessionKindMapRef.current = sessionKindMap;
 
   // Set up output listener
   useEffect(() => {
@@ -609,11 +614,12 @@ export function MultiTerminal({
         return;
       }
 
-      // Check if Claude is already detected as ready for this session
-      const isReady = isReadyRef.current.get(sessionId);
+      // Shell sessions bypass Claude-readiness gating; agent output stays
+      // buffered until Claude's welcome box is detected (isOutputReady).
+      const isReady = isOutputReady(isReadyRef.current.get(sessionId), sessionKindMapRef.current?.[sessionId]);
 
       if (isReady) {
-        // Claude is ready, write directly to terminal
+        // Ready (or a shell) — write directly to terminal
         terminal.write(data);
       } else {
         // Buffer the output and check for Claude patterns
@@ -689,7 +695,7 @@ export function MultiTerminal({
       pendingOutputRef.current.delete(sessionId);
       for (const data of pending) {
         // Re-process through the same output pipeline
-        const isReady = isReadyRef.current.get(sessionId);
+        const isReady = isOutputReady(isReadyRef.current.get(sessionId), sessionKindMapRef.current?.[sessionId]);
         if (isReady) {
           terminal.write(data);
         } else {

--- a/src/renderer/terminal/shell-key-rules.test.ts
+++ b/src/renderer/terminal/shell-key-rules.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { shouldShowCloseDialog, isNewlineChord } from './shell-key-rules';
+import { shouldShowCloseDialog, isNewlineChord, isOutputReady } from './shell-key-rules';
 
 describe('shouldShowCloseDialog', () => {
   it('intercepts Ctrl+C for agent sessions in legacy mode', () => {
@@ -28,5 +28,20 @@ describe('isNewlineChord', () => {
   it('is not a chord without a modifier or non-Enter keys', () => {
     expect(isNewlineChord(enter({}), 'agent')).toBe(false);
     expect(isNewlineChord({ key: 'a', ctrlKey: true, shiftKey: false, altKey: false, metaKey: false }, 'agent')).toBe(false);
+  });
+});
+
+describe('isOutputReady', () => {
+  // Agent sessions gate output on Claude-readiness detection (isReady). Shell
+  // sessions have no Claude welcome box to wait for, so their PTY output must
+  // render immediately regardless of the readiness flag.
+  it('mirrors the readiness flag for agent sessions', () => {
+    expect(isOutputReady(true, 'agent')).toBe(true);
+    expect(isOutputReady(false, 'agent')).toBe(false);
+    expect(isOutputReady(undefined, undefined)).toBe(false); // agent, not yet ready
+  });
+  it('is always ready for shell sessions, even before the readiness flag is set', () => {
+    expect(isOutputReady(false, 'shell')).toBe(true);
+    expect(isOutputReady(undefined, 'shell')).toBe(true);
   });
 });

--- a/src/renderer/terminal/shell-key-rules.ts
+++ b/src/renderer/terminal/shell-key-rules.ts
@@ -10,6 +10,17 @@ export function shouldShowCloseDialog(
   return data === '\x03' && kittyFlags === 0 && kind !== 'shell';
 }
 
+/** Whether PTY output should be written straight to the terminal instead of
+ *  being held in the Claude-readiness buffer. Agent sessions gate output until
+ *  Claude's welcome box is detected (`isReady`); shell sessions have no such
+ *  box to wait for, so their output is always ready to render. */
+export function isOutputReady(
+  isReady: boolean | undefined,
+  kind: SessionKind | undefined,
+): boolean {
+  return isReady === true || kind === 'shell';
+}
+
 /** Ctrl/Shift/Alt/Cmd+Enter inserts a literal newline — a Claude-input
  *  affordance. Shell sessions want a real Enter, so this is agent-only. */
 export function isNewlineChord(


### PR DESCRIPTION
## Problem

Shell (Terminal) sessions rendered a **blank pane** — no prompt, no output — even though the PTY was running (reported against v2.1.0, with screenshot).

## Root cause

`MultiTerminal`'s output pipeline (`Terminal.tsx`) writes PTY output to xterm only once a session is marked *ready* in `isReadyRef`, and that flag is set **exclusively** by `checkClaudeReadyPatterns()` matching Claude's welcome box. This is intentional for agents — it hides the shell's startup noise until Claude's UI appears. But a plain shell's `cmd.exe`/`$SHELL` output never matches those patterns, so its banner and prompt were buffered indefinitely and never written to the terminal.

The shell-sessions feature (#39) set the *Terminal-level* `isClaudeReady` (the loading overlay) true for shells, but missed this **second, separate** output-write gate in `MultiTerminal`. The gate is pre-existing code the #39 diff only threaded `kind` into, so neither the per-task nor the whole-branch review flagged it — it was the deferred manual verification that surfaced it.

## Fix

Gate output writes on a new pure predicate `isOutputReady(isReady, kind)`:

```ts
isReady === true || kind === 'shell'
```

Shell sessions bypass the Claude-readiness buffer and write output directly and untrimmed, at both write sites (live output and the pre-registration `pendingOutputRef` flush). `kind` is read via a latest-value ref because the `onOutput` effect and `handleReady` callback deps omit the prop and would otherwise capture a stale map for a newly created shell.

## Testing

- New `isOutputReady` unit tests (agent gates on readiness; shell always ready).
- Full suite green: **393/393**; typecheck + `build` + `build:electron` clean.
- Manual: shell session now shows its prompt, runs commands, and Ctrl+C interrupts a running command; agent sessions unchanged.

Follow-up: cut **v2.1.1** after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)