### PR TITLE
docs: fix doc drift across README, CONTRIBUTING, repo-index, CLAUDE.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -554,7 +554,10 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines on suggesting changes and 
 
 ---
 
-[Unreleased]: https://github.com/carloluisito/omnidesk/compare/v2.0.0...HEAD
+[Unreleased]: https://github.com/carloluisito/omnidesk/compare/v2.1.1...HEAD
+[2.1.1]: https://github.com/carloluisito/omnidesk/compare/v2.1.0...v2.1.1
+[2.1.0]: https://github.com/carloluisito/omnidesk/compare/v2.0.1...v2.1.0
+[2.0.1]: https://github.com/carloluisito/omnidesk/compare/v2.0.0...v2.0.1
 [2.0.0]: https://github.com/carloluisito/omnidesk/compare/v1.4.1...v2.0.0
 [1.4.1]: https://github.com/carloluisito/omnidesk/compare/v1.4.0...v1.4.1
 [1.4.0]: https://github.com/carloluisito/omnidesk/compare/v1.3.0...v1.4.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -129,7 +129,7 @@ npm run test:ci             # CI mode (coverage + JUnit XML)
 
 ## Design Language
 
-Dark theme (Obsidian): bg `#0D0E14`, accent `#00C9A7`, danger `#F7678E`, border `#292E44`
+Dark theme (Obsidian): surface base `#0A0B11`, accent `#00C9A7`, danger `#F7678E`, borders `rgba(255,255,255,0.035–0.12)` (subtle/default/strong). See `src/renderer/styles/tokens.css` for the full token set.
 Font: JetBrains Mono. Monospace everywhere.
 Design tokens defined in `src/renderer/styles/tokens.css`.
 `globals.css` imports `tokens.css`, `animations.css`, `motion.css`, and `prototype-shell.css` (the Phase 4 shell's own CSS). `App.tsx` imports `tokens.css` and `animations.css` directly before mounting.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,7 @@ Electron 28 | React 18 | TypeScript | xterm.js | node-pty | Tailwind CSS
 ```
 ┌─────────────────────────────────────────────┐
 │  Main Process (Node.js)                     │
-│  ~8 managers + IPC handlers + session pool  │
+│  ~7 managers + IPC handlers + session pool  │
 └──────────────────┬──────────────────────────┘
                    │ IPC (103 methods)
 ┌──────────────────┴──────────────────────────┐
@@ -40,8 +40,8 @@ Electron 28 | React 18 | TypeScript | xterm.js | node-pty | Tailwind CSS
 
 | Domain | Main (manager) | Renderer (hook + UI) | Shared types | IPC prefix |
 |--------|---------------|---------------------|-------------|------------|
-| Shell | — | `components/shell/` (RepoActivityBar, SessionRail, MainView, RightInspector, TerminalHost, Palette, RepoSwitcher, AddRepoSheet, NewSessionSheet, StatusBar, TitleBar, ContextMenu, PromptDialog, CloseSessionDialog, P4Icon, SessionPane, SessionTile, shell-utils) | — | — |
-| Sessions | session-manager, cli-manager, session-pool, session-persistence | useSessionManager, useSessionPreviews, Terminal | ipc-types.ts | `session:*` |
+| Shell | — | `components/shell/` (RepoActivityBar, SessionRail, MainView, RightInspector, TerminalHost, Palette, RepoSwitcher, AddRepoSheet, NewSessionSheet, StatusBar, TitleBar, ContextMenu, PromptDialog, CloseSessionDialog, NonGitFolderDialog, P4Icon, SessionPane, SessionTile, shell-utils) | — | — |
+| Sessions | session-manager, cli-manager, session-pool, session-persistence | useSessionManager, useSessionPreviews, Terminal, `terminal/` (kitty-keyboard, shell-key-rules) | ipc-types.ts (`SessionKind`) | `session:*` |
 | Repos / Workspaces | settings-persistence | useRepos | ipc-types.ts | `workspace:*`, `fs:listGitRepos` |
 | Git (worktree ops) | git-manager | — (backend only; useRepos calls git IPC) | types/git-types.ts | `git:*` |
 | History | history-manager | — (backend/persistence only; no UI panel) | types/history-types.ts | `history:*` |
@@ -76,8 +76,9 @@ Example: The **Providers** domain uses `src/main/providers/` with `IProvider` in
 - **Shell setup**: `cli-manager.ts` uses `cmd.exe` on Windows and the user's default shell on Unix. No directory locking or shell overrides.
 - **Output buffering**: 16ms batches in `CLIManager` prevent IPC flooding (~60fps).
 - **Claude readiness**: Pattern detection ("Claude Code", "Sonnet", "Tips for getting started") + 5s fallback timeout in `Terminal.tsx`.
-- **Ctrl+C interception**: Caught in `terminal.onData()`, shows `ConfirmDialog`. Never forward `\x03` to Claude (it exits).
+- **Ctrl+C interception**: In **agent** sessions, `\x03` is caught in `terminal.onData()` and shows `ConfirmDialog` — never forward it to Claude (it exits). In **plain shell** sessions, `Ctrl+C` passes straight through to interrupt the running command (`Terminal.tsx:413-416`). Session kind drives the branch (`SessionKind` in `src/shared/ipc-types.ts`).
 - **Newline insertion**: Ctrl+Enter, Shift+Enter, Alt+Enter, and Cmd+Enter insert a literal `\n` into the terminal via `attachCustomKeyEventHandler` in `Terminal.tsx`. Works in both host and read-only modes (suppressed in read-only).
+- **Terminal key handling** (`src/renderer/terminal/`): `kitty-keyboard.ts` negotiates and encodes the Kitty keyboard protocol when the running CLI requests it (accurate key/modifier encoding); `shell-key-rules.ts` holds the plain-shell key mapping (incl. the Ctrl+C pass-through rule). Both are unit-tested.
 - **Session pool**: Pre-warmed shells in `session-pool.ts` for faster session creation. Delayed init (2.5s after app start).
 - **IPC contract**: One entry in `IPCContractMap` = auto-derived channel, kind, preload bridge method, and TypeScript type. No manual wiring needed.
 - **Git integration**: `GitManager` uses `child_process.execFile` (not `exec` — prevents shell injection). Per-directory mutex serializes operations. `.git` directory watching with 500ms debounce for real-time status. Heuristic-based AI commit message generation (conventional commits format). Used by `useRepos` for repo/worktree discovery and session creation — there is no Git panel UI in the current shell.
@@ -85,7 +86,7 @@ Example: The **Providers** domain uses `src/main/providers/` with `IProvider` in
 - **Provider abstraction**: `IProvider` interface decouples CLI specifics. `CLIManager` delegates to provider for command building, env vars, and model detection. Default provider is Claude. `ProviderRegistry` auto-registers Claude and Codex providers on construction.
 - **Launch mode picker**: `NewSessionSheet` (in `src/renderer/components/shell/NewSessionSheet.tsx`) shows a launch mode control when the Claude provider is selected, with three options driven by `LaunchMode = 'default' | 'bypass-permissions' | 'agents'` (`src/shared/ipc-types.ts`). Selection rides on the optional `SessionCreateRequest.launchMode`; `ClaudeProvider.buildCommand` switches on it. The default selection comes from the workspace's `defaultPermissionMode` (`'skip-permissions'` → seeds `'bypass-permissions'`). Codex sessions ignore the field. Defense-in-depth: `ClaudeProvider` reads the live availability cache and downgrades `'agents'` → `'default'` with a warning if availability is `'unavailable'`.
 - **Agent View availability**: `claude agents` mode is gated by a one-shot main-process probe of `claude --version` plus `~/.claude/settings.json.disableAgentView` and `CLAUDE_CODE_DISABLE_AGENT_VIEW` kill switches (`src/main/agent-view/`). The probe runs in a `setTimeout(..., 2000)` block off the synchronous `createWindow` critical path (lesson from a prior aborted feature). Result is held in a module-level cache (`availability-cache.ts`), exposed via `agentView:availability` IPC (one-shot fetch on sheet open), and pushed to the renderer via `agentView:availabilityChanged` event once the probe completes. The `useAgentViewAvailability` hook does a **one-shot fetch on mount** then **subscribes to `onAgentViewAvailabilityChanged`**; if the initial fetch returns `reason: 'probing'` the hook stays `loading: true` until the push event delivers the final state. Reason variants: `'cli-not-found'`, `'cli-too-old'`, `'version-unparseable'`, `'disabled-by-setting'`, `'disabled-by-env'`, `'probing'` (transient initial cache state — internal sentinel, never exposed to picker consumers), `'detection-failed'` (renderer-side IPC catch + the no-args ClaudeProvider fallback getter).
-- **Agent teams CLI capability**: The `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS` environment variable is injected by `ClaudeProvider` when the setting is enabled. This is independent of any team-visualization UI (which was removed). The provider env-var injection is the only surviving part of the agent-teams feature.
+- **Agent teams CLI capability**: The `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS` environment variable is injected by `ClaudeProvider` (`claude-provider.ts:120`) when the setting is enabled, and also set directly in `cli-manager.ts:334`. This is independent of any team-visualization UI (which was removed). The env-var injection is the only surviving part of the agent-teams feature.
 
 ## Testing
 
@@ -121,7 +122,7 @@ npm run test:ci             # CI mode (coverage + JUnit XML)
 ## Pitfalls
 
 - Windows paths need `.replace(/\\/g, '\\\\')`
-- Never send Ctrl+C (`\x03`) to Claude — it exits immediately
+- Never send Ctrl+C (`\x03`) to Claude in **agent** sessions — it exits immediately (plain shell sessions intentionally pass it through)
 - Always batch PTY output (16ms `FLUSH_INTERVAL` in CLIManager)
 - Reuse existing UI components from `components/ui/` for consistency
 - No global state library — React hooks only

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,133 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity and
+orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+- The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+**carlo.adap@hotmail.com**. All complaints will be reviewed and investigated
+promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][mozilla].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[mozilla]: https://github.com/mozilla/diversity
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][faq]. Translations are available at
+[https://www.contributor-covenant.org/translations][translations].
+
+[faq]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -102,15 +102,12 @@ npm run build
 # Package for current platform
 npm run package
 
-# Run tests (when available)
+# Run tests
 npm test
-
-# Lint code
-npm run lint
-
-# Format code (if configured)
-npm run format
 ```
+
+> **Note:** There is no `lint` or `format` script — the project relies on TypeScript's
+> compiler (`strict` mode) for static checking rather than ESLint/Prettier.
 
 ---
 
@@ -222,7 +219,7 @@ await window.electronAPI.createSession(name, dir);
 
 ### Current State
 
-OmniDesk has **334 tests across 25 test files**, using Vitest 4 with 3 workspace projects:
+OmniDesk has **393 tests across 33 test files**, using Vitest 4 with 3 workspace projects:
 
 | Project | Environment | Pattern |
 |---------|-------------|---------|
@@ -433,7 +430,6 @@ Fixes #456
 1. **Don't use Node.js APIs in renderer** - Use IPC to communicate with main process
 2. **Don't forget to clean up** - Remove event listeners in `useEffect` cleanup
 3. **Escape Windows paths** - Use `.replace(/\\/g, '\\\\')` for PowerShell
-4. **PowerShell line endings** - Use `\r`, not `\n`
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@
 
 ### Multi-Provider Support
 - **Pluggable provider layer** — swap between Claude Code, Codex CLI, and future providers
-- **Provider selector** in the new-session sheet (shown automatically when more than one provider is available)
+- **Provider selector** in the new-session sheet — choose Claude or Codex for each agent session
 - **Provider badges** on sessions to distinguish non-default providers
 - **Auto-detection** — providers register automatically based on installed CLI binaries
 
@@ -252,7 +252,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for development guidelines.
 
 - **Local-first** — all session data is stored on your machine
 - **No telemetry** — no usage data is collected or transmitted
-- **Minimal external services** — the only network calls are to Anthropic's API for quota/burn-rate data
+- **Minimal external services** — network calls are limited to: Anthropic's API (quota/burn-rate), GitHub (app update checks via `electron-updater`), and your configured git remotes (clone/fetch/push). Nothing else is contacted.
 - **Credential security** — reads Claude CLI credentials locally, never logs or stores them
 
 For more details, see [SECURITY.md](SECURITY.md).

--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ Built packages will be in the `release/` directory.
 | Terminal | xterm.js + node-pty |
 | Styling | Tailwind CSS (Obsidian theme) |
 | Build | Vite + electron-builder |
-| Testing | Vitest 4 (334 tests) + Playwright |
+| Testing | Vitest 4 (393 tests) + Playwright |
 
 ---
 
@@ -236,7 +236,7 @@ See [docs/repo-index.md](docs/repo-index.md) for a detailed domain-to-file mappi
 ```bash
 npm install              # Install dependencies
 npm run electron:dev     # Dev mode with hot reload (renderer)
-npm test                 # Run all 334 tests
+npm test                 # Run all 393 tests
 npm run test:watch       # Watch mode
 npm run test:e2e         # E2E tests (local only — requires a built app)
 npm run test:coverage    # Coverage report

--- a/docs/doc-drift-audit.md
+++ b/docs/doc-drift-audit.md
@@ -1,0 +1,91 @@
+# Doc Drift + CLAUDE.md Audit
+
+> Read-only audit of docs vs. code. Every finding cites the doc claim and the code reality with `file:line`. Use the checkboxes as a work list.
+
+## Resolution (applied 2026-07-07)
+All findings below have been applied, **except** the `CHANGELOG.md` item, which was a **false positive** (the file exists — see the corrected entry). Real test count confirmed via `npm test`: **393 tests across 33 files** (badge was already correct; the stale `334`/`25 files` figures were fixed in README, CONTRIBUTING, and repo-index). `CODE_OF_CONDUCT.md` created (Contributor Covenant 2.1). Decisions taken per user: authored `CODE_OF_CONDUCT.md`; kept the `tsc --strict` claim (verified `tsconfig.json:14`) and only removed the phantom `lint`/`format` commands rather than adding a linter.
+
+## Summary
+The docs are broadly aligned with the code on the big structural claims — the **103 IPC methods** figure (`docs/repo-index.md:3` vs `src/shared/ipc-contract.ts` = 103 `Contract<'…'>` entries), the config-dir/credentials paths, the shell layout, and the CI workflow all check out. The drift is concentrated in **counts and cross-references**: the test count is quoted three different ways (393 / 334 / "25 files") and the real number is neither; two referenced repo files (`CODE_OF_CONDUCT.md`, `CHANGELOG.md`) don't exist; CONTRIBUTING tells contributors to run `npm run lint`/`npm run format`, which aren't defined. `CLAUDE.md` is high-quality and mostly current — it needs a handful of edits (manager count, a couple of new files/dirs, and the Ctrl+C nuance from shell sessions), not a rewrite. **Verdict: exists and needs edits.**
+
+## Drift findings (worst first)
+
+### Critical (breaks setup, build, or a documented feature)
+- None. Documented setup (`npm install`, `npm run electron:dev`, `npm run package`) matches real scripts (`package.json:12-21`).
+
+### High (misleads a developer, wastes real time)
+- [x] **CONTRIBUTING documents lint/format scripts that don't exist**
+  - Doc says: `npm run lint` and `npm run format` (`CONTRIBUTING.md:108-112`); also "All code must pass `tsc --strict`" (`CONTRIBUTING.md:159`)
+  - Code does: `package.json` scripts contain no `lint`, `format`, `eslint`, or `prettier` entry (`package.json:10-29`; grep = 0 matches)
+  - Fix: Remove the lint/format commands or add the scripts; either way stop instructing contributors to run non-existent commands.
+
+- [x] **Dead links to `CODE_OF_CONDUCT.md` (file absent)**
+  - Doc says: "read our [Code of Conduct](CODE_OF_CONDUCT.md)" (`README.md:276`); "adheres to a [Code of Conduct](CODE_OF_CONDUCT.md)" (`CONTRIBUTING.md:21`)
+  - Code does: no `CODE_OF_CONDUCT.md` at repo root (root `*.md` listing shows only `CLAUDE.md`, `CONTRIBUTING.md`, `SECURITY.md` + scratch docs)
+  - Fix: Add the file or remove the links.
+
+- [x] ~~**Dead references to `CHANGELOG.md` (file absent)**~~ — **WITHDRAWN (false positive).** `CHANGELOG.md` exists, is tracked, and is well-maintained (`git ls-files` confirms it). The original audit glob missed it (the `**/*.md` listing truncated at 100 results, dominated by `node_modules`). The `CONTRIBUTING.md:277,442,445` references are valid. Separate minor fix applied: the CHANGELOG's own footer compare-links stopped at `[2.0.0]` — added `[2.0.1]`/`[2.1.0]`/`[2.1.1]` and repointed `[Unreleased]` to `v2.1.1` (`CHANGELOG.md:557-583`).
+
+- [x] **Test count is quoted three inconsistent ways and all are stale**
+  - Doc says: badge "tests-393 passing" (`README.md:6`); "Vitest 4 (334 tests)" (`README.md:191`); "Run all 334 tests" (`README.md:239`); "334 tests across 25 test files" (`CONTRIBUTING.md:225`); "334 tests + 6 e2e specs" (`docs/repo-index.md:3`)
+  - Code does: **33** unit/integration test files exist (glob `src/**/*.test.{ts,tsx}`), not 25; the exact passing-test total can't be read statically (see "Could not verify")
+  - Fix: Pick one source of truth, regenerate the number from a real run, and reconcile the badge with the body.
+
+### Medium (stale but not blocking)
+- [x] **`repo-index.md` test tables omit 8 test files that now exist**
+  - Doc says: unit/integration/component tables enumerate 25 files (`docs/repo-index.md:216-251`)
+  - Code does: also present but undocumented — `src/main/cli-manager.test.ts`, `src/main/path-access.test.ts`, `src/shared/session-kind.test.ts`, `src/renderer/components/shell/shell-utils.test.ts`, `src/renderer/components/shell/NewSessionSheet.test.tsx`, `src/renderer/components/shell/NonGitFolderDialog.test.tsx`, `src/renderer/terminal/kitty-keyboard.test.ts`, `src/renderer/terminal/shell-key-rules.test.ts`
+  - Fix: Regenerate the test tables (or replace them with a "run `npm test` for current counts" note to avoid perpetual staleness).
+
+- [x] **`src/renderer/terminal/` (Kitty protocol + shell key rules) is undocumented in repo-index**
+  - Doc says: repo-index Shared/Renderer sections list no `terminal/` directory (`docs/repo-index.md:184-199`)
+  - Code does: `src/renderer/terminal/kitty-keyboard.ts` and `src/renderer/terminal/shell-key-rules.ts` exist and back a shipped feature (README documents Kitty protocol at `README.md:96`; commit `8a82279`)
+  - Fix: Add a `terminal/` row to repo-index.
+
+- [x] **`NonGitFolderDialog.tsx` missing from shell inventories**
+  - Doc says: shell component list in `CLAUDE.md` Domain Map (Shell row) and `docs/repo-index.md:32-49` — neither lists it
+  - Code does: `src/renderer/components/shell/NonGitFolderDialog.tsx` exists (backs README's "offers to initialize git", `README.md:78`)
+  - Fix: Add it to both lists.
+
+- [x] **CLAUDE.md Ctrl+C pattern states the old absolute behavior**
+  - Doc says: "Ctrl+C interception: Caught in `terminal.onData()`, shows `ConfirmDialog`. Never forward `\x03` to Claude" (`CLAUDE.md`, Critical Implementation Patterns)
+  - Code does: behavior is now conditional — plain shell sessions pass Ctrl+C through: "sessions let Ctrl+C pass through to interrupt the running command" (`src/renderer/components/Terminal.tsx:413-416`). README already reflects this (`README.md:95`)
+  - Fix: Add the shell-session pass-through caveat to the CLAUDE.md pattern.
+
+### Low (cosmetic, wording, minor gaps)
+- [x] **Manager count: CLAUDE.md says ~8, everything else says ~7**
+  - Doc says: "~8 managers" (`CLAUDE.md`, architecture diagram) vs "~7 managers" (`README.md:202`, `CONTRIBUTING.md:119`, `docs/repo-index.md:9`)
+  - Code does: `index.ts` instantiates 7 (`SettingsManager`, `HistoryManager`, `CheckpointManager`, `SessionPool`, `SessionManager`, `GitManager`, `ProviderRegistry`) (`src/main/index.ts:167-201`)
+  - Fix: Change CLAUDE.md's "~8" to "~7".
+
+- [x] **CONTRIBUTING PowerShell tip contradicts actual newline handling**
+  - Doc says: "PowerShell line endings - Use `\r`, not `\n`" (`CONTRIBUTING.md:436`)
+  - Code does: newline insertion sends `\n` (`src/renderer/components/Terminal.tsx:403`, `onInput(sessionId, '\n')`)
+  - Fix: Remove or clarify the tip; it reads as a codebase convention but isn't one.
+
+- [x] **`CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS` is injected in two places, not just ClaudeProvider**
+  - Doc says: "injected by `ClaudeProvider` … the only surviving part of the agent-teams feature" (`CLAUDE.md`, Agent teams CLI capability)
+  - Code does: set in `src/main/providers/claude-provider.ts:120` **and** `src/main/cli-manager.ts:334`
+  - Fix: Note both injection points (or dedupe in code — a code-quality item, out of audit scope).
+
+## CLAUDE.md
+- Verdict: **exists and needs edits** (accurate and genuinely useful — correct build/test commands, real IPC-contract mechanics, good pitfalls; the drift is small and localized).
+- [ ] Change "~8 managers" → "~7 managers" in the architecture diagram (matches `src/main/index.ts:167-201`).
+- [ ] Add `NonGitFolderDialog` to the Shell row of the Domain Map.
+- [ ] Add the `src/renderer/terminal/` directory (Kitty keyboard protocol + shell key rules) to the Domain Map / Critical Implementation Patterns — it's a shipped feature with tests but absent from CLAUDE.md.
+- [ ] Update the "Ctrl+C interception" pattern to note plain shell sessions pass `\x03` through (`Terminal.tsx:413-416`), so the "Never forward `\x03`" rule is scoped to agent/Claude sessions.
+- [ ] Note that `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS` is also set in `cli-manager.ts:334`, not only `ClaudeProvider`.
+- Leave as-is (verified correct): 103 IPC methods, provider abstraction, launch-mode picker, agent-view availability probe, config-dir migration (`~/.claudedesk` → `~/.omnidesk`), session pool, output buffering.
+
+## Could not verify statically
+- ~~**Exact passing test total (393 vs 334):**~~ **RESOLVED** — `npm test` reports 393 passed across 33 files; docs reconciled to 393/33.
+- **"All code must pass `tsc --strict`" (`CONTRIBUTING.md:159`):** confirm with `npx tsc --noEmit -p tsconfig.json` and check `"strict"` in `tsconfig.json`.
+- **README badge "393 passing" accuracy:** same as above — the badge is hand-maintained, so it's only as current as the last manual edit.
+
+## Suggested fix order
+1. **Missing referenced files** — add or delink `CODE_OF_CONDUCT.md` and `CHANGELOG.md` (broken links hurt every new contributor). *Human decision:* whether to author these files or remove the references.
+2. **CONTRIBUTING lint/format** — delete the phantom commands or add real `lint`/`format` scripts. *Human decision:* adopt ESLint/Prettier vs. just remove the claim.
+3. **Reconcile the test count** — run the suite, set one number, fix the README badge/body + CONTRIBUTING + repo-index; consider replacing hard counts with "run `npm test`".
+4. **repo-index refresh** — add the 8 missing test files, the `terminal/` dir, and `NonGitFolderDialog`.
+5. **CLAUDE.md edits** — the 5 checkboxes above (all mechanical, no human decision needed).
+6. **Low-severity wording** — manager count in CLAUDE.md, PowerShell `\r` tip, agent-teams env-var note.

--- a/docs/doc-drift-audit.md
+++ b/docs/doc-drift-audit.md
@@ -89,3 +89,15 @@ The docs are broadly aligned with the code on the big structural claims — the 
 4. **repo-index refresh** — add the 8 missing test files, the `terminal/` dir, and `NonGitFolderDialog`.
 5. **CLAUDE.md edits** — the 5 checkboxes above (all mechanical, no human decision needed).
 6. **Low-severity wording** — manager count in CLAUDE.md, PowerShell `\r` tip, agent-teams env-var note.
+
+---
+
+## Addendum: README ↔ code feature audit (applied 2026-07-08)
+
+Second pass — verify every README feature/shortcut claim against the actually-mounted code (static, no app run). Most claims verified accurate (shortcuts `App.tsx:382-402`; links `Terminal.tsx:362-367`; Kitty `Terminal.tsx:379,600-603`; inspector fields `RightInspector.tsx:51-77`; provider auto-detect `claude-provider.ts:51-54` / `codex-provider.ts:32-35`; packaging `electron-builder.yml:5,20-46`). Three drifts found and fixed:
+
+- [x] **Privacy claim understated network calls** — README said "the only network calls are to Anthropic's API." Reworded to include GitHub update checks (`ipc-handlers.ts:674-682`, `electron-builder.yml:48-51`) and git remotes (`git-manager.ts:675`). "No telemetry" verified (no analytics endpoints found).
+- [x] **Provider selector claim overstated** — README said the selector is "shown automatically when more than one provider is available," but `NewSessionSheet.tsx:483-505` renders a hardcoded, unconditional Claude/Codex toggle and never consults provider availability. Reworded README to match actual behavior (doc fix, not code change). **Latent code gap for later:** the new-session UI ignores the registry's `provider:available` detection — gating the toggle on `useProvider` availability would be the "intended" behavior.
+- [x] **CLAUDE.md Design Language hexes stale** — claimed `bg #0D0E14` / `border #292E44`; actual is `--surface-base: #0A0B11` (`tokens.css:9`) and `rgba(255,255,255,0.035–0.12)` borders (`tokens.css:35-37`). Accent/danger were correct. Fixed.
+
+**Not statically verifiable:** runtime rendering/visual correctness (needs the app running); README "macOS 10.13+" / "Linux libxtst6/libnss3" (Electron 28 runtime facts, confirm against Electron's support matrix).

--- a/docs/repo-index.md
+++ b/docs/repo-index.md
@@ -1,6 +1,6 @@
 # OmniDesk — Repository Index
 
-~7 core managers (+ quota-service, providers/, agent-view/) | 103 IPC methods | 18 channel-prefix domains | 334 tests + 6 e2e specs
+~7 core managers (+ quota-service, providers/, agent-view/) | 103 IPC methods | 18 channel-prefix domains | 393 tests across 33 files + 6 e2e specs
 
 ## Entrypoints
 
@@ -44,6 +44,7 @@ The renderer uses a flat repo→session model. The shell lives in `src/renderer/
 | `src/renderer/components/shell/NewSessionSheet.tsx` | Renderer | New session form — includes launch mode picker for Claude |
 | `src/renderer/components/shell/PromptDialog.tsx` | Renderer | Generic text-input prompt dialog (used for group create/rename) |
 | `src/renderer/components/shell/CloseSessionDialog.tsx` | Renderer | Confirm-before-close dialog for sessions |
+| `src/renderer/components/shell/NonGitFolderDialog.tsx` | Renderer | Prompt to initialize git when adding a non-git folder |
 | `src/renderer/components/shell/ContextMenu.tsx` | Renderer | Right-click context menu for shell elements |
 | `src/renderer/components/shell/P4Icon.tsx` | Renderer | Phase 4 icon component |
 | `src/renderer/components/shell/shell-utils.ts` | Renderer | Shared utilities: color helpers, status metadata, formatting |
@@ -62,6 +63,8 @@ IPC: `session:*`, `model:*`
 | `src/renderer/hooks/useSessionManager.ts` | Renderer | Session CRUD hook, IPC event listeners |
 | `src/renderer/hooks/useSessionPreviews.ts` | Renderer | Last-N-lines stdout snapshots + last-activity timestamps for Grid tiles |
 | `src/renderer/components/Terminal.tsx` | Renderer | xterm.js wrapper, Ctrl+C intercept, Claude readiness detection |
+| `src/renderer/terminal/kitty-keyboard.ts` | Renderer | Kitty keyboard protocol negotiation + key/modifier encoding |
+| `src/renderer/terminal/shell-key-rules.ts` | Renderer | Plain-shell key mapping (incl. Ctrl+C pass-through) |
 
 ## Repos / Workspaces
 
@@ -227,15 +230,21 @@ IPC: `window:*`, `dialog:*`, `shell:*`, `updates:*`, `app:*`
 | `src/main/agent-view/probe-version.test.ts` | 6 | Successful version parse, missing binary, non-zero exit, parse-unsafe output, 5s timeout |
 | `src/main/ipc-handlers.availability.test.ts` | 7 | Cached-and-return semantics, no-respawn on N calls, IPC wrapper, initial `'probing'` state |
 | `src/main/quota-service.test.ts` | 13 | Quota fetching, burn rate calculation, cache |
+| `src/main/cli-manager.test.ts` | 2 | PTY spawn wiring, agent-teams env var injection |
+| `src/main/path-access.test.ts` | 6 | Home + workspace path allow-listing, Windows normalization |
+| `src/shared/session-kind.test.ts` | 2 | `SessionKind` type-level guards (agent vs shell) |
+| `src/renderer/components/shell/shell-utils.test.ts` | 5 | Color helpers, status metadata, formatting |
+| `src/renderer/terminal/kitty-keyboard.test.ts` | 23 | Kitty protocol negotiation + key/modifier encoding |
+| `src/renderer/terminal/shell-key-rules.test.ts` | 8 | Plain-shell key mapping incl. Ctrl+C pass-through |
 
 ### Integration Tests
 
 | File | Tests | Covers |
 |------|-------|--------|
-| `src/renderer/hooks/useSessionManager.test.ts` | 7 | CRUD, events, output subscribers |
+| `src/renderer/hooks/useSessionManager.test.ts` | 8 | CRUD, events, output subscribers |
 | `src/renderer/hooks/useAgentViewAvailability.test.tsx` | 6 | Initial null/loading state, stays loading when initial fetch returns `'probing'`, success path, rejection synthesizes `detection-failed`, subscribes to push event, unsubscribes on unmount |
-| `src/main/session-persistence.test.ts` | 16 | Load/save/clear, validation, atomic write |
-| `src/main/session-manager.test.ts` | 14 | Session lifecycle, history recording, model events |
+| `src/main/session-persistence.test.ts` | 17 | Load/save/clear, validation, atomic write |
+| `src/main/session-manager.test.ts` | 20 | Session lifecycle, history recording, model events |
 | `src/main/ipc-registry.test.ts` | 5 | handle(), on(), removeAll() |
 | `src/main/ipc-emitter.test.ts` | 3 | emit(), destroyed window guard |
 | `src/main/ipc-handlers.test.ts` | 4 | IPC handler integration |
@@ -244,8 +253,10 @@ IPC: `window:*`, `dialog:*`, `shell:*`, `updates:*`, `app:*`
 
 | File | Tests | Covers |
 |------|-------|--------|
-| `src/renderer/components/ui/TabBar.test.tsx` | 8 | Tabs render, active state, callbacks |
+| `src/renderer/components/ui/TabBar.test.tsx` | 7 | Tabs render, active state, callbacks |
 | `src/renderer/components/ui/EmptyState.test.tsx` | 5 | Welcome screen, quick actions |
+| `src/renderer/components/shell/NewSessionSheet.test.tsx` | 1 | Shell-form submit passes kind=shell + repo path |
+| `src/renderer/components/shell/NonGitFolderDialog.test.tsx` | 4 | Renders options, fires onInitGit on initialize-git click |
 | `src/renderer/components/ui/CommitDialog.test.tsx` | 11 | Form, validation, commit flow, AI message generation |
 | `src/renderer/components/ui/NewSessionDialog.test.tsx` | 8 | Launch-mode picker: three options render, default seeded from workspace, agents available/unavailable, submit-with-each-mode passes correct `launchMode` (uses `vi.hoisted` for stable mock refs) |
 | `src/renderer/components/ui/ShareIndicator.test.tsx` | 8 | Renders, count display (0/1/5/9/10+), aria-label, "9+" clamp |


### PR DESCRIPTION
## Summary

Reconciles documentation with the current code after a read-only doc-drift audit. **Docs-only — no source changes.**

## Changes
- **Test counts:** corrected `334 → 393` tests / `25 → 33` files in README, CONTRIBUTING, and `docs/repo-index.md` (verified via `npm run test:ci`).
- **CONTRIBUTING:** removed phantom `npm run lint` / `npm run format` commands (no such scripts exist); kept the `tsc --strict` claim (verified `tsconfig.json:14`); dropped the misleading PowerShell `\r`-not-`\n` tip (`Terminal.tsx:403` sends `\n`).
- **CODE_OF_CONDUCT.md** *(new)*: Contributor Covenant 2.1, so the README/CONTRIBUTING links resolve.
- **repo-index:** added `NonGitFolderDialog` + `terminal/` (`kitty-keyboard`, `shell-key-rules`); refreshed test tables (6 new files, fixed drifted counts for `session-manager`, `session-persistence`, `useSessionManager`, `TabBar`).
- **CLAUDE.md:** `~8 → ~7` managers; added `NonGitFolderDialog` + `terminal/`; scoped the Ctrl+C rule (agent-session guard vs shell-session pass-through); noted `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS` is also set in `cli-manager.ts:334`.
- **CHANGELOG:** added missing footer compare-links (`2.0.1`/`2.1.0`/`2.1.1`), repointed `[Unreleased]` to `v2.1.1`.
- **docs/doc-drift-audit.md** *(new)*: the audit work-list / rationale (includes one withdrawn false-positive finding — `CHANGELOG.md` exists).

## Verification
Full CI `build` job run locally — all green:
- `tsc --noEmit` ✅
- `tsc -p tsconfig.main.json --noEmit` ✅
- `build:electron` ✅
- `build` (renderer) ✅
- `test:ci` → **393 passed (33 files)** ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)