### PR TITLE
docs(claude): require branching from up-to-date main for all new work

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,9 +2,16 @@
 
 Multi-provider Electron desktop application for AI coding CLIs. Organizes work around a flat repo→session model: an activity bar for switching repositories, a session rail for navigating sessions within a repo, and a terminal host that fills the main view. Supports Claude Code, Codex CLI, and future providers via a pluggable provider abstraction layer.
 
-## Workflow Rule
+## Workflow Rules
 
 **Always run the `requirements-clarifier` agent (via the Task tool) on the user's initial prompt before planning or implementing.** This ensures requirements are analyzed, ambiguities are surfaced, and acceptance criteria are established before any work begins. Skip only for trivial tasks (typo fixes, single-line changes, or purely informational questions).
+
+**Always start new work on a fresh branch cut from an up-to-date `main`.** For any new feature, issue, or bug fix, before writing code:
+1. `git fetch origin` (pull the latest `main` first — never branch from a stale local `main`).
+2. Create the working branch off the freshly-fetched `main`: `git checkout -b <type>/<short-desc> origin/main` (e.g. `fix/terminal-initial-size-garble`, `feat/session-search`).
+3. Do all work for that item on this one branch, then open a PR against `main`.
+
+Never commit work directly to `main`, and never build a fix on top of an unrelated feature branch — if you're already on another branch with uncommitted changes, stash them, branch from `origin/main`, then restore. Skip only when the user explicitly asks to work on the current branch.
 
 ## Tech Stack
 


### PR DESCRIPTION
## What

Adds a workflow rule to `CLAUDE.md`: for any new feature, issue, or bug fix, fetch `origin` and cut the working branch from the freshly-pulled `main` before writing code — one branch per item, PR against `main`.

Key points:
- `git fetch origin` first — never branch from a stale local `main`.
- `git checkout -b <type>/<short-desc> origin/main`.
- Never commit to `main`; never stack a fix on an unrelated feature branch (stash → branch from `origin/main` → restore).

Also renames the section from "Workflow Rule" to "Workflow Rules" since it now holds two.

## Why

Formalizes the branching flow so new work always starts from current `main`, avoiding drift and accidental commits onto the wrong branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)