### PR TITLE
docs(readme): note remote access prerequisites

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,8 @@ Before installing OmniDesk, ensure you have:
 
 > **Optional:** install the [Codex CLI](https://github.com/openai/codex) to enable the Codex provider — OmniDesk detects it automatically.
 
+> **Remote Access (optional):** no extra install needed — OmniDesk offers to download `cloudflared` for you when you start the managed tunnel. Requires an internet connection for the Cloudflare tunnel. If you run from source, launch via `npm start` (not a dev command) so the built UI exists for the remote server to serve.
+
 ---
 
 ## Installation


### PR DESCRIPTION
## Summary

The README **Prerequisites** section listed Node.js, Claude Code CLI, credentials, and (optionally) Codex — but nothing for **Remote Access**, which landed in v2.2.0. This adds a short note under Prerequisites.

There's no *install-time* prerequisite to add (the managed tunnel auto-downloads `cloudflared`), so the note instead surfaces the genuine runtime requirements a user should know up front:

- `cloudflared` is auto-downloaded on request — no manual install
- Needs an internet connection for the Cloudflare tunnel (`trycloudflare.com`)
- **From-source runs must use `npm start`** (a production build), or the remote server 404s with "renderer build not found" — it serves the built `dist/renderer` (`remote-access-server.ts:83,212`)

## Changes

- `README.md`: add a "Remote Access (optional)" note to the Prerequisites section

🤖 Generated with [Claude Code](https://claude.com/claude-code)