### PR TITLE
fix(terminal): eliminate ConPTY scrollback ghosting on Windows

### DIFF
--- a/src/main/cli-manager.test.ts
+++ b/src/main/cli-manager.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import * as pty from 'node-pty';
 
 // Stop the fresh-env probe from shelling out to powershell/login shell.
@@ -55,6 +55,94 @@ describe('CLIManager shell sessions', () => {
     mgr.resize({ cols: 180, rows: 50 });
     expect(getResize()).toHaveBeenCalledWith(180, 50);
     expect(writtenText()).not.toContain('claude');
+  });
+});
+
+describe('CLIManager Windows ConPTY rendering workarounds', () => {
+  const realPlatform = Object.getOwnPropertyDescriptor(process, 'platform')!;
+  const setPlatform = (value: string) =>
+    Object.defineProperty(process, 'platform', { value, configurable: true });
+
+  beforeEach(() => vi.clearAllMocks());
+  afterEach(() => Object.defineProperty(process, 'platform', realPlatform));
+
+  function spawnOptions(): Record<string, unknown> {
+    const spawnMock = pty.spawn as unknown as ReturnType<typeof vi.fn>;
+    return spawnMock.mock.calls[spawnMock.mock.calls.length - 1][2];
+  }
+
+  it('opts into the bundled Windows Terminal ConPTY on win32', async () => {
+    setPlatform('win32');
+    const mgr = new CLIManager({ workingDirectory: '/tmp', permissionMode: 'standard' });
+    await mgr.spawn();
+    expect(spawnOptions().useConptyDll).toBe(true);
+  });
+
+  it('sets Claude full-repaint + synchronized-output env vars on win32', async () => {
+    setPlatform('win32');
+    const mgr = new CLIManager({ workingDirectory: '/tmp', permissionMode: 'standard' });
+    await mgr.spawn();
+    const env = spawnOptions().env as Record<string, string>;
+    expect(env.CLAUDE_CODE_ALT_SCREEN_FULL_REPAINT).toBe('1');
+    expect(env.CLAUDE_CODE_FORCE_SYNC_OUTPUT).toBe('1');
+  });
+
+  it('leaves non-Windows spawns untouched', async () => {
+    setPlatform('linux');
+    const mgr = new CLIManager({ workingDirectory: '/tmp', permissionMode: 'standard' });
+    await mgr.spawn();
+    const opts = spawnOptions();
+    expect('useConptyDll' in opts).toBe(false);
+    const env = opts.env as Record<string, string>;
+    expect(env.CLAUDE_CODE_ALT_SCREEN_FULL_REPAINT).toBeUndefined();
+    expect(env.CLAUDE_CODE_FORCE_SYNC_OUTPUT).toBeUndefined();
+  });
+
+  it('answers the bundled ConPTY startup DA1 query from main and strips it', async () => {
+    setPlatform('win32');
+    const mgr = new CLIManager({ workingDirectory: '/tmp', permissionMode: 'standard' });
+    await mgr.spawn();
+    const chunks: string[] = [];
+    mgr.onOutput(d => chunks.push(d));
+
+    // The modern conpty.dll's real startup burst (captured from node-pty).
+    getOnData()('\x1b[1t\x1b[c\x1b[?1004h\x1b[?9001h');
+    await new Promise(r => setTimeout(r, 30));
+
+    expect(writtenText()).toContain('\x1b[?1;2c');            // main answered
+    expect(chunks.join('')).not.toContain('\x1b[c');          // query stripped
+    expect(chunks.join('')).toContain('\x1b[?1004h');         // rest untouched
+  });
+
+  it('stops scanning for DA1 after the startup window', async () => {
+    setPlatform('win32');
+    const mgr = new CLIManager({ workingDirectory: '/tmp', permissionMode: 'standard' });
+    await mgr.spawn();
+    const chunks: string[] = [];
+    mgr.onOutput(d => chunks.push(d));
+
+    const onData = getOnData();
+    for (let i = 0; i < 16; i++) onData('regular output\r\n');
+    const writesBefore = getWrite().mock.calls.length;
+    onData('\x1b[c'); // e.g. an app-level DA1 passed through post-startup
+    await new Promise(r => setTimeout(r, 30));
+
+    expect(getWrite().mock.calls.length).toBe(writesBefore);  // no auto-reply
+    expect(chunks.join('')).toContain('\x1b[c');              // passes through
+  });
+
+  it('does not intercept DA1 on non-Windows', async () => {
+    setPlatform('linux');
+    const mgr = new CLIManager({ workingDirectory: '/tmp', permissionMode: 'standard' });
+    await mgr.spawn();
+    const chunks: string[] = [];
+    mgr.onOutput(d => chunks.push(d));
+
+    getOnData()('\x1b[c');
+    await new Promise(r => setTimeout(r, 30));
+
+    expect(writtenText()).not.toContain('\x1b[?1;2c');
+    expect(chunks.join('')).toContain('\x1b[c');
   });
 });
 

--- a/src/main/cli-manager.ts
+++ b/src/main/cli-manager.ts
@@ -199,6 +199,12 @@ export class CLIManager {
   private providerLaunched: boolean = false;
   private launchTimer: NodeJS.Timeout | null = null;
   private readonly LAUNCH_FALLBACK_MS = 500; // launch anyway if no resize arrives
+  // The bundled conpty.dll (useConptyDll) probes terminal capabilities at
+  // startup with a DA1 query (`ESC [ c`) and withholds output ~3s when no
+  // reply arrives. Agent sessions buffer output away from xterm until the
+  // CLI is detected as ready, so xterm can't answer in time — main answers
+  // instead. Counts down chunks scanned; 0 = disarmed.
+  private da1ScanChunksLeft = 0;
   private currentModel: ClaudeModel | null = null;
   private initialDetectionBuffer: string = '';
   private initialDetectionDone: boolean = false;
@@ -354,6 +360,16 @@ export class CLIManager {
       ...cleanEnv,
       TERM: 'xterm-256color',
       COLORTERM: 'truecolor',
+      // ConPTY can coalesce Claude Code's incremental (changed-cells-only)
+      // repaints incorrectly, freezing fragments of old frames into xterm
+      // scrollback. Full repaint + DEC 2026 synchronized output make each
+      // frame atomic. Set at the PTY level (not the provider) so a `claude`
+      // launched manually in a shell session is covered too; other CLIs
+      // ignore these vars.
+      ...(process.platform === 'win32' ? {
+        CLAUDE_CODE_ALT_SCREEN_FULL_REPAINT: '1',
+        CLAUDE_CODE_FORCE_SYNC_OUTPUT: '1',
+      } : {}),
     };
     if (this.options.provider) {
       // Use provider-supplied env vars (provider is responsible for agent teams flag)
@@ -374,12 +390,21 @@ export class CLIManager {
       rows: 24,
       cwd: this.options.workingDirectory,
       env: ptyEnv,
+      // Use node-pty's bundled Windows Terminal conpty.dll instead of the
+      // OS in-box conhost — it carries years of rendering/passthrough fixes
+      // for the scrollback ghosting that TUI diff-repaints trigger.
+      ...(process.platform === 'win32' ? { useConptyDll: true } : {}),
     });
 
     this._isRunning = true;
 
+    // Arm the DA1 responder for the bundled ConPTY's startup probe (win32
+    // only — matches the useConptyDll spawn option above). 16 chunks is far
+    // past the probe, which arrives in the very first chunk.
+    this.da1ScanChunksLeft = process.platform === 'win32' ? 16 : 0;
+
     this.ptyProcess.onData((data: string) => {
-      this.bufferOutput(data);
+      this.bufferOutput(this.interceptConptyDa1(data));
     });
 
     this.ptyProcess.onExit(({ exitCode }) => {
@@ -534,6 +559,23 @@ export class CLIManager {
     this.initialDetectionDone = false;
     this.switchDetectionBuffer = '';
     this.currentModel = null;
+  }
+
+  /**
+   * Answer the bundled ConPTY's startup DA1 capability query on xterm's
+   * behalf (same reply xterm.js sends) and strip it from the stream, so a
+   * late second reply from xterm never lands as shell/CLI input. Scanning
+   * disarms after the startup window; later app-level DA1 queries pass
+   * through to the terminal untouched.
+   */
+  private interceptConptyDa1(data: string): string {
+    if (this.da1ScanChunksLeft <= 0) return data;
+    this.da1ScanChunksLeft--;
+    const idx = data.indexOf('\x1b[c');
+    if (idx === -1) return data;
+    this.da1ScanChunksLeft = 0;
+    this.ptyProcess?.write('\x1b[?1;2c');
+    return data.slice(0, idx) + data.slice(idx + 3);
   }
 
   /**


### PR DESCRIPTION
## Problem

In long Claude sessions, scrolling up revealed leftover text fragments in the leftmost columns of the terminal (prefixes of spinner/status lines like `Pr`, `Wh`, `To`, `o`).

**Root cause:** Claude Code's TUI repaints its live region incrementally (changed cells only, via cursor positioning). The OS in-box ConPTY is documented to coalesce these positioned writes incorrectly, leaving characters of older frames behind. Once a mangled line scrolls out of the live viewport into xterm.js scrollback, nothing ever repaints it — the residue is permanent. See [Claude Code fullscreen rendering docs](https://code.claude.com/docs/en/fullscreen) (ConPTY-backed hosts called out explicitly).

## Fix (all in `CLIManager`, win32-gated)

1. **`useConptyDll: true`** on `pty.spawn` — switches to node-pty's bundled Windows Terminal ConPTY (years of rendering/passthrough fixes vs the in-box conhost; same switch VS Code exposes).
2. **`CLAUDE_CODE_ALT_SCREEN_FULL_REPAINT=1` + `CLAUDE_CODE_FORCE_SYNC_OUTPUT=1`** in the PTY env — Anthropic's documented workaround; frames repaint fully/atomically instead of diffing. Set at the PTY level (not the provider) so `claude` launched manually in a shell session is covered; other CLIs ignore the vars.
3. **DA1 startup probe answered in main** — the bundled ConPTY queries terminal capabilities at startup and withholds output ~3s without a reply. Agent sessions buffer output away from xterm until CLI readiness, so xterm can't answer in time. CLIManager now replies (`ESC[?1;2c`, same as xterm.js) and strips the query so xterm never sends a late duplicate that would land as CLI input. Measured: first output at **194ms vs 3150ms**.

## Verification

- 6 new unit tests: spawn option, env vars, non-Windows untouched, DA1 answered+stripped, scan-window disarm, non-Windows passthrough
- Full suite: 53 files / 508 tests green; `tsc` (renderer+shared and main), `build:electron`, and `vite build` all clean
- Live smoke tests against the real bundled `conpty.dll`: spawn works, output renders, no startup stall

## Notes

- Artifacts already baked into an existing session's scrollback can't be cleaned retroactively; the fix prevents new ones.
- Packaged builds ship `conpty.dll` + `OpenConsole.exe` from `node-pty/build/Release/conpty/` (present in npm build output).

🤖 Generated with [Claude Code](https://claude.com/claude-code)