### PR TITLE
fix(terminal): defer CLI launch until first resize to prevent garbled startup

### DIFF
--- a/src/main/cli-manager.test.ts
+++ b/src/main/cli-manager.test.ts
@@ -20,6 +20,14 @@ function getWrite(): ReturnType<typeof vi.fn> {
   const ptyInstance = spawnMock.mock.results[spawnMock.mock.results.length - 1].value;
   return ptyInstance.write;
 }
+function getResize(): ReturnType<typeof vi.fn> {
+  const spawnMock = pty.spawn as unknown as ReturnType<typeof vi.fn>;
+  const ptyInstance = spawnMock.mock.results[spawnMock.mock.results.length - 1].value;
+  return ptyInstance.resize;
+}
+function writtenText(): string {
+  return getWrite().mock.calls.map((c: string[]) => c[0]).join('');
+}
 
 describe('CLIManager shell sessions', () => {
   beforeEach(() => vi.clearAllMocks());
@@ -39,5 +47,72 @@ describe('CLIManager shell sessions', () => {
     await mgr.spawnShellSession();
     getOnData()('Welcome to Claude Code\nSonnet 4.6\nTips for getting started');
     expect(onModel).not.toHaveBeenCalled();
+  });
+
+  it('shell session resize never launches a provider command', async () => {
+    const mgr = new CLIManager({ workingDirectory: '/tmp', permissionMode: 'standard', kind: 'shell' });
+    await mgr.spawnShellSession();
+    mgr.resize({ cols: 180, rows: 50 });
+    expect(getResize()).toHaveBeenCalledWith(180, 50);
+    expect(writtenText()).not.toContain('claude');
+  });
+});
+
+describe('CLIManager deferred provider launch', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('spawn does not launch the provider until the first resize arrives', async () => {
+    const mgr = new CLIManager({ workingDirectory: '/tmp', permissionMode: 'standard' });
+    await mgr.spawn();
+    expect(mgr.isInitialized).toBe(true);
+    // Provider CLI must NOT be launched yet — we wait for the real terminal size.
+    expect(writtenText()).not.toContain('claude');
+
+    // First resize sizes the PTY correctly, THEN releases the launch.
+    mgr.resize({ cols: 180, rows: 50 });
+    expect(getResize()).toHaveBeenCalledWith(180, 50);
+    expect(writtenText()).toContain('claude');
+  });
+
+  it('resizes the PTY before writing the launch command', async () => {
+    const mgr = new CLIManager({ workingDirectory: '/tmp', permissionMode: 'standard' });
+    await mgr.spawn();
+    mgr.resize({ cols: 200, rows: 60 });
+
+    const resizeOrder = getResize().mock.invocationCallOrder[0];
+    const claudeWrite = getWrite().mock.calls.find((c: string[]) => c[0].includes('claude'));
+    expect(claudeWrite).toBeDefined();
+    const claudeWriteIdx = getWrite().mock.calls.indexOf(claudeWrite!);
+    const claudeWriteOrder = getWrite().mock.invocationCallOrder[claudeWriteIdx];
+    expect(resizeOrder).toBeLessThan(claudeWriteOrder);
+  });
+
+  it('launches the provider command exactly once across multiple resizes', async () => {
+    const mgr = new CLIManager({ workingDirectory: '/tmp', permissionMode: 'standard' });
+    await mgr.spawn();
+    mgr.resize({ cols: 180, rows: 50 });
+    mgr.resize({ cols: 120, rows: 40 });
+    mgr.resize({ cols: 200, rows: 60 });
+
+    const launchCount = writtenText().split('claude').length - 1;
+    expect(launchCount).toBe(1);
+  });
+
+  it('falls back to launching without a resize after the timeout', async () => {
+    vi.useFakeTimers();
+    try {
+      const mgr = new CLIManager({ workingDirectory: '/tmp', permissionMode: 'standard' });
+      const spawnPromise = mgr.spawn();
+      // createPtyProcess waits ~150ms for shell readiness.
+      await vi.advanceTimersByTimeAsync(200);
+      await spawnPromise;
+      expect(writtenText()).not.toContain('claude');
+
+      // No resize ever arrives (e.g. pane hidden at create) — fallback fires.
+      await vi.advanceTimersByTimeAsync(600);
+      expect(writtenText()).toContain('claude');
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/src/main/cli-manager.ts
+++ b/src/main/cli-manager.ts
@@ -192,6 +192,13 @@ export class CLIManager {
   private options: CLIManagerOptions;
   private _isRunning: boolean = false;
   private _isInitialized: boolean = false;
+  // Deferred provider launch: the CLI (e.g. `claude`) is launched only once the
+  // renderer reports the real terminal size, so it never paints its startup UI
+  // at the default 80×24 and then reflows garbled. See armDeferredLaunch().
+  private launchDeferred: boolean = false;
+  private providerLaunched: boolean = false;
+  private launchTimer: NodeJS.Timeout | null = null;
+  private readonly LAUNCH_FALLBACK_MS = 500; // launch anyway if no resize arrives
   private currentModel: ClaudeModel | null = null;
   private initialDetectionBuffer: string = '';
   private initialDetectionDone: boolean = false;
@@ -259,10 +266,10 @@ export class CLIManager {
       this.write(`cd '${escapedDir}'\r`);
     }
 
-    this.launchProviderCommand();
+    this.armDeferredLaunch();
     this._isInitialized = true;
 
-    // Wait for Claude to launch
+    // Brief settle for the pool shell before the (deferred) provider launch.
     await new Promise(resolve => setTimeout(resolve, 200));
   }
 
@@ -272,8 +279,34 @@ export class CLIManager {
    */
   async spawn(): Promise<void> {
     await this.createPtyProcess();
-    this.launchProviderCommand();
+    this.armDeferredLaunch();
     this._isInitialized = true;
+  }
+
+  /**
+   * Arm a deferred provider launch. Rather than running `claude` immediately
+   * into the default 80×24 PTY, we wait for the renderer's first resize (which
+   * carries the real terminal dimensions) and launch then — so the CLI renders
+   * its startup UI at the correct width instead of painting at 80 cols and
+   * leaving a garbled frame until the user manually resizes the window.
+   *
+   * A fallback timer launches anyway if no resize arrives (e.g. the pane is
+   * hidden at create time), preserving the previous behaviour as a floor.
+   */
+  private armDeferredLaunch(): void {
+    this.launchDeferred = true;
+    this.launchTimer = setTimeout(() => this.launchProviderCommandOnce(), this.LAUNCH_FALLBACK_MS);
+  }
+
+  /** Launch the provider command exactly once; cancels the fallback timer. */
+  private launchProviderCommandOnce(): void {
+    if (!this.launchDeferred || this.providerLaunched) return;
+    this.providerLaunched = true;
+    if (this.launchTimer) {
+      clearTimeout(this.launchTimer);
+      this.launchTimer = null;
+    }
+    this.launchProviderCommand();
   }
 
   /**
@@ -534,12 +567,20 @@ export class CLIManager {
   resize(size: TerminalSize): void {
     if (this.ptyProcess && this._isRunning) {
       this.ptyProcess.resize(size.cols, size.rows);
+      // The first real resize releases the deferred provider launch, so the CLI
+      // starts at the correct dimensions. Idempotent for later resizes and a
+      // no-op for shell sessions (which never arm a deferred launch).
+      this.launchProviderCommandOnce();
     }
   }
 
   destroy(): void {
     this._isRunning = false;
     this._isInitialized = false;
+    if (this.launchTimer) {
+      clearTimeout(this.launchTimer);
+      this.launchTimer = null;
+    }
     if (this.flushTimeout) {
       clearTimeout(this.flushTimeout);
       this.flushTimeout = null;


### PR DESCRIPTION
## Problem

When opening a session, the CLI screen frequently rendered garbled (duplicated/overflowing text, prompt box wider than the viewport) until the OmniDesk window was manually resized, which repainted it cleanly.

| Before resize | After manual resize |
|---|---|
| garbled 80-col paint reflowed into a wider grid | clean full repaint |

## Root cause

The PTY is spawned at a hardcoded **80×24** (`cli-manager.ts`), and `claude` is launched into it **immediately** — before the renderer reports the real terminal size. The real dimensions only arrive later via an async `session:resize` after the React `Terminal` mounts. So the CLI painted its startup UI at 80 columns; the late resize + xterm reflow left a garbled frame that only a fresh manual resize (a clean `fit → resize → SIGWINCH`) fully repainted.

This is the classic embedded-terminal anti-pattern (spawn at 80×24, correct size afterward) — not a Claude Code bug.

## Fix

Defer the provider launch until the terminal's real size is known:

- `spawn()` / `initializeSession()` now **arm** a deferred launch instead of running `claude` immediately.
- `resize()` applies the PTY dimensions **then** releases the launch, so the CLI starts at the correct width and renders correctly on the first frame — nothing to clean up.
- A **500 ms fallback timer** launches anyway if no resize ever arrives (e.g. a hidden pane), so the worst case equals prior behavior.
- Idempotent across subsequent resizes; **no-op for shell sessions** (they never arm a launch, so Ctrl+C pass-through is untouched).

## Testing

- 5 new tests in `cli-manager.test.ts` (written first, failed against old code): deferral, resize-releases-launch, resize-before-write ordering, launch-once across multiple resizes, and fallback-timeout.
- Full main + shared suites pass (**302 tests**); `tsc -p tsconfig.main.json` clean.

## Manual verification

Requires a main-process rebuild (`npm run build:electron` / `npm run start`) since this is main-side. Open a fresh session and confirm the display is clean from the start with no manual resize.

🤖 Generated with [Claude Code](https://claude.com/claude-code)