### PR TITLE
feat(mobile): project + session switching in the drawer

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -188,6 +188,19 @@ function App() {
     setMode('focus');
   }, [switchSession]);
 
+  // Mobile drawer: a session tap can cross projects, so make the session's repo
+  // active before switching. (The desktop rail is repo-scoped, so its
+  // handleSelectSession never needs this.)
+  const handleMobileSelectSession = useCallback((id: string) => {
+    const owner = repos.find(r => sessionsForRepo(r, sessions).some(s => s.id === id));
+    if (owner && owner.id !== activeRepoId) {
+      setActiveRepoId(owner.id);
+      setActiveGroupId(null);
+    }
+    switchSession(id);
+    setMode('focus');
+  }, [repos, sessions, activeRepoId, setActiveRepoId, setActiveGroupId, switchSession]);
+
   const handleCloseRepo = useCallback((id: string) => {
     const target = repos.find(r => r.id === id);
     if (!target) return;
@@ -619,9 +632,11 @@ function App() {
           activeRepo={activeRepo}
           sessions={sessions}
           activeSessionId={activeSessionId}
-          onSelectSession={handleSelectSession}
+          onSelectSession={handleMobileSelectSession}
+          onSelectRepo={handleSelectRepo}
           onCloseSession={handleCloseSession}
           onNewSession={() => setShowNewSession(true)}
+          onAddRepo={() => setShowAddRepo(true)}
           onOpenRemote={() => setShowRemote(true)}
         />
       ) : (

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -25,6 +25,7 @@ import { useSessionPreviews } from './hooks/useSessionPreviews';
 import { useTouchMode } from './hooks/useTouchMode';
 import { MobileKeyBar } from './components/shell/mobile/MobileKeyBar';
 import { MobileShell } from './components/shell/mobile/MobileShell';
+import { repoIdForSession } from './components/shell/mobile/nav-utils';
 import { shouldShowCloseDialog } from './terminal/shell-key-rules';
 import { ToastContainer } from './components/ui/ToastContainer';
 import { ConfirmDialog } from './components/ui/ConfirmDialog';
@@ -192,14 +193,14 @@ function App() {
   // active before switching. (The desktop rail is repo-scoped, so its
   // handleSelectSession never needs this.)
   const handleMobileSelectSession = useCallback((id: string) => {
-    const owner = repos.find(r => sessionsForRepo(r, sessions).some(s => s.id === id));
-    if (owner && owner.id !== activeRepoId) {
-      setActiveRepoId(owner.id);
+    const ownerId = repoIdForSession(visibleRepos, sessions, id);
+    if (ownerId && ownerId !== activeRepoId) {
+      setActiveRepoId(ownerId);
       setActiveGroupId(null);
     }
     switchSession(id);
     setMode('focus');
-  }, [repos, sessions, activeRepoId, setActiveRepoId, setActiveGroupId, switchSession]);
+  }, [visibleRepos, sessions, activeRepoId, setActiveRepoId, setActiveGroupId, switchSession]);
 
   const handleCloseRepo = useCallback((id: string) => {
     const target = repos.find(r => r.id === id);
@@ -628,7 +629,7 @@ function App() {
     >
       {touchMode ? (
         <MobileShell
-          repos={repos}
+          repos={visibleRepos}
           activeRepo={activeRepo}
           sessions={sessions}
           activeSessionId={activeSessionId}

--- a/src/renderer/components/shell/mobile/MobileDrawer.css
+++ b/src/renderer/components/shell/mobile/MobileDrawer.css
@@ -1,6 +1,7 @@
-.mdrawer-backdrop { position: fixed; inset: 0; background: rgba(0,0,0,0.5); z-index: 30; }
+/* Above TerminalHost's terminal overlay (z 1) and the mobile key bar (z 40). */
+.mdrawer-backdrop { position: fixed; inset: 0; background: rgba(0,0,0,0.5); z-index: 50; }
 .mdrawer-panel {
-  position: fixed; top: 0; left: 0; bottom: 0; z-index: 31;
+  position: fixed; top: 0; left: 0; bottom: 0; z-index: 51;
   width: min(320px, 85vw);
   display: flex; flex-direction: column; gap: 4px;
   padding: env(safe-area-inset-top) 8px 8px;

--- a/src/renderer/components/shell/mobile/MobileDrawer.css
+++ b/src/renderer/components/shell/mobile/MobileDrawer.css
@@ -1,7 +1,7 @@
 .mdrawer-backdrop { position: fixed; inset: 0; background: rgba(0,0,0,0.5); z-index: 30; }
 .mdrawer-panel {
   position: fixed; top: 0; left: 0; bottom: 0; z-index: 31;
-  width: min(300px, 82vw);
+  width: min(320px, 85vw);
   display: flex; flex-direction: column; gap: 4px;
   padding: env(safe-area-inset-top) 8px 8px;
   background: var(--v2-surface-high, #14151d);
@@ -10,12 +10,36 @@
   animation: mdrawer-in 0.18s ease;
 }
 @keyframes mdrawer-in { from { transform: translateX(-100%); } to { transform: none; } }
-.mdrawer-repo { padding: 10px; color: var(--v2-text-tertiary, #6b7089); font-size: 12px; }
-.mdrawer-list { list-style: none; margin: 0; padding: 0; overflow-y: auto; flex: 1 1 auto; }
-.mdrawer-item, .mdrawer-new, .mdrawer-remote {
+
+.mdrawer-title { padding: 10px 12px 4px; color: var(--v2-text-tertiary, #6b7089); font-size: 11px; text-transform: uppercase; letter-spacing: 0.06em; }
+.mdrawer-list { list-style: none; margin: 0; padding: 0; overflow-y: auto; flex: 1 1 auto; -webkit-overflow-scrolling: touch; }
+.mdrawer-group { margin-bottom: 6px; }
+
+/* Project header row — tappable to switch the active project. */
+.mdrawer-project {
+  display: flex; align-items: center; justify-content: space-between; gap: 8px;
+  width: 100%; text-align: left;
+  min-height: 44px; padding: 0 12px; border: none; border-radius: 8px;
+  background: transparent; color: var(--v2-text-primary, #E2E4F0);
+  font-size: 14px; font-weight: 600;
+}
+.mdrawer-project.active { background: var(--v2-surface-mid, #262935); }
+.mdrawer-project.active .mdrawer-project-name { color: var(--v2-accent, #00C9A7); }
+.mdrawer-project-static { font-weight: 600; color: var(--v2-text-tertiary, #6b7089); }
+.mdrawer-project-name { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.mdrawer-count {
+  flex: 0 0 auto; min-width: 20px; text-align: center;
+  font-size: 11px; color: var(--v2-text-tertiary, #6b7089);
+  background: var(--v2-surface-mid, #262935); border-radius: 10px; padding: 2px 6px;
+}
+
+/* Session rows — indented beneath their project. */
+.mdrawer-item, .mdrawer-new, .mdrawer-open, .mdrawer-remote {
   display: block; width: 100%; text-align: left;
   min-height: 44px; padding: 0 12px; border: none; border-radius: 8px;
   background: transparent; color: var(--v2-text-secondary, #C0C4D6); font-size: 14px;
 }
+.mdrawer-item { padding-left: 24px; }
 .mdrawer-item.active { background: var(--v2-surface-mid, #262935); color: var(--v2-text-primary, #E2E4F0); }
-.mdrawer-remote { color: var(--v2-accent, #00C9A7); }
+.mdrawer-empty { padding: 12px; color: var(--v2-text-tertiary, #6b7089); font-size: 13px; }
+.mdrawer-open, .mdrawer-remote { color: var(--v2-accent, #00C9A7); }

--- a/src/renderer/components/shell/mobile/MobileDrawer.test.tsx
+++ b/src/renderer/components/shell/mobile/MobileDrawer.test.tsx
@@ -60,7 +60,10 @@ describe('MobileDrawer', () => {
 
   it('keeps sessions whose project is not open reachable under "Other sessions"', () => {
     const p = mk();
-    p.repos = [{ id: 'r1', name: 'demo', path: '/demo' }] as any; // r2 (api) closed
+    // App feeds the drawer only "open" projects (visibleRepos). Dropping r2 here
+    // stands in for a project that isn't in that open set but still has a live
+    // session — that session must not vanish.
+    p.repos = [{ id: 'r1', name: 'demo', path: '/demo' }] as any;
     render(<MobileDrawer {...p} />);
     expect(screen.getByText('Other sessions')).toBeInTheDocument();
     fireEvent.click(screen.getByText('tests'));

--- a/src/renderer/components/shell/mobile/MobileDrawer.test.tsx
+++ b/src/renderer/components/shell/mobile/MobileDrawer.test.tsx
@@ -2,23 +2,73 @@ import { describe, it, expect, vi } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { MobileDrawer } from './MobileDrawer';
 
-const props = {
-  open: true, onClose: vi.fn(),
-  repos: [], activeRepo: { id: 'r1', name: 'demo' } as any,
-  sessions: [{ id: 's1', name: 'work' }, { id: 's2', name: 'build' }] as any,
+const mk = () => ({
+  open: true,
+  onClose: vi.fn(),
+  repos: [
+    { id: 'r1', name: 'demo', path: '/demo' },
+    { id: 'r2', name: 'api', path: '/api' },
+  ] as any,
+  activeRepo: { id: 'r1', name: 'demo', path: '/demo' } as any,
+  sessions: [
+    { id: 's1', name: 'work', mainRepoPath: '/demo', workingDirectory: '/demo' },
+    { id: 's2', name: 'build', mainRepoPath: '/demo', workingDirectory: '/demo' },
+    { id: 's3', name: 'tests', mainRepoPath: '/api', workingDirectory: '/api' },
+  ] as any,
   activeSessionId: 's1',
-  onSelectSession: vi.fn(), onCloseSession: vi.fn(), onNewSession: vi.fn(), onOpenRemote: vi.fn(),
-};
+  onSelectSession: vi.fn(),
+  onSelectRepo: vi.fn(),
+  onCloseSession: vi.fn(),
+  onNewSession: vi.fn(),
+  onAddRepo: vi.fn(),
+  onOpenRemote: vi.fn(),
+});
 
 describe('MobileDrawer', () => {
-  it('lists sessions and selects one (closing the drawer)', () => {
-    render(<MobileDrawer {...props} />);
-    fireEvent.click(screen.getByText('build'));
-    expect(props.onSelectSession).toHaveBeenCalledWith('s2');
-    expect(props.onClose).toHaveBeenCalled();
+  it('groups sessions under their project and shows every open project', () => {
+    render(<MobileDrawer {...mk()} />);
+    // Both projects are present as headers…
+    expect(screen.getByRole('button', { name: /demo/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /api/i })).toBeInTheDocument();
+    // …and every session is reachable.
+    ['work', 'build', 'tests'].forEach(n => expect(screen.getByText(n)).toBeInTheDocument());
   });
+
+  it('selects a session (which sets its project active) and closes', () => {
+    const p = mk();
+    render(<MobileDrawer {...p} />);
+    fireEvent.click(screen.getByText('tests')); // a session in the non-active project
+    expect(p.onSelectSession).toHaveBeenCalledWith('s3');
+    expect(p.onClose).toHaveBeenCalled();
+  });
+
+  it('switches project when a project header is tapped, and closes', () => {
+    const p = mk();
+    render(<MobileDrawer {...p} />);
+    fireEvent.click(screen.getByRole('button', { name: /api/i }));
+    expect(p.onSelectRepo).toHaveBeenCalledWith('r2');
+    expect(p.onClose).toHaveBeenCalled();
+  });
+
+  it('opens a new project via + Open project, and closes', () => {
+    const p = mk();
+    render(<MobileDrawer {...p} />);
+    fireEvent.click(screen.getByText('+ Open project'));
+    expect(p.onAddRepo).toHaveBeenCalled();
+    expect(p.onClose).toHaveBeenCalled();
+  });
+
+  it('keeps sessions whose project is not open reachable under "Other sessions"', () => {
+    const p = mk();
+    p.repos = [{ id: 'r1', name: 'demo', path: '/demo' }] as any; // r2 (api) closed
+    render(<MobileDrawer {...p} />);
+    expect(screen.getByText('Other sessions')).toBeInTheDocument();
+    fireEvent.click(screen.getByText('tests'));
+    expect(p.onSelectSession).toHaveBeenCalledWith('s3');
+  });
+
   it('does not render its panel when closed', () => {
-    const { container } = render(<MobileDrawer {...props} open={false} />);
+    const { container } = render(<MobileDrawer {...mk()} open={false} />);
     expect(container.querySelector('.mdrawer-panel')).toBeNull();
   });
 });

--- a/src/renderer/components/shell/mobile/MobileDrawer.tsx
+++ b/src/renderer/components/shell/mobile/MobileDrawer.tsx
@@ -1,3 +1,4 @@
+import { createPortal } from 'react-dom';
 import { sessionsForRepo } from '../SessionRail';
 import type { MobileShellProps } from './types';
 import './MobileDrawer.css';
@@ -27,7 +28,10 @@ export function MobileDrawer(props: Props) {
   // stays reachable under "Other" so nothing is stranded.
   const orphans = sessions.filter(s => !claimed.has(s.id));
 
-  return (
+  // Portal to <body>: the drawer must escape MobileShell's stacking context,
+  // which sits *below* TerminalHost's fixed terminal overlay — otherwise the
+  // terminal paints on top of the drawer.
+  return createPortal(
     <>
       <div className="mdrawer-backdrop" onClick={onClose} />
       <nav className="mdrawer-panel" aria-label="Projects and sessions">
@@ -82,6 +86,7 @@ export function MobileDrawer(props: Props) {
         <button className="mdrawer-open" onClick={() => { onAddRepo(); onClose(); }}>+ Open project</button>
         <button className="mdrawer-remote" onClick={() => { onOpenRemote(); onClose(); }}>Remote access…</button>
       </nav>
-    </>
+    </>,
+    document.body,
   );
 }

--- a/src/renderer/components/shell/mobile/MobileDrawer.tsx
+++ b/src/renderer/components/shell/mobile/MobileDrawer.tsx
@@ -1,30 +1,79 @@
+import { sessionsForRepo } from '../SessionRail';
 import type { MobileShellProps } from './types';
 import './MobileDrawer.css';
 
 interface Props extends MobileShellProps { open: boolean; onClose: () => void; }
 
 export function MobileDrawer(props: Props) {
-  const { open, onClose, activeRepo, sessions, activeSessionId, onSelectSession, onNewSession, onOpenRemote } = props;
+  const {
+    open, onClose, repos, activeRepo, sessions, activeSessionId,
+    onSelectSession, onSelectRepo, onNewSession, onAddRepo, onOpenRemote,
+  } = props;
   if (!open) return null;
-  const pick = (id: string) => { onSelectSession(id); onClose(); };
+
+  const pickSession = (id: string) => { onSelectSession(id); onClose(); };
+  const pickRepo = (id: string) => { onSelectRepo(id); onClose(); };
+
+  // Group sessions under each open project. Any session that doesn't match a
+  // listed project (e.g. its repo was closed) falls into "Other" so it stays
+  // reachable — the whole point of this drawer is that nothing is stranded.
+  const grouped = repos.map(r => ({ repo: r, repoSessions: sessionsForRepo(r, sessions) }));
+  const claimed = new Set(grouped.flatMap(g => g.repoSessions.map(s => s.id)));
+  const orphans = sessions.filter(s => !claimed.has(s.id));
+
   return (
     <>
       <div className="mdrawer-backdrop" onClick={onClose} />
-      <nav className="mdrawer-panel" aria-label="Sessions">
-        <div className="mdrawer-repo">{activeRepo?.name ?? '—'}</div>
-        <ul className="mdrawer-list">
-          {sessions.map(s => (
-            <li key={s.id}>
+      <nav className="mdrawer-panel" aria-label="Projects and sessions">
+        <div className="mdrawer-title">Projects</div>
+
+        <div className="mdrawer-list">
+          {grouped.map(({ repo, repoSessions }) => (
+            <div key={repo.id} className="mdrawer-group">
               <button
-                className={'mdrawer-item' + (s.id === activeSessionId ? ' active' : '')}
-                onClick={() => pick(s.id)}
+                className={'mdrawer-project' + (repo.id === activeRepo?.id ? ' active' : '')}
+                aria-current={repo.id === activeRepo?.id ? 'true' : undefined}
+                onClick={() => pickRepo(repo.id)}
               >
-                {s.name}
+                <span className="mdrawer-project-name">{repo.name}</span>
+                <span className="mdrawer-count">{repoSessions.length}</span>
               </button>
-            </li>
+              {repoSessions.map(s => (
+                <button
+                  key={s.id}
+                  className={'mdrawer-item' + (s.id === activeSessionId ? ' active' : '')}
+                  aria-current={s.id === activeSessionId ? 'true' : undefined}
+                  onClick={() => pickSession(s.id)}
+                >
+                  {s.name}
+                </button>
+              ))}
+            </div>
           ))}
-        </ul>
+
+          {orphans.length > 0 && (
+            <div className="mdrawer-group">
+              <div className="mdrawer-project mdrawer-project-static">Other sessions</div>
+              {orphans.map(s => (
+                <button
+                  key={s.id}
+                  className={'mdrawer-item' + (s.id === activeSessionId ? ' active' : '')}
+                  aria-current={s.id === activeSessionId ? 'true' : undefined}
+                  onClick={() => pickSession(s.id)}
+                >
+                  {s.name}
+                </button>
+              ))}
+            </div>
+          )}
+
+          {grouped.length === 0 && orphans.length === 0 && (
+            <div className="mdrawer-empty">No projects open.</div>
+          )}
+        </div>
+
         <button className="mdrawer-new" onClick={() => { onNewSession(); onClose(); }}>+ New session</button>
+        <button className="mdrawer-open" onClick={() => { onAddRepo(); onClose(); }}>+ Open project</button>
         <button className="mdrawer-remote" onClick={() => { onOpenRemote(); onClose(); }}>Remote access…</button>
       </nav>
     </>

--- a/src/renderer/components/shell/mobile/MobileDrawer.tsx
+++ b/src/renderer/components/shell/mobile/MobileDrawer.tsx
@@ -14,11 +14,17 @@ export function MobileDrawer(props: Props) {
   const pickSession = (id: string) => { onSelectSession(id); onClose(); };
   const pickRepo = (id: string) => { onSelectRepo(id); onClose(); };
 
-  // Group sessions under each open project. Any session that doesn't match a
-  // listed project (e.g. its repo was closed) falls into "Other" so it stays
-  // reachable — the whole point of this drawer is that nothing is stranded.
-  const grouped = repos.map(r => ({ repo: r, repoSessions: sessionsForRepo(r, sessions) }));
-  const claimed = new Set(grouped.flatMap(g => g.repoSessions.map(s => s.id)));
+  // Group sessions under each open project, claiming each session exactly once.
+  // (sessionBelongsToRepo can match nested repo paths, so a session could
+  // otherwise appear under two headers — claim-as-we-go dedups across groups.)
+  const claimed = new Set<string>();
+  const grouped = repos.map(r => {
+    const repoSessions = sessionsForRepo(r, sessions).filter(s => !claimed.has(s.id));
+    repoSessions.forEach(s => claimed.add(s.id));
+    return { repo: r, repoSessions };
+  });
+  // Any session not matched by a listed project (rare — e.g. a path mismatch)
+  // stays reachable under "Other" so nothing is stranded.
   const orphans = sessions.filter(s => !claimed.has(s.id));
 
   return (

--- a/src/renderer/components/shell/mobile/MobileShell.css
+++ b/src/renderer/components/shell/mobile/MobileShell.css
@@ -21,3 +21,11 @@
   background: transparent;
   color: var(--v2-accent, #00C9A7);
 }
+.ms-secondary {
+  min-height: 44px;
+  padding: 0 16px;
+  border-radius: 8px;
+  border: 1px solid var(--v2-border-default, rgba(255,255,255,0.08));
+  background: transparent;
+  color: var(--v2-text-secondary, #C0C4D6);
+}

--- a/src/renderer/components/shell/mobile/MobileShell.flow.test.tsx
+++ b/src/renderer/components/shell/mobile/MobileShell.flow.test.tsx
@@ -9,11 +9,19 @@ describe('MobileShell flow', () => {
     const onSelectSession = vi.fn();
     render(
       <MobileShell
-        repos={[]} activeRepo={{ id: 'r1', name: 'demo' } as any}
-        sessions={[{ id: 's1', name: 'work' }, { id: 's2', name: 'build' }] as any}
+        repos={[{ id: 'r1', name: 'demo', path: '/demo' }] as any}
+        activeRepo={{ id: 'r1', name: 'demo', path: '/demo' } as any}
+        sessions={[
+          { id: 's1', name: 'work', mainRepoPath: '/demo', workingDirectory: '/demo' },
+          { id: 's2', name: 'build', mainRepoPath: '/demo', workingDirectory: '/demo' },
+        ] as any}
         activeSessionId="s1"
         onSelectSession={onSelectSession}
-        onCloseSession={() => {}} onNewSession={() => {}} onOpenRemote={() => {}}
+        onSelectRepo={() => {}}
+        onCloseSession={() => {}}
+        onNewSession={() => {}}
+        onAddRepo={() => {}}
+        onOpenRemote={() => {}}
       />
     );
     fireEvent.click(screen.getByRole('button', { name: /open navigation/i }));

--- a/src/renderer/components/shell/mobile/MobileShell.test.tsx
+++ b/src/renderer/components/shell/mobile/MobileShell.test.tsx
@@ -7,7 +7,8 @@ const baseProps = {
   repos: [], activeRepo: { id: 'r1', name: 'demo' } as any,
   sessions: [{ id: 's1', name: 'work' }] as any,
   activeSessionId: 's1',
-  onSelectSession: noop, onCloseSession: noop, onNewSession: noop, onOpenRemote: noop,
+  onSelectSession: noop, onSelectRepo: noop, onCloseSession: noop,
+  onNewSession: noop, onAddRepo: noop, onOpenRemote: noop,
 };
 
 describe('MobileShell', () => {

--- a/src/renderer/components/shell/mobile/MobileShell.test.tsx
+++ b/src/renderer/components/shell/mobile/MobileShell.test.tsx
@@ -16,8 +16,9 @@ describe('MobileShell', () => {
     render(<MobileShell {...baseProps} />);
     expect(screen.getByText('work')).toBeInTheDocument();
   });
-  it('renders an empty state when no repo is active', () => {
+  it('renders an empty state (with Open project) when no repo is active', () => {
     render(<MobileShell {...baseProps} activeRepo={null} sessions={[]} activeSessionId={null} />);
-    expect(screen.getByText(/no repository/i)).toBeInTheDocument();
+    expect(screen.getByText(/no project open/i)).toBeInTheDocument();
+    expect(screen.getByText(/open project/i)).toBeInTheDocument();
   });
 });

--- a/src/renderer/components/shell/mobile/MobileShell.tsx
+++ b/src/renderer/components/shell/mobile/MobileShell.tsx
@@ -14,8 +14,9 @@ export function MobileShell(props: MobileShellProps) {
   if (!activeRepo) {
     return (
       <div className="ms-shell ms-empty">
-        <p>No repository open.</p>
-        <button className="ms-primary" onClick={props.onOpenRemote}>Remote access…</button>
+        <p>No project open.</p>
+        <button className="ms-primary" onClick={props.onAddRepo}>+ Open project</button>
+        <button className="ms-secondary" onClick={props.onOpenRemote}>Remote access…</button>
       </div>
     );
   }

--- a/src/renderer/components/shell/mobile/nav-utils.test.ts
+++ b/src/renderer/components/shell/mobile/nav-utils.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest';
+import { repoIdForSession } from './nav-utils';
+
+const repos = [
+  { id: 'r1', name: 'demo', path: '/demo' },
+  { id: 'r2', name: 'api', path: '/api' },
+] as any;
+
+const sessions = [
+  { id: 's1', name: 'work', mainRepoPath: '/demo', workingDirectory: '/demo' },
+  { id: 's2', name: 'tests', mainRepoPath: '/api', workingDirectory: '/api' },
+  { id: 's3', name: 'nested', workingDirectory: '/demo/packages/app' }, // path-prefix match
+] as any;
+
+describe('repoIdForSession', () => {
+  it('maps a session to its owning repo via mainRepoPath', () => {
+    expect(repoIdForSession(repos, sessions, 's1')).toBe('r1');
+    expect(repoIdForSession(repos, sessions, 's2')).toBe('r2');
+  });
+  it('maps via working-directory path prefix', () => {
+    expect(repoIdForSession(repos, sessions, 's3')).toBe('r1');
+  });
+  it('returns undefined for an unknown session id', () => {
+    expect(repoIdForSession(repos, sessions, 'nope')).toBeUndefined();
+  });
+  it('returns undefined when no repo matches (orphan session)', () => {
+    const orphan = [{ id: 'x', name: 'x', workingDirectory: '/somewhere/else' }] as any;
+    expect(repoIdForSession(repos, orphan, 'x')).toBeUndefined();
+  });
+});

--- a/src/renderer/components/shell/mobile/nav-utils.ts
+++ b/src/renderer/components/shell/mobile/nav-utils.ts
@@ -1,0 +1,18 @@
+import type { Repo } from '../../../hooks/useRepos';
+import type { TabData } from '../../ui/Tab';
+import { sessionBelongsToRepo } from '../RepoActivityBar';
+
+/**
+ * The id of the repo a session belongs to, among `repos` (first match), or
+ * undefined if the session is unknown or matches none of them. Used by the
+ * mobile drawer so tapping a session can make its project active.
+ */
+export function repoIdForSession(
+  repos: Repo[],
+  sessions: TabData[],
+  sessionId: string,
+): string | undefined {
+  const session = sessions.find(s => s.id === sessionId);
+  if (!session) return undefined;
+  return repos.find(r => sessionBelongsToRepo(r.path, session))?.id;
+}

--- a/src/renderer/components/shell/mobile/types.ts
+++ b/src/renderer/components/shell/mobile/types.ts
@@ -6,8 +6,13 @@ export interface MobileShellProps {
   activeRepo: Repo | null;
   sessions: TabData[];
   activeSessionId: string | null;
+  /** Switch to a session and make its project active. */
   onSelectSession: (id: string) => void;
+  /** Switch the active project (repo). */
+  onSelectRepo: (id: string) => void;
   onCloseSession: (id: string) => void;
   onNewSession: () => void;
+  /** Open/clone a new project (the Add-Repo sheet). */
+  onAddRepo: () => void;
   onOpenRemote: () => void;
 }


### PR DESCRIPTION
## What & why

Follow-up to the v2.3.0 remote/mobile UX. On a phone there was **no way to switch projects**, and selecting a session from another project left the active project stale — so multi-project work was effectively stuck. This makes the mobile drawer a real navigator.

## Changes

- **Grouped drawer** — every open project shows as a tappable header with its sessions grouped beneath (and a session count).
  - Tap a **project** → switches the active repo (jumps to its latest session).
  - Tap a **session** → switches to it *and* makes its project active (fixes the stale-`activeRepo` bug via a new `handleMobileSelectSession` + a tested `repoIdForSession` helper).
- **+ Open project** — opens the existing Add-Repo sheet (clone / open-folder), including from the zero-repo empty state (previously only offered "Remote access…").
- **Uses the open-projects set** (`visibleRepos`) like every other switcher, not the full scanned repo list.
- **Dedup** — each session renders under exactly one project (guards the nested-repo-path edge); unmatched sessions stay reachable under "Other sessions".
- **Layering fix** — the drawer is now portaled to `document.body` above `TerminalHost`'s fixed terminal overlay. Previously it lived inside `MobileShell`'s stacking context (below the overlay), so the terminal painted over it and only a top strip showed. (This latent bug also affected the v2.3.0 drawer.)

## Scope / safety

- Renderer-only. **No IPC / no `ipc-contract.ts` changes.**
- Desktop path untouched — the new handler and drawer are reached only via the touch-mode `MobileShell` branch; desktop `handleSelectSession` is unchanged (App-level regression test still asserts desktop renders `.p4-shell`, never `MobileShell`).

## Testing

- **490 tests pass** (52 files); typecheck (renderer + main) + build clean.
- New/updated unit tests: `repoIdForSession` owner-resolution, grouped drawer (project switch, cross-project session select, open-project, "Other sessions" reachability), empty-state open-project.
- **Verified on-device (iPhone Safari):** drawer opens as a full-height panel over a dimmed terminal; project + session switching and the portal layering fix confirmed on real hardware.

## Known minor follow-ups (non-blocking)
- Tapping an opened-but-empty project shows the previous session's terminal until you start one (could add a "no sessions — start one" state).
- Session rows use `div`s rather than `ul/li` (minor screen-reader nicety).

🤖 Generated with [Claude Code](https://claude.com/claude-code)