### PR TITLE
feat(cockpit): the attention router — session-state classifier + cross-repo cockpit (Phases 1-3)

### DIFF
--- a/src/main/cli-manager.ts
+++ b/src/main/cli-manager.ts
@@ -627,6 +627,12 @@ export class CLIManager {
       clearTimeout(this.flushTimeout);
       this.flushTimeout = null;
     }
+    // Drop callbacks BEFORE killing the pty so a late node-pty exit event from
+    // a deliberately-destroyed manager can't deliver a stale exit/output to a
+    // session that may already have a replacement manager.
+    this.exitCallback = null;
+    this.outputCallback = null;
+    this.modelChangeCallback = null;
     if (this.ptyProcess) {
       this.ptyProcess.kill();
       this.ptyProcess = null;

--- a/src/main/providers/claude-provider.test.ts
+++ b/src/main/providers/claude-provider.test.ts
@@ -230,3 +230,26 @@ describe('ClaudeProvider', () => {
     });
   });
 });
+
+describe('ClaudeProvider.getStateSignals', () => {
+  const provider = new ClaudeProvider();
+  const sig = provider.getStateSignals();
+  const anyMatch = (table: RegExp[], s: string) => table.some(re => { re.lastIndex = 0; return re.test(s); });
+
+  it('working does NOT match a bare middle-dot (would pin every session to working)', () => {
+    expect(anyMatch(sig.working, '1,234 tokens · $0.12')).toBe(false);
+    expect(anyMatch(sig.working, 'esc to interrupt')).toBe(true);
+  });
+
+  it('approval matches the numbered Yes triad / selector but not generic prose', () => {
+    expect(anyMatch(sig.approval, '❯ 1. Yes\n  2. Yes, and\n  3. No')).toBe(true);
+    expect(anyMatch(sig.approval, 'Do you want to run the migration now, or wait?')).toBe(false);
+  });
+
+  it('fatalError matches a real banner but not casual prose about errors', () => {
+    expect(anyMatch(sig.fatalError, 'API Error: Request timed out')).toBe(true);
+    expect(anyMatch(sig.fatalError, 'usage limit reached')).toBe(true);
+    expect(anyMatch(sig.fatalError, 'I fixed the API Error case in the handler')).toBe(false);
+    expect(anyMatch(sig.fatalError, 'we should add rate limiting here')).toBe(false);
+  });
+});

--- a/src/main/providers/claude-provider.ts
+++ b/src/main/providers/claude-provider.ts
@@ -10,38 +10,44 @@ import type { StateSignals } from '../../shared/session-state-types';
 // State-classifier marker tables for Claude Code's TUI. Matched against the
 // line-reduced, ANSI-stripped tail of the session's output.
 const CLAUDE_STATE_SIGNALS: StateSignals = {
-  // Shown while a turn/tool call is in flight — a strong "still busy" signal
-  // that survives in-place repaints, so it also vetoes premature done/idle.
+  // In-flight markers that survive in-place repaints. "esc to interrupt" is the
+  // reliable one; the spinner glyphs are the distinctive star + braille frames.
+  // A bare middle-dot '·' is deliberately NOT here — it appears in ordinary
+  // output/footers and would pin every session to 'working'.
   working: [
     /esc to interrupt/i,
     /\besc\b\s+to\s+interrupt/i,
-    // Braille + star spinner glyphs Claude animates while thinking.
     /[⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏]/,
-    /[✻✽✳✢·]/,
+    /[✻✽✳✢]/,
   ],
-  // Permission / trust prompts. Anchored to the tail end by the detector, so
-  // these fire only when the prompt is the current bottom-of-screen state.
+  // Permission / trust prompts, anchored to the tail end by the detector. The
+  // structural numbered selector is the strong, box-specific signal; the verb
+  // list is kept box-specific ('proceed' / 'make this edit') — generic verbs
+  // like run/create/continue were dropped because they appear in agent prose.
   approval: [
-    /Do you want to (proceed|make this edit|create|run|apply|continue)/i,
-    /Do you trust the files in this folder/i,
-    // The interactive selector sitting on the "Yes" option.
     /❯\s*1\.\s*Yes/,
-    // The numbered Yes / Yes-and triad that only the approval box renders.
     /\b1\.\s*Yes\b[\s\S]{0,120}\b2\.\s*Yes,/i,
+    /Do you want to (proceed|make this edit)\b/i,
+    /Do you trust the files in this folder/i,
   ],
   // Explicit "your turn to type" prompts distinct from a bare idle prompt box.
   awaitingInput: [
     /Press Enter to continue/i,
     /\bwaiting for your (input|response)\b/i,
   ],
-  // Fatal banners — narrow on purpose so an agent merely printing "error"
-  // while debugging does not trip this (also gated on quiescence by the detector).
+  // Fatal banners anchored to their real framing (start-of-line / banner shape)
+  // so ordinary prose about "the API Error case" or "rate limiting" doesn't trip
+  // 'errored'. Includes the subscription usage-limit hard block.
   fatalError: [
-    /API Error/i,
+    /^\s*(⎿\s*)?API Error[:\s(]/im,
     /Credit balance is too low/i,
-    /\brate limit(?:ed|s)?\b/i,
+    /rate_limit_error/i,
+    /You have exceeded your rate limit/i,
     /overloaded_error/i,
     /Invalid API key/i,
+    /usage limit reached/i,
+    /\b\d+-hour limit reached\b/i,
+    /approaching (?:your )?usage limit/i,
   ],
 };
 

--- a/src/main/providers/claude-provider.ts
+++ b/src/main/providers/claude-provider.ts
@@ -5,6 +5,45 @@ import { CLAUDE_READY_PATTERNS } from '../../shared/claude-detector';
 import { WELCOME_PATTERNS, SWITCH_PATTERNS } from '../../shared/model-detector';
 import type { AgentViewAvailability } from '../../shared/types/agent-view-types';
 import type { LaunchMode } from '../../shared/ipc-types';
+import type { StateSignals } from '../../shared/session-state-types';
+
+// State-classifier marker tables for Claude Code's TUI. Matched against the
+// line-reduced, ANSI-stripped tail of the session's output.
+const CLAUDE_STATE_SIGNALS: StateSignals = {
+  // Shown while a turn/tool call is in flight — a strong "still busy" signal
+  // that survives in-place repaints, so it also vetoes premature done/idle.
+  working: [
+    /esc to interrupt/i,
+    /\besc\b\s+to\s+interrupt/i,
+    // Braille + star spinner glyphs Claude animates while thinking.
+    /[⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏]/,
+    /[✻✽✳✢·]/,
+  ],
+  // Permission / trust prompts. Anchored to the tail end by the detector, so
+  // these fire only when the prompt is the current bottom-of-screen state.
+  approval: [
+    /Do you want to (proceed|make this edit|create|run|apply|continue)/i,
+    /Do you trust the files in this folder/i,
+    // The interactive selector sitting on the "Yes" option.
+    /❯\s*1\.\s*Yes/,
+    // The numbered Yes / Yes-and triad that only the approval box renders.
+    /\b1\.\s*Yes\b[\s\S]{0,120}\b2\.\s*Yes,/i,
+  ],
+  // Explicit "your turn to type" prompts distinct from a bare idle prompt box.
+  awaitingInput: [
+    /Press Enter to continue/i,
+    /\bwaiting for your (input|response)\b/i,
+  ],
+  // Fatal banners — narrow on purpose so an agent merely printing "error"
+  // while debugging does not trip this (also gated on quiescence by the detector).
+  fatalError: [
+    /API Error/i,
+    /Credit balance is too low/i,
+    /\brate limit(?:ed|s)?\b/i,
+    /overloaded_error/i,
+    /Invalid API key/i,
+  ],
+};
 
 export class ClaudeProvider implements IProvider {
   /**
@@ -112,6 +151,15 @@ export class ClaudeProvider implements IProvider {
     return {
       welcome: [...WELCOME_PATTERNS],
       switch: [...SWITCH_PATTERNS],
+    };
+  }
+
+  getStateSignals(): StateSignals {
+    return {
+      working: [...CLAUDE_STATE_SIGNALS.working],
+      approval: [...CLAUDE_STATE_SIGNALS.approval],
+      awaitingInput: [...CLAUDE_STATE_SIGNALS.awaitingInput],
+      fatalError: [...CLAUDE_STATE_SIGNALS.fatalError],
     };
   }
 

--- a/src/main/providers/codex-provider.test.ts
+++ b/src/main/providers/codex-provider.test.ts
@@ -109,3 +109,19 @@ describe('CodexProvider', () => {
     });
   });
 });
+
+describe('CodexProvider.getStateSignals', () => {
+  const provider = new CodexProvider();
+  const sig = provider.getStateSignals();
+  const anyMatch = (table: RegExp[], s: string) => table.some(re => { re.lastIndex = 0; return re.test(s); });
+
+  it('working matches a standalone status line but not the bare words in prose', () => {
+    expect(anyMatch(sig.working, 'Thinking…')).toBe(true);
+    expect(anyMatch(sig.working, 'the tests are working now')).toBe(false);
+  });
+
+  it('fatalError does not match casual auth/quota prose', () => {
+    expect(anyMatch(sig.fatalError, 'handle the 401 unauthorized response')).toBe(false);
+    expect(anyMatch(sig.fatalError, 'check the remaining quota')).toBe(false);
+  });
+});

--- a/src/main/providers/codex-provider.ts
+++ b/src/main/providers/codex-provider.ts
@@ -17,27 +17,29 @@ const PERMISSION_MODE_MAP: Record<string, string> = {
 // hidden as 'idle'), so imperfect tables under-fire rather than mislead.
 // TODO(codex-signals): validate/replace against a live Codex session.
 const CODEX_STATE_SIGNALS: StateSignals = {
+  // Line-anchored status forms only — bare words 'working'/'thinking' would
+  // match ordinary prose ("tests are working now") and pin the session.
   working: [
     /esc to interrupt/i,
-    /\bthinking\b/i,
-    /\bworking\b…?/i,
+    /^\s*(Thinking|Working)…?\s*$/im,
     /[⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏]/,
   ],
+  // Codex's own approval framing (not a generic '[y/n]', which appears in
+  // captured subprocess output the agent itself answers).
   approval: [
     /Allow command/i,
     /Run this command\?/i,
-    /\bApprove\b\??/i,
     /Allow Codex to run/i,
-    /\[y\/n\]/i,
   ],
   awaitingInput: [
     /Press Enter to continue/i,
   ],
+  // Banner-shaped only; dropped bare /quota/ and /unauthorized/, which match
+  // normal code-writing about auth/HTTP status.
   fatalError: [
-    /\brate limit(?:ed|s)?\b/i,
-    /API error/i,
-    /\bquota\b/i,
-    /unauthorized/i,
+    /^\s*Error:/im,
+    /You have exceeded your rate limit/i,
+    /rate_limit_error/i,
   ],
 };
 

--- a/src/main/providers/codex-provider.ts
+++ b/src/main/providers/codex-provider.ts
@@ -1,11 +1,44 @@
 import { execFile } from 'child_process';
 import { IProvider, ProviderCommandOptions } from './provider';
 import { ProviderId, ProviderInfo } from '../../shared/types/provider-types';
+import type { StateSignals } from '../../shared/session-state-types';
 
 /** Map OmniDesk permission mode names to Codex approval modes */
 const PERMISSION_MODE_MAP: Record<string, string> = {
   'standard': 'suggest',
   'skip-permissions': 'full-auto',
+};
+
+// PROVISIONAL state-classifier tables for Codex CLI. Unlike the Claude table
+// these have NOT yet been validated against captured real Codex transcripts —
+// the design flags that as a ship gate. Kept intentionally conservative: the
+// classifier biases toward surfacing (an unmatched quiescent-after-output
+// state degrades to 'done', which is still surfaced for review, never silently
+// hidden as 'idle'), so imperfect tables under-fire rather than mislead.
+// TODO(codex-signals): validate/replace against a live Codex session.
+const CODEX_STATE_SIGNALS: StateSignals = {
+  working: [
+    /esc to interrupt/i,
+    /\bthinking\b/i,
+    /\bworking\b…?/i,
+    /[⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏]/,
+  ],
+  approval: [
+    /Allow command/i,
+    /Run this command\?/i,
+    /\bApprove\b\??/i,
+    /Allow Codex to run/i,
+    /\[y\/n\]/i,
+  ],
+  awaitingInput: [
+    /Press Enter to continue/i,
+  ],
+  fatalError: [
+    /\brate limit(?:ed|s)?\b/i,
+    /API error/i,
+    /\bquota\b/i,
+    /unauthorized/i,
+  ],
 };
 
 export class CodexProvider implements IProvider {
@@ -65,6 +98,15 @@ export class CodexProvider implements IProvider {
         /Switched to (\w[\w-]*)/i,
         /Using model[: ]+(\w[\w-]*)/i,
       ],
+    };
+  }
+
+  getStateSignals(): StateSignals {
+    return {
+      working: [...CODEX_STATE_SIGNALS.working],
+      approval: [...CODEX_STATE_SIGNALS.approval],
+      awaitingInput: [...CODEX_STATE_SIGNALS.awaitingInput],
+      fatalError: [...CODEX_STATE_SIGNALS.fatalError],
     };
   }
 

--- a/src/main/providers/provider.ts
+++ b/src/main/providers/provider.ts
@@ -1,5 +1,6 @@
 import { ProviderId, ProviderInfo } from '../../shared/types/provider-types';
 import type { LaunchMode } from '../../shared/ipc-types';
+import type { StateSignals } from '../../shared/session-state-types';
 
 export interface ProviderCommandOptions {
   workingDirectory: string;
@@ -19,6 +20,12 @@ export interface IProvider {
   buildCommand(options: ProviderCommandOptions): string;
   getReadinessPatterns(): string[];
   getModelDetectionPatterns(): { welcome: RegExp[]; switch: RegExp[] };
+  /**
+   * Regex tables the session-state classifier matches against this provider's
+   * terminal output to derive live activity state (working / awaiting-approval
+   * / awaiting-input / errored). Same idiom as getModelDetectionPatterns.
+   */
+  getStateSignals(): StateSignals;
   getEnvironmentVariables(options?: { enableAgentTeams?: boolean }): Record<string, string>;
   normalizeModel(raw: string): string | null;
 }

--- a/src/main/session-manager.test.ts
+++ b/src/main/session-manager.test.ts
@@ -521,9 +521,46 @@ describe('SessionManager.createSession — early map insertion (F2)', () => {
     const meta = await manager.createSession({ ...baseRequest });
 
     // Before F2 this exit was dropped (session not yet in the map) and the
-    // session sat at 'starting' forever; now it is correctly 'exited'.
-    expect(manager.getSession(meta.id)?.status).toBe('exited');
+    // session sat at 'starting' forever. Now it is recorded — and since the
+    // exit code is non-zero it is a crash, so status is 'error'.
+    expect(manager.getSession(meta.id)?.status).toBe('error');
     expect(manager.getSession(meta.id)?.exitCode).toBe(1);
+  });
+});
+
+describe('SessionManager — stale-manager guard & crash status (review fixes)', () => {
+  let manager: SessionManager;
+  const baseRequest = { workingDirectory: '/mock/home', permissionMode: 'standard' as const };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    manager = createSessionManager();
+    const registry = { get: vi.fn(() => ({ getEnvironmentVariables: () => ({}), buildCommand: () => 'claude' })) };
+    manager.setProviderRegistry(registry as any);
+  });
+
+  it('a clean exit (code 0) is exited; a non-zero exit is error', async () => {
+    const exitCbs: Array<(c: number) => void> = [];
+    vi.mocked(CLIManager.prototype.onExit).mockImplementation((cb: (c: number) => void) => { exitCbs.push(cb); });
+
+    const meta = await manager.createSession({ ...baseRequest });
+    exitCbs[exitCbs.length - 1](0);
+    expect(manager.getSession(meta.id)?.status).toBe('exited');
+  });
+
+  it('ignores a stale (replaced) manager\'s late exit — the live session is untouched', async () => {
+    const exitCbs: Array<(c: number) => void> = [];
+    vi.mocked(CLIManager.prototype.onExit).mockImplementation((cb: (c: number) => void) => { exitCbs.push(cb); });
+
+    const meta = await manager.createSession({ ...baseRequest });
+    const staleExit = exitCbs[exitCbs.length - 1]; // manager A's onExit
+    await manager.restartSession(meta.id);          // installs manager B
+    expect(manager.getSession(meta.id)?.status).toBe('running');
+
+    // Manager A's PTY dies late (non-zero). The guard must ignore it so the
+    // healthy replacement isn't torn down.
+    staleExit(1);
+    expect(manager.getSession(meta.id)?.status).toBe('running');
   });
 });
 

--- a/src/main/session-manager.ts
+++ b/src/main/session-manager.ts
@@ -12,7 +12,11 @@ import {
   SessionOutput,
   ClaudeModel,
   ModelSwitchEvent,
+  SessionStateChangeEvent,
+  SessionActivityState,
 } from '../shared/ipc-types';
+import { SessionStateClassifier } from './session-state/classifier';
+import type { StateSignals } from '../shared/session-state-types';
 import {
   loadSessionState,
   saveSessionState,
@@ -29,6 +33,8 @@ import type { ProviderRegistry } from './providers/provider-registry';
 import type { IProvider } from './providers/provider';
 
 const MAX_SESSIONS = 10;
+
+const EMPTY_STATE_SIGNALS: StateSignals = { working: [], approval: [], awaitingInput: [], fatalError: [] };
 
 interface Session {
   metadata: SessionMetadata;
@@ -47,6 +53,8 @@ export class SessionManager {
   private worktreeSettings: WorktreeSettings = { basePath: 'sibling', cleanupOnSessionClose: 'ask' };
   private outputSubscribers: Map<string, Set<(data: string) => void>> = new Map();
   private providerRegistry: ProviderRegistry | null = null;
+  /** Per-session live-activity-state classifier (the attention-router feed). */
+  private classifiers: Map<string, SessionStateClassifier> = new Map();
   /** Rolling per-session raw output buffer, replayed to clients that attach
    *  mid-session (e.g. a phone joining, or a renderer reload). Bounded. */
   private scrollback: Map<string, string> = new Map();
@@ -350,7 +358,44 @@ export class SessionManager {
    *  cannot drift (they previously had — restart silently dropped the
    *  scrollback append and the session-end notification). This is also the
    *  single output tap the session-state classifier will hook into. */
+  /** Resolve the state-signal tables for a session's provider (empty for shells
+   *  or when the provider can't be resolved). */
+  private stateSignalsFor(sessionId: string): StateSignals {
+    const meta = this.sessions.get(sessionId)?.metadata;
+    if (!meta || meta.kind === 'shell') return EMPTY_STATE_SIGNALS;
+    try {
+      return this.providerRegistry?.get(meta.providerId ?? 'claude')?.getStateSignals() ?? EMPTY_STATE_SIGNALS;
+    } catch {
+      return EMPTY_STATE_SIGNALS;
+    }
+  }
+
+  /** Create (replacing any prior) the activity-state classifier for a session
+   *  and broadcast its transitions. */
+  private setupClassifier(sessionId: string): SessionStateClassifier {
+    this.classifiers.get(sessionId)?.dispose();
+    const kind = this.sessions.get(sessionId)?.metadata.kind;
+    const classifier = new SessionStateClassifier({
+      signals: this.stateSignalsFor(sessionId),
+      kind,
+      onStateChange: (state, reason) => this.emitActivityState(sessionId, state, reason),
+    });
+    this.classifiers.set(sessionId, classifier);
+    return classifier;
+  }
+
+  /** Record + broadcast a session's live activity state (transient, not persisted). */
+  private emitActivityState(sessionId: string, state: SessionActivityState, reason?: string): void {
+    const session = this.sessions.get(sessionId);
+    if (!session) return;
+    session.metadata.activityState = state;
+    const event: SessionStateChangeEvent = { sessionId, state, reason, at: Date.now() };
+    this.emitter?.emit('onSessionStateChanged', event);
+  }
+
   private wireCliManager(mgr: CLIManager, sessionId: string): void {
+    this.setupClassifier(sessionId);
+
     mgr.onModelChange((model: ClaudeModel) => {
       const session = this.sessions.get(sessionId);
       if (!session) return;
@@ -374,6 +419,9 @@ export class SessionManager {
       this.emitter?.emit('onSessionOutput', output);
       this.notifyOutputSubscribers(sessionId, data);
 
+      // Feed the activity-state classifier (the attention-router signal).
+      this.classifiers.get(sessionId)?.onOutput(data);
+
       // Record to history (async, non-blocking). Pass kind so shells skip the
       // Claude-ready gate (and don't leak an unbounded pre-ready buffer).
       const kind = this.sessions.get(sessionId)?.metadata.kind;
@@ -392,6 +440,14 @@ export class SessionManager {
       this.persistState();
       this.notifySessionEnd(sessionId);
 
+      // Fuse the authoritative exit into the classifier (an unexpected exit is a
+      // crash → 'errored'; a deliberate stop/close disposes it first so this is
+      // a no-op there), then tear it down.
+      const classifier = this.classifiers.get(sessionId);
+      classifier?.onExit(exitCode);
+      classifier?.dispose();
+      this.classifiers.delete(sessionId);
+
       // Flush final history buffer
       this.historyManager.onSessionExit(sessionId, exitCode).catch(err => {
         console.error('Failed to finalize session history:', err);
@@ -407,6 +463,11 @@ export class SessionManager {
     if (!session) {
       return false;
     }
+
+    // Dispose the classifier before destroy (the session is going away — no
+    // exit state to report).
+    this.classifiers.get(sessionId)?.dispose();
+    this.classifiers.delete(sessionId);
 
     // Destroy CLI manager if running
     if (session.cliManager) {
@@ -548,10 +609,15 @@ export class SessionManager {
   async stopSession(sessionId: string): Promise<boolean> {
     const session = this.sessions.get(sessionId);
     if (!session) return false;
+    // Deliberate stop: dispose the classifier BEFORE destroy so the resulting
+    // PTY exit isn't misread as a crash ('errored'), then mark it 'exited'.
+    this.classifiers.get(sessionId)?.dispose();
+    this.classifiers.delete(sessionId);
     if (session.cliManager) {
       session.cliManager.destroy();
       session.cliManager = null;
     }
+    this.emitActivityState(sessionId, 'exited', 'stopped');
     // Clear the terminal display so a killed session reads as a clean black
     // slate — matching freshly-restored idle sessions. ESC[2J (clear screen),
     // ESC[3J (clear scrollback), ESC[H (cursor home).
@@ -568,6 +634,12 @@ export class SessionManager {
     if (!session) {
       return false;
     }
+
+    // Dispose the outgoing classifier BEFORE destroy so the old PTY's exit
+    // isn't emitted as a spurious state change during restart. wireCliManager
+    // installs a fresh one below.
+    this.classifiers.get(sessionId)?.dispose();
+    this.classifiers.delete(sessionId);
 
     // Destroy existing CLI manager if any
     if (session.cliManager) {
@@ -624,6 +696,7 @@ export class SessionManager {
     session.metadata.exitCode = undefined;
     session.metadata.error = undefined;
     session.metadata.currentModel = undefined; // Clear stale detected model — Phase 1 will re-detect
+    this.emitActivityState(sessionId, 'initializing', 'restart'); // clear stale activity state in the UI
 
     try {
       if (isShell) {
@@ -682,6 +755,10 @@ export class SessionManager {
 
   // Cleanup all sessions
   destroyAll(): void {
+    for (const classifier of this.classifiers.values()) {
+      classifier.dispose();
+    }
+    this.classifiers.clear();
     for (const session of this.sessions.values()) {
       if (session.cliManager) {
         session.cliManager.destroy();

--- a/src/main/session-manager.ts
+++ b/src/main/session-manager.ts
@@ -396,9 +396,15 @@ export class SessionManager {
   private wireCliManager(mgr: CLIManager, sessionId: string): void {
     this.setupClassifier(sessionId);
 
+    // A CLIManager that has been destroyed and replaced (pool-fallback,
+    // restart, or Stop) can still deliver a late PTY exit/output. Every wired
+    // callback ignores events from a manager that is no longer the session's
+    // current one, so a stale manager can't tear down or feed a live session.
+    const isStale = () => this.sessions.get(sessionId)?.cliManager !== mgr;
+
     mgr.onModelChange((model: ClaudeModel) => {
       const session = this.sessions.get(sessionId);
-      if (!session) return;
+      if (!session || isStale()) return;
       const previousModel = session.metadata.currentModel ?? null;
       session.metadata.currentModel = model;
 
@@ -414,6 +420,7 @@ export class SessionManager {
     });
 
     mgr.onOutput((data: string) => {
+      if (isStale()) return;
       this.appendScrollback(sessionId, data);
       const output: SessionOutput = { sessionId, data };
       this.emitter?.emit('onSessionOutput', output);
@@ -432,17 +439,22 @@ export class SessionManager {
 
     mgr.onExit((exitCode: number) => {
       const session = this.sessions.get(sessionId);
-      if (!session) return;
-      session.metadata.status = 'exited';
+      // Ignore a stale manager's exit (a deliberate Stop/close/restart nulls or
+      // replaces cliManager first, so only a LIVE manager's genuine exit lands
+      // here — which means a non-zero code is a real crash, not a user Stop).
+      if (!session || isStale()) return;
+      const crashed = exitCode !== 0;
+      // A crash is authoritative 'error' so both the rail and the attention
+      // cockpit surface it; a clean exit is 'exited'.
+      session.metadata.status = crashed ? 'error' : 'exited';
       session.metadata.exitCode = exitCode;
       this.emitter?.emit('onSessionUpdated', session.metadata);
       this.emitter?.emit('onSessionExited', { sessionId, exitCode });
       this.persistState();
       this.notifySessionEnd(sessionId);
 
-      // Fuse the authoritative exit into the classifier (an unexpected exit is a
-      // crash → 'errored'; a deliberate stop/close disposes it first so this is
-      // a no-op there), then tear it down.
+      // Fuse the authoritative exit into the classifier (crash → 'errored',
+      // clean → 'exited'), then tear it down.
       const classifier = this.classifiers.get(sessionId);
       classifier?.onExit(exitCode);
       classifier?.dispose();
@@ -687,11 +699,14 @@ export class SessionManager {
       kind: session.metadata.kind,
     });
 
+    // Point the session at the new manager BEFORE wiring, so the callbacks'
+    // manager-identity guard recognises this manager as the current one.
+    session.cliManager = cliManager;
+
     // Same wiring the create path uses — including the scrollback append this
     // path used to omit, so a client attaching after a restart sees output.
     this.wireCliManager(cliManager, sessionId);
 
-    session.cliManager = cliManager;
     session.metadata.status = 'starting';
     session.metadata.exitCode = undefined;
     session.metadata.error = undefined;

--- a/src/main/session-state/alt-screen-tracker.test.ts
+++ b/src/main/session-state/alt-screen-tracker.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { AltScreenTracker } from './alt-screen-tracker';
+
+describe('AltScreenTracker', () => {
+  let tracker: AltScreenTracker;
+
+  beforeEach(() => {
+    tracker = new AltScreenTracker();
+  });
+
+  it('starts inactive', () => {
+    expect(tracker.isActive()).toBe(false);
+  });
+
+  it('enters alt screen on CSI ?1049h and exits on CSI ?1049l', () => {
+    tracker.process('\x1b[?1049h');
+    expect(tracker.isActive()).toBe(true);
+
+    tracker.process('some vim output here');
+    expect(tracker.isActive()).toBe(true);
+
+    tracker.process('\x1b[?1049l');
+    expect(tracker.isActive()).toBe(false);
+  });
+
+  it('treats a combined param sequence CSI ?1049;2004h as entering alt screen', () => {
+    tracker.process('\x1b[?1049;2004h');
+    expect(tracker.isActive()).toBe(true);
+  });
+
+  it('treats a combined param sequence CSI ?1049;2004l as exiting alt screen', () => {
+    tracker.process('\x1b[?1049;2004h');
+    expect(tracker.isActive()).toBe(true);
+    tracker.process('\x1b[?1049;2004l');
+    expect(tracker.isActive()).toBe(false);
+  });
+
+  it('does not react to unrelated DEC private modes bundled in the same sequence', () => {
+    // 2004 (bracketed paste) alone should not toggle alt screen state.
+    tracker.process('\x1b[?2004h');
+    expect(tracker.isActive()).toBe(false);
+  });
+
+  it('supports legacy mode 1047 (enter/exit)', () => {
+    tracker.process('\x1b[?1047h');
+    expect(tracker.isActive()).toBe(true);
+    tracker.process('\x1b[?1047l');
+    expect(tracker.isActive()).toBe(false);
+  });
+
+  it('supports legacy mode 47 (enter/exit)', () => {
+    tracker.process('\x1b[?47h');
+    expect(tracker.isActive()).toBe(true);
+    tracker.process('\x1b[?47l');
+    expect(tracker.isActive()).toBe(false);
+  });
+
+  it('applies multiple transitions within a single chunk in order, final state wins', () => {
+    // Enter via 1049, then immediately exit via 47 in the same chunk —
+    // final state should be inactive.
+    tracker.process('\x1b[?1049h some text \x1b[?47l');
+    expect(tracker.isActive()).toBe(false);
+
+    // Enter, exit, enter again in one chunk — final state should be active.
+    tracker.process('\x1b[?1049h\x1b[?1049l\x1b[?1047h');
+    expect(tracker.isActive()).toBe(true);
+  });
+
+  it('is incremental across multiple process() calls', () => {
+    tracker.process('\x1b[?1049h');
+    expect(tracker.isActive()).toBe(true);
+    tracker.process('more output without any escape codes');
+    expect(tracker.isActive()).toBe(true);
+    tracker.process('trailing chunk \x1b[?1049l done');
+    expect(tracker.isActive()).toBe(false);
+  });
+
+  it('reset() clears state back to inactive', () => {
+    tracker.process('\x1b[?1049h');
+    expect(tracker.isActive()).toBe(true);
+    tracker.reset();
+    expect(tracker.isActive()).toBe(false);
+  });
+});

--- a/src/main/session-state/alt-screen-tracker.ts
+++ b/src/main/session-state/alt-screen-tracker.ts
@@ -1,0 +1,56 @@
+// Tracks whether the terminal is currently in the alternate screen buffer
+// (i.e. a full-screen TUI, editor, or pager is currently open) by scanning
+// raw PTY output chunks for DEC private mode set/reset sequences.
+//
+// Recognized modes (all treated as "alt screen" for our purposes):
+//   - 1049 (alt screen buffer + cursor save/restore — used by vim, less, htop, …)
+//   - 1047 (alt screen buffer, no cursor save/restore — legacy)
+//   - 47   (alt screen buffer — very old legacy)
+//
+// ENTER: CSI ? <params> h   where <params> contains one of 1049/1047/47
+// EXIT:  CSI ? <params> l   where <params> contains one of 1049/1047/47
+//
+// A single DECSET/DECRST can set multiple modes in one sequence, e.g.
+// `CSI ?1049;2004h` enables both the alt screen (1049) and bracketed paste
+// (2004) in one go. The params must be split on ';' and each checked for
+// membership in the alt-screen mode set — testing the whole param string for
+// equality would miss this (and any other) multi-param case.
+//
+// Chunk boundary caveat (intentional, not a bug): if a single escape
+// sequence is split across two `process()` calls (e.g. the PTY write
+// boundary lands mid-sequence, like "...\x1b[?10" | "49h..."), this
+// tail-heuristic will miss that transition. In practice PTYs very rarely
+// split escape sequences this way, and reassembling a cross-chunk carry
+// buffer is not worth the complexity for a heuristic used only to gate UI
+// state — so we deliberately do not handle it here.
+
+const ALT_SCREEN_MODES = new Set(['1049', '1047', '47']);
+
+// Matches CSI ? <params> <h|l> where params is digits/semicolons.
+// e.g. \x1b[?1049h  \x1b[?1049;2004h  \x1b[?47l
+const CSI_DECSET_DECRST = /\x1b\[\?([0-9;]+)([hl])/g;
+
+export class AltScreenTracker {
+  private active = false;
+
+  /** Scan a chunk of raw terminal output, applying any alt-screen transitions in order. */
+  process(chunk: string): void {
+    CSI_DECSET_DECRST.lastIndex = 0;
+    let match: RegExpExecArray | null;
+    while ((match = CSI_DECSET_DECRST.exec(chunk)) !== null) {
+      const params = match[1].split(';');
+      const action = match[2]; // 'h' = set, 'l' = reset
+      const touchesAltScreen = params.some((p) => ALT_SCREEN_MODES.has(p));
+      if (!touchesAltScreen) continue;
+      this.active = action === 'h';
+    }
+  }
+
+  isActive(): boolean {
+    return this.active;
+  }
+
+  reset(): void {
+    this.active = false;
+  }
+}

--- a/src/main/session-state/classifier.test.ts
+++ b/src/main/session-state/classifier.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { SessionStateClassifier, type ClassifierOptions } from './classifier';
+import type { StateSignals } from '../../shared/session-state-types';
+import type { SessionActivityState } from '../../shared/ipc-types';
+
+// A minimal single-slot scheduler: the classifier only ever has one timer
+// armed at a time (armTimer clears the previous), so one pending slot suffices.
+function makeHarness(over: Partial<ClassifierOptions> = {}) {
+  let pending: (() => void) | null = null;
+  const emitted: SessionActivityState[] = [];
+  const onStateChange = vi.fn((s: SessionActivityState) => { emitted.push(s); });
+
+  const signals: StateSignals = {
+    working: [/esc to interrupt/i],
+    approval: [/Do you want to proceed\?/i, /\b1\.\s*Yes\b[\s\S]{0,120}\b2\.\s*Yes,/i],
+    awaitingInput: [/Press Enter to continue/i],
+    fatalError: [/API Error/i],
+  };
+
+  const classifier = new SessionStateClassifier({
+    signals,
+    onStateChange,
+    quietMs: 1000,
+    setTimer: (fn) => { pending = fn; return 1 as unknown as ReturnType<typeof setTimeout>; },
+    clearTimer: () => { pending = null; },
+    ...over,
+  });
+
+  return {
+    classifier,
+    onStateChange,
+    emitted,
+    /** Fire the currently-armed quiescence evaluation. */
+    tick: () => { const p = pending; pending = null; p?.(); },
+    hasTimer: () => pending !== null,
+  };
+}
+
+describe('SessionStateClassifier', () => {
+  it('starts in initializing', () => {
+    const h = makeHarness();
+    expect(h.classifier.getState()).toBe('initializing');
+  });
+
+  it('leading edge: visible output → working immediately', () => {
+    const h = makeHarness();
+    h.classifier.onOutput('Thinking about it...\n');
+    expect(h.classifier.getState()).toBe('working');
+    expect(h.emitted).toEqual(['working']);
+  });
+
+  it('pure color/cursor chunks are not treated as visible output', () => {
+    const h = makeHarness();
+    h.classifier.onOutput('\x1b[2m\x1b[0m'); // SGR only, no visible glyphs
+    expect(h.classifier.getState()).toBe('initializing');
+    expect(h.onStateChange).not.toHaveBeenCalled();
+  });
+
+  it('settles to done after output goes quiet (dwell of 2 ticks)', () => {
+    const h = makeHarness();
+    h.classifier.onOutput('Here is your answer.\n');
+    expect(h.classifier.getState()).toBe('working');
+    h.tick(); // quietTicks=1 → not yet
+    expect(h.classifier.getState()).toBe('working');
+    h.tick(); // quietTicks=2 → done
+    expect(h.classifier.getState()).toBe('done');
+    expect(h.emitted).toEqual(['working', 'done']);
+  });
+
+  it('surfaces an approval prompt immediately (no dwell)', () => {
+    const h = makeHarness();
+    h.classifier.onOutput('Do you want to proceed?\n');
+    h.tick();
+    expect(h.classifier.getState()).toBe('awaiting-approval');
+  });
+
+  it('matches the multi-line approval triad in reading order', () => {
+    const h = makeHarness();
+    h.classifier.onOutput('Do you want to make this edit?\n❯ 1. Yes\n  2. Yes, and don\'t ask\n  3. No\n');
+    h.tick();
+    expect(h.classifier.getState()).toBe('awaiting-approval');
+  });
+
+  it('interrupt affordance vetoes settling — stays working and keeps watching', () => {
+    const h = makeHarness();
+    h.classifier.onOutput('Running a slow tool… (esc to interrupt)\n');
+    expect(h.classifier.getState()).toBe('working');
+    h.tick();
+    expect(h.classifier.getState()).toBe('working');
+    expect(h.hasTimer()).toBe(true); // re-armed, still watching
+  });
+
+  it('exit code 0 → exited; non-zero → errored', () => {
+    const a = makeHarness();
+    a.classifier.onExit(0);
+    expect(a.classifier.getState()).toBe('exited');
+
+    const b = makeHarness();
+    b.classifier.onExit(1);
+    expect(b.classifier.getState()).toBe('errored');
+  });
+
+  it('user-initiated stop never paints errored even on a non-zero exit', () => {
+    const h = makeHarness();
+    h.classifier.onOutput('working\n');
+    h.classifier.onExit(137, true); // SIGKILL-style code, but user pressed Stop
+    expect(h.classifier.getState()).toBe('exited');
+  });
+
+  it('suppresses transitions while the alternate screen is active', () => {
+    const h = makeHarness();
+    h.classifier.onOutput('opening editor\x1b[?1049h');
+    expect(h.classifier.getState()).toBe('working');
+    h.tick(); // alt screen active → hold, re-arm
+    expect(h.classifier.getState()).toBe('working');
+    expect(h.hasTimer()).toBe(true);
+  });
+
+  it('emits only on delta — repeated working output does not re-emit', () => {
+    const h = makeHarness();
+    h.classifier.onOutput('token1 ');
+    h.classifier.onOutput('token2 ');
+    h.classifier.onOutput('token3 ');
+    expect(h.emitted).toEqual(['working']);
+  });
+
+  it('shell sessions only toggle working ↔ idle (never approval/done)', () => {
+    const h = makeHarness({ kind: 'shell', signals: { working: [], approval: [/proceed/i], awaitingInput: [], fatalError: [] } });
+    h.classifier.onOutput('Do you want to proceed?\n'); // would be approval for an agent
+    expect(h.classifier.getState()).toBe('working');
+    h.tick();
+    h.tick();
+    expect(h.classifier.getState()).toBe('idle'); // forced idle, not awaiting-approval
+  });
+
+  it('dispose stops the machine — a pending tick is a no-op', () => {
+    const h = makeHarness();
+    h.classifier.onOutput('working\n');
+    h.classifier.dispose();
+    h.tick();
+    expect(h.classifier.getState()).toBe('working'); // unchanged
+  });
+});

--- a/src/main/session-state/classifier.ts
+++ b/src/main/session-state/classifier.ts
@@ -1,0 +1,194 @@
+// Per-session state machine that turns a PTY output stream into a
+// SessionActivityState for the attention-router cockpit. It fuses:
+//   • output patterns   — via the provider's StateSignals + the pure detector
+//   • output-idle timing — a quiescence timer (renderer timers throttle when
+//                          backgrounded, so this MUST live in main)
+//   • alt-screen state   — suppress transitions while a full-screen TUI is open
+//   • PTY exit code      — authoritative terminal state
+// with asymmetric hysteresis (instant on the leading edge, dwell before
+// settling to done/idle) so the signal doesn't flap.
+//
+// One instance per session, fed from SessionManager.wireCliManager's single
+// output tap. Pure logic lives in ../../shared (line-reducer, state-detector);
+// this file only owns the stateful timer/tail/hysteresis.
+
+import { reduceLines } from '../../shared/line-reducer';
+import { detectStateFromTail } from '../../shared/state-detector';
+import { stripAnsi } from '../ansi-strip';
+import { AltScreenTracker } from './alt-screen-tracker';
+import type { StateSignals } from '../../shared/session-state-types';
+import type { SessionActivityState, SessionKind } from '../../shared/ipc-types';
+
+/** Quiet window before a settle is evaluated. */
+const DEFAULT_QUIET_MS = 1000;
+/** Consecutive quiet ticks required before emitting done/idle (anti-flap). */
+const DWELL_TICKS = 2;
+/** Bounded raw-output tail kept for the reducer (chars). */
+const RAW_TAIL_MAX = 8 * 1024;
+
+export interface ClassifierOptions {
+  /** Provider signal tables. Empty tables are fine (e.g. shells). */
+  signals: StateSignals;
+  /** Shell sessions reduce to working / idle / exited only. */
+  kind?: SessionKind;
+  /** Quiet window override (ms). */
+  quietMs?: number;
+  /** Called on every state DELTA (never for a no-op re-classification). */
+  onStateChange: (state: SessionActivityState, reason?: string) => void;
+  /** Injectable timer hooks (tests). Default to global setTimeout/clearTimeout. */
+  setTimer?: (fn: () => void, ms: number) => ReturnType<typeof setTimeout>;
+  clearTimer?: (h: ReturnType<typeof setTimeout>) => void;
+}
+
+export class SessionStateClassifier {
+  private state: SessionActivityState = 'initializing';
+  private rawTail = '';
+  private hadOutputSinceView = false;
+  private quietTicks = 0;
+  private timer: ReturnType<typeof setTimeout> | null = null;
+  private disposed = false;
+  private readonly alt = new AltScreenTracker();
+  private readonly signals: StateSignals;
+  private readonly isShell: boolean;
+  private readonly quietMs: number;
+  private readonly emit: (s: SessionActivityState, reason?: string) => void;
+  private readonly setTimer: (fn: () => void, ms: number) => ReturnType<typeof setTimeout>;
+  private readonly clearTimer: (h: ReturnType<typeof setTimeout>) => void;
+
+  constructor(opts: ClassifierOptions) {
+    this.signals = opts.signals;
+    this.isShell = opts.kind === 'shell';
+    this.quietMs = opts.quietMs ?? DEFAULT_QUIET_MS;
+    this.setTimer = opts.setTimer ?? ((fn, ms) => setTimeout(fn, ms));
+    this.clearTimer = opts.clearTimer ?? ((h) => clearTimeout(h));
+    this.emit = (s, reason) => {
+      if (this.disposed || s === this.state) return;
+      this.state = s;
+      opts.onStateChange(s, reason);
+    };
+  }
+
+  getState(): SessionActivityState {
+    return this.state;
+  }
+
+  /** Feed a flushed output chunk (already batched by CLIManager, not per-byte). */
+  onOutput(data: string): void {
+    if (this.disposed || !data) return;
+
+    this.alt.process(data);
+
+    this.rawTail += data;
+    if (this.rawTail.length > RAW_TAIL_MAX) {
+      this.rawTail = this.rawTail.slice(this.rawTail.length - RAW_TAIL_MAX);
+    }
+
+    // Leading edge: any fresh VISIBLE content (ignoring pure color/cursor
+    // control chunks) means the agent is actively producing → 'working' now.
+    const visible = stripAnsi(data).trim().length > 0;
+    if (visible) {
+      this.hadOutputSinceView = true;
+      this.quietTicks = 0;
+      this.emit('working');
+      this.armTimer();
+    }
+  }
+
+  /** Authoritative terminal signal. `userInitiated` (Stop) never paints red. */
+  onExit(exitCode: number, userInitiated = false): void {
+    if (this.disposed) return;
+    this.clearActiveTimer();
+    if (!userInitiated && exitCode !== 0) {
+      this.emit('errored', `exit ${exitCode}`);
+    } else {
+      this.emit('exited', userInitiated ? 'stopped' : `exit ${exitCode}`);
+    }
+  }
+
+  dispose(): void {
+    this.disposed = true;
+    this.clearActiveTimer();
+  }
+
+  private armTimer(): void {
+    this.clearActiveTimer();
+    this.timer = this.setTimer(() => this.onQuiesce(), this.quietMs);
+  }
+
+  private clearActiveTimer(): void {
+    if (this.timer !== null) {
+      this.clearTimer(this.timer);
+      this.timer = null;
+    }
+  }
+
+  private onQuiesce(): void {
+    if (this.disposed) return;
+    this.timer = null;
+
+    // A full-screen TUI/editor/pager is open — its repaints aren't turn output.
+    // Hold the prior state and keep watching.
+    if (this.alt.isActive()) {
+      this.armTimer();
+      return;
+    }
+
+    const reduced = stripAnsi(reduceLines(this.rawTail));
+
+    // Shells never have approval/awaiting/error prompts to classify — they only
+    // toggle working ↔ idle.
+    if (this.isShell) {
+      this.settleQuiet('idle');
+      return;
+    }
+
+    const interruptAffordance = this.matches(this.signals.working, reduced);
+    const candidate = detectStateFromTail(reduced, this.signals, {
+      hadOutputSinceView: this.hadOutputSinceView,
+      interruptAffordance,
+    });
+
+    switch (candidate) {
+      case 'awaiting-approval':
+      case 'awaiting-input':
+      case 'errored':
+        // Positive signal — surface immediately; new output re-arms the timer.
+        this.quietTicks = 0;
+        this.emit(candidate);
+        return;
+      case 'working':
+        // Interrupt affordance present: still busy on a silent tool call.
+        this.emit('working');
+        this.armTimer();
+        return;
+      case 'done':
+      case 'idle':
+        this.settleQuiet(candidate);
+        return;
+    }
+  }
+
+  /** Emit a quiet settle (done/idle) only after DWELL_TICKS consecutive quiet
+   *  evaluations, to avoid flapping on a brief lull mid-turn. */
+  private settleQuiet(candidate: 'done' | 'idle'): void {
+    this.quietTicks++;
+    if (this.quietTicks < DWELL_TICKS) {
+      this.armTimer();
+      return;
+    }
+    if (candidate === 'idle') {
+      // Truly quiet with nothing new — clear the surface bias.
+      this.hadOutputSinceView = false;
+    }
+    this.emit(candidate);
+    // Settled — stop the timer; the next output chunk re-arms it.
+  }
+
+  private matches(table: RegExp[], text: string): boolean {
+    for (const re of table) {
+      re.lastIndex = 0;
+      if (re.test(text)) return true;
+    }
+    return false;
+  }
+}

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -26,6 +26,9 @@ import { useTouchMode } from './hooks/useTouchMode';
 import { MobileKeyBar } from './components/shell/mobile/MobileKeyBar';
 import { MobileShell } from './components/shell/mobile/MobileShell';
 import { repoIdForSession } from './components/shell/mobile/nav-utils';
+import { CockpitPanel } from './components/shell/CockpitPanel';
+import { useAttentionQueue } from './hooks/useAttentionQueue';
+import type { TabData } from './components/ui/Tab';
 import { shouldShowCloseDialog } from './terminal/shell-key-rules';
 import { ToastContainer } from './components/ui/ToastContainer';
 import { ConfirmDialog } from './components/ui/ConfirmDialog';
@@ -130,6 +133,7 @@ function App() {
   const setShowAddRepo = (next: boolean) => setAddRepoTab(next ? (addRepoTab ?? 'clone') : null);
   const [showNewSession, setShowNewSession] = useState(false);
   const [showPalette, setShowPalette] = useState(false);
+  const [showCockpit, setShowCockpit] = useState(false);
   const [showRightPanel, setShowRightPanel] = useState(false);
   const [showRemote, setShowRemote] = useState(false);
   const [showVoiceSettings, setShowVoiceSettings] = useState(false);
@@ -203,6 +207,21 @@ function App() {
     switchSession(id);
     setMode('focus');
   }, [visibleRepos, sessions, activeRepoId, setActiveRepoId, setActiveGroupId, switchSession]);
+
+  // ─── Attention cockpit: cross-repo "who needs you" queue + backgrounded toasts ───
+  const repoOf = useCallback((s: TabData) => {
+    const id = repoIdForSession(visibleRepos, sessions, s.id);
+    const r = repos.find(x => x.id === id);
+    return r ? { id: r.id, name: r.name } : null;
+  }, [visibleRepos, sessions, repos]);
+
+  const attention = useAttentionQueue({
+    sessions,
+    repoOf,
+    previews,
+    activeSessionId,
+    onJump: handleMobileSelectSession,
+  });
 
   const handleCloseRepo = useCallback((id: string) => {
     const target = repos.find(r => r.id === id);
@@ -410,12 +429,14 @@ function App() {
         return;
       }
       if (cmd && e.key === 'k') { e.preventDefault(); setShowPalette(true); return; }
+      if (cmd && e.key === 'j') { e.preventDefault(); setShowCockpit(v => !v); return; }
       if (cmd && e.key === 'n') { e.preventDefault(); setShowNewSession(true); return; }
       if (cmd && e.key === '1') { e.preventDefault(); setMode('focus'); return; }
       if (cmd && e.key === '2') { e.preventDefault(); setMode('grid'); return; }
       if (cmd && e.key === '.') { e.preventDefault(); setShowRightPanel(v => !v); return; }
       if (e.key === 'Escape') {
         if (showPalette)    setShowPalette(false);
+        if (showCockpit)    setShowCockpit(false);
         if (showNewSession) setShowNewSession(false);
         if (showAddRepo)    setShowAddRepo(false);
         if (showRemote)     setShowRemote(false);
@@ -424,7 +445,7 @@ function App() {
     };
     window.addEventListener('keydown', onKey);
     return () => window.removeEventListener('keydown', onKey);
-  }, [showPalette, showNewSession, showAddRepo, showRemote, showVoiceSettings]);
+  }, [showPalette, showCockpit, showNewSession, showAddRepo, showRemote, showVoiceSettings]);
 
   useEffect(() => {
     const open = () => setShowVoiceSettings(true);
@@ -438,6 +459,11 @@ function App() {
       id: 'new', icon: 'plus', title: 'New session…',
       sub: 'Open the new-session sheet', shortcut: ['⌘', 'N'],
       run: () => { setShowPalette(false); setShowNewSession(true); },
+    },
+    {
+      id: 'cockpit', icon: 'bolt', title: 'Who needs you…',
+      sub: 'Attention cockpit — agents awaiting approval, input, or errored', shortcut: ['⌘', 'J'],
+      run: () => { setShowPalette(false); setShowCockpit(true); },
     },
     {
       id: 'focus', icon: 'focus', title: 'Switch to Focus view',
@@ -750,6 +776,8 @@ function App() {
           sessions={sessions}
           burnRatePerHour={(burnRate as any)?.dollarsPerHour ?? null}
           onOpenOtherReposLive={() => setRepoSwitcher({ anchorRect: null })}
+          needYouCount={attention.count}
+          onOpenCockpit={() => setShowCockpit(true)}
         />
       </div>
       )}
@@ -808,6 +836,15 @@ function App() {
           onPickSession={(id) => { handleSelectSession(id); setShowPalette(false); }}
           onClose={() => setShowPalette(false)}
           actions={paletteActions}
+        />
+      )}
+
+      {showCockpit && (
+        <CockpitPanel
+          items={attention.items}
+          onJump={handleMobileSelectSession}
+          onAcknowledge={attention.acknowledge}
+          onClose={() => setShowCockpit(false)}
         />
       )}
 

--- a/src/renderer/components/shell/CockpitPanel.tsx
+++ b/src/renderer/components/shell/CockpitPanel.tsx
@@ -1,0 +1,114 @@
+// @atlas-entrypoint: Attention cockpit (⌘J).
+// A cross-repo "who needs you" overlay — the routing surface of the
+// supervisory cockpit. Reuses the ⌘K palette's overlay shell and chip visuals.
+import { useEffect, useRef, useState } from 'react';
+import { P4Icon } from './P4Icon';
+import {
+  colorBg, colorFg, initials, agentLetter,
+  STATUS_META, type RepoColor,
+} from './shell-utils';
+import { mapTabStatus } from './SessionRail';
+import type { AttentionItem } from '../../hooks/useAttentionQueue';
+
+interface CockpitPanelProps {
+  items: AttentionItem[];
+  onJump: (sessionId: string) => void;
+  onAcknowledge: (sessionId: string) => void;
+  onClose: () => void;
+}
+
+export function CockpitPanel({ items, onJump, onAcknowledge, onClose }: CockpitPanelProps) {
+  const [sel, setSel] = useState(0);
+  const rowsRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => { rowsRef.current?.focus(); }, []);
+  useEffect(() => { if (sel > items.length - 1) setSel(Math.max(0, items.length - 1)); }, [items.length, sel]);
+
+  const jump = (id: string) => { onJump(id); onClose(); };
+
+  const handleKey = (e: React.KeyboardEvent) => {
+    if (e.key === 'ArrowDown') { setSel(s => Math.min(items.length - 1, s + 1)); e.preventDefault(); }
+    else if (e.key === 'ArrowUp') { setSel(s => Math.max(0, s - 1)); e.preventDefault(); }
+    else if (e.key === 'Enter') { const it = items[sel]; if (it) jump(it.session.id); e.preventDefault(); }
+    else if (e.key === 'Escape') { onClose(); }
+  };
+
+  return (
+    <div className="p4-overlay" onClick={(e) => { if (e.target === e.currentTarget) onClose(); }}>
+      <div
+        className="p4-palette"
+        role="dialog"
+        aria-modal="true"
+        aria-label="Attention cockpit"
+        tabIndex={-1}
+        ref={rowsRef}
+        onKeyDown={handleKey}
+      >
+        <div className="p4-palette-input" style={{ cursor: 'default' }}>
+          <P4Icon name="bolt" size={15} style={{ color: 'var(--warning)' }} />
+          <div style={{ flex: 1, fontWeight: 600 }}>
+            {items.length === 0 ? 'Nothing needs you' : `${items.filter(i => !i.acknowledged).length} need you`}
+          </div>
+          <kbd className="p4-kbd">⎋</kbd>
+        </div>
+
+        <div className="p4-palette-list">
+          {items.length === 0 && (
+            <div style={{ padding: 28, textAlign: 'center', color: 'var(--text-tertiary)', fontSize: 'var(--text-sm)' }}>
+              All quiet. Agents that need approval, are waiting for input, errored, or finished a turn will appear here.
+            </div>
+          )}
+
+          {items.map((it, i) => {
+            const status = mapTabStatus(it.session);
+            const meta = STATUS_META[status];
+            const color: RepoColor = status === 'errored' ? 'error'
+              : status === 'needs-approval' || status === 'awaiting' ? 'warn'
+              : status === 'done' ? 'success' : 'info';
+            return (
+              <div
+                key={it.session.id}
+                className={'p4-palette-row' + (sel === i ? ' on' : '')}
+                onMouseEnter={() => setSel(i)}
+                style={{ opacity: it.acknowledged ? 0.5 : 1, alignItems: 'flex-start' }}
+              >
+                <span style={{
+                  width: 20, height: 20, borderRadius: 5,
+                  background: colorBg(color), color: colorFg(color),
+                  display: 'grid', placeItems: 'center',
+                  fontFamily: 'var(--font-mono)', fontSize: 10, fontWeight: 700, flexShrink: 0,
+                }}>{initials(it.session.name)}</span>
+
+                <div style={{ flex: 1, marginLeft: 2, minWidth: 0 }}>
+                  <div className="txt" style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
+                    <span style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{it.session.name}</span>
+                    <span
+                      className={'p4-chip ' + (meta.chip || '')}
+                      style={{ flexShrink: 0, animation: meta.pulse ? 'p4-pulse 1.6s var(--ease-in-out) infinite' : undefined }}
+                    >
+                      <span style={{ width: 6, height: 6, borderRadius: '50%', background: meta.color, display: 'inline-block' }} />
+                      {meta.label}
+                    </span>
+                  </div>
+                  <div className="sub" style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                    {it.repoName ? `${it.repoName} · ` : ''}{agentLetter(it.session.providerId)}
+                    {it.preview ? ` · ${it.preview}` : ''}
+                  </div>
+                </div>
+
+                <div style={{ display: 'flex', gap: 6, flexShrink: 0 }}>
+                  <button className="p4-btn primary" style={{ padding: '4px 10px' }} onClick={() => jump(it.session.id)}>
+                    <P4Icon name="focus" size={12} /> Jump
+                  </button>
+                  <button className="p4-btn" style={{ padding: '4px 10px' }} onClick={() => onAcknowledge(it.session.id)}>
+                    Dismiss
+                  </button>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/renderer/components/shell/SessionRail.tsx
+++ b/src/renderer/components/shell/SessionRail.tsx
@@ -12,14 +12,44 @@ import type { RepoGroup } from '../../hooks/useRepos';
 import type { Repo } from '../../hooks/useRepos';
 import type { TabData } from '../ui/Tab';
 
-// ─── TabData (running/exited/error) → prototype's richer status set ───
+// ─── TabData → rich status ───
+// Process lifecycle (running/exited/error) is authoritative for terminal
+// states; while running, the classifier's fine-grained activityState (from the
+// session:stateChanged event) drives the status. Falls back to 'live' when no
+// classifier signal has arrived yet (back-compat / pre-classification).
 export function mapTabStatus(t: TabData): SessionStatus {
   if (t.status === 'error')  return 'errored';
   if (t.status === 'exited') return 'idle';
-  return 'live';
+  switch (t.activityState) {
+    case 'working':           return 'live';
+    case 'awaiting-approval': return 'needs-approval';
+    case 'awaiting-input':    return 'awaiting';
+    case 'done':              return 'done';
+    case 'errored':           return 'errored';
+    case 'idle':              return 'idle';
+    case 'initializing':      return 'live';
+    case 'exited':            return 'idle';
+    default:                  return 'live';
+  }
 }
 
-export const ACTIVE_STATUSES: SessionStatus[] = ['live', 'thinking', 'awaiting', 'errored'];
+export const ACTIVE_STATUSES: SessionStatus[] = ['live', 'thinking', 'awaiting', 'needs-approval', 'errored', 'done'];
+
+// Attention priority for ordering within the Active group — most urgent first.
+// Sessions the user must act on (a blocking approval, an error) rise to the top.
+const ATTENTION_PRIORITY: Record<SessionStatus, number> = {
+  'needs-approval': 0,
+  errored:          1,
+  awaiting:         2,
+  done:             3,
+  thinking:         4,
+  live:             5,
+  idle:             6,
+};
+
+export function attentionRank(t: TabData): number {
+  return ATTENTION_PRIORITY[mapTabStatus(t)] ?? 5;
+}
 
 // ─── Sessions are scoped to a repo by mainRepoPath OR working-directory prefix ───
 export function sessionsForRepo(repo: Repo, sessions: TabData[]): TabData[] {
@@ -215,10 +245,13 @@ export function SessionRail({
   // For group view, we still split active/idle but ALSO sub-group by repo.
   // In single-repo mode, apply the persisted drag order for this repo.
   const singleOrder = !group ? sessionOrders?.[repo.id] : undefined;
-  const active = applyOrder(
+  // Apply the persisted drag order, then float attention-urgent sessions
+  // (needs-approval / errored) to the top. Array.sort is stable, so the drag
+  // order is preserved within each attention rank — reordering still works.
+  const active = [...applyOrder(
     allRepoSessions.filter(s => ACTIVE_STATUSES.includes(mapTabStatus(s)) && matches(s)),
     singleOrder,
-  );
+  )].sort((a, b) => attentionRank(a) - attentionRank(b));
   const idle = applyOrder(
     allRepoSessions.filter(s => !ACTIVE_STATUSES.includes(mapTabStatus(s)) && matches(s)),
     singleOrder,

--- a/src/renderer/components/shell/StatusBar.tsx
+++ b/src/renderer/components/shell/StatusBar.tsx
@@ -12,6 +12,10 @@ interface StatusBarProps {
   /** Burn rate, USD per hour, displayed as N.NN /hr. Provide null if not yet known. */
   burnRatePerHour?: number | null;
   onOpenOtherReposLive: () => void;
+  /** Count of agents (across all repos) currently needing attention. */
+  needYouCount?: number;
+  /** Open the attention cockpit (⌘J). */
+  onOpenCockpit?: () => void;
 }
 
 export function StatusBar({
@@ -20,6 +24,8 @@ export function StatusBar({
   sessions,
   burnRatePerHour,
   onOpenOtherReposLive,
+  needYouCount = 0,
+  onOpenCockpit,
 }: StatusBarProps) {
   if (!repo) {
     return (
@@ -71,6 +77,22 @@ export function StatusBar({
       <span>
         {repoSessions.length} session{repoSessions.length === 1 ? '' : 's'} · {worktreeCount} worktree{worktreeCount === 1 ? '' : 's'}
       </span>
+
+      {needYouCount > 0 && (
+        <>
+          <span className="sep">|</span>
+          <button
+            type="button"
+            className="pill"
+            onClick={onOpenCockpit}
+            title="Agents that need you (⌘J)"
+            style={{ color: 'var(--warning)' }}
+          >
+            <P4Icon name="bolt" size={10} style={{ color: 'var(--warning)' }} />
+            {needYouCount} need you
+          </button>
+        </>
+      )}
 
       {otherLive > 0 && (
         <>

--- a/src/renderer/components/shell/shell-utils.ts
+++ b/src/renderer/components/shell/shell-utils.ts
@@ -4,7 +4,7 @@ import type { TabData } from '../ui/Tab';
 
 export type RepoColor = 'accent' | 'info' | 'success' | 'warn' | 'error' | 'neutral';
 
-export type SessionStatus = 'live' | 'thinking' | 'awaiting' | 'errored' | 'done' | 'idle';
+export type SessionStatus = 'live' | 'thinking' | 'awaiting' | 'needs-approval' | 'errored' | 'done' | 'idle';
 
 export const colorBg = (color: RepoColor | string | undefined): string => {
   switch (color) {
@@ -65,6 +65,9 @@ export const STATUS_META: Record<SessionStatus, StatusMeta> = {
   live:     { color: 'var(--success)',         label: 'live',           pulse: true,  chip: 'success' },
   thinking: { color: 'var(--accent)',          label: 'thinking',       pulse: true,  chip: 'accent' },
   awaiting: { color: 'var(--warning)',         label: 'awaiting input', pulse: false, chip: 'warn' },
+  // A decision is blocking the agent — highest attention. Non-pulsing (a
+  // decision reads differently from "still running") but the most urgent chip.
+  'needs-approval': { color: 'var(--warning)', label: 'needs approval', pulse: false, chip: 'warn' },
   errored:  { color: 'var(--error)',           label: 'errored',        pulse: false, chip: 'err' },
   done:     { color: 'var(--success)',         label: 'done',           pulse: false, chip: 'success' },
   idle:     { color: 'var(--text-tertiary)',   label: 'idle',           pulse: false, chip: '' },

--- a/src/renderer/components/ui/Tab.tsx
+++ b/src/renderer/components/ui/Tab.tsx
@@ -7,6 +7,7 @@
  */
 import { useState, useRef, useEffect } from 'react';
 import type { ProviderId } from '../../../shared/types/provider-types';
+import type { SessionActivityState } from '../../../shared/ipc-types';
 import { ProviderBadge } from './ProviderBadge';
 import { StatusDot, StatusDotState } from './StatusDot';
 // import { ShareIndicator } from './ShareIndicator'; // LaunchTunnel disabled
@@ -17,6 +18,8 @@ export interface TabData {
   workingDirectory: string;
   permissionMode:   'standard' | 'skip-permissions';
   status:           'running' | 'exited' | 'error';
+  /** Live classifier state (from session:stateChanged); drives the rich rail/cockpit status. */
+  activityState?:   SessionActivityState;
   worktreeBranch?:  string | null;
   /** Main repo this session is rooted under (set when session was created with a worktree). */
   mainRepoPath?:    string | null;

--- a/src/renderer/hooks/useAttentionQueue.test.ts
+++ b/src/renderer/hooks/useAttentionQueue.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import {
+  useAttentionQueue,
+  effectiveAttentionState,
+  isAttentionState,
+} from './useAttentionQueue';
+import type { TabData } from '../components/ui/Tab';
+import type { SessionActivityState } from '../../shared/ipc-types';
+
+function tab(id: string, status: TabData['status'], activityState?: SessionActivityState): TabData {
+  return { id, name: id, workingDirectory: '/x', permissionMode: 'standard', status, activityState };
+}
+
+const previews = { outputSnapshots: {}, lastActivityAt: {}, attach: vi.fn() } as any;
+const repoOf = (s: TabData) => ({ id: 'r1', name: 'repo-one' });
+
+describe('effectiveAttentionState', () => {
+  it('maps a failed process to errored regardless of activityState', () => {
+    expect(effectiveAttentionState(tab('a', 'error', 'working'))).toBe('errored');
+  });
+  it('a stopped session does not nag', () => {
+    expect(effectiveAttentionState(tab('a', 'exited', 'done'))).toBeUndefined();
+  });
+  it('a running session uses its classifier state', () => {
+    expect(effectiveAttentionState(tab('a', 'running', 'awaiting-approval'))).toBe('awaiting-approval');
+  });
+});
+
+describe('isAttentionState', () => {
+  it('true for the four attention states', () => {
+    for (const s of ['awaiting-approval', 'awaiting-input', 'errored', 'done'] as SessionActivityState[]) {
+      expect(isAttentionState(s)).toBe(true);
+    }
+  });
+  it('false for calm states', () => {
+    for (const s of ['working', 'idle', 'initializing', 'exited', undefined] as (SessionActivityState | undefined)[]) {
+      expect(isAttentionState(s)).toBe(false);
+    }
+  });
+});
+
+describe('useAttentionQueue', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('surfaces only attention sessions, most-urgent first', () => {
+    const sessions = [
+      tab('calm', 'running', 'working'),
+      tab('finished', 'running', 'done'),
+      tab('blocked', 'running', 'awaiting-approval'),
+      tab('broken', 'running', 'errored'),
+    ];
+    const { result } = renderHook(() =>
+      useAttentionQueue({ sessions, repoOf, previews, activeSessionId: null, onJump: vi.fn() }),
+    );
+    expect(result.current.items.map(i => i.session.id)).toEqual(['blocked', 'broken', 'finished']);
+    expect(result.current.count).toBe(3);
+  });
+
+  it('acknowledge suppresses a session from the count until its state changes', () => {
+    const sessions = [tab('blocked', 'running', 'awaiting-approval')];
+    const { result, rerender } = renderHook(
+      ({ s }) => useAttentionQueue({ sessions: s, repoOf, previews, activeSessionId: null, onJump: vi.fn() }),
+      { initialProps: { s: sessions } },
+    );
+    expect(result.current.count).toBe(1);
+    act(() => result.current.acknowledge('blocked'));
+    expect(result.current.count).toBe(0);
+    expect(result.current.items[0].acknowledged).toBe(true);
+
+    // State changes → resurfaces.
+    rerender({ s: [tab('blocked', 'running', 'errored')] });
+    expect(result.current.count).toBe(1);
+  });
+
+  it('fires a toast when a backgrounded session enters an urgent state', () => {
+    const spy = vi.spyOn(window, 'dispatchEvent');
+    const onJump = vi.fn();
+    const { rerender } = renderHook(
+      ({ s }) => useAttentionQueue({ sessions: s, repoOf, previews, activeSessionId: 'other', onJump }),
+      { initialProps: { s: [tab('blocked', 'running', 'working')] } },
+    );
+    spy.mockClear();
+    rerender({ s: [tab('blocked', 'running', 'awaiting-approval')] });
+    expect(spy).toHaveBeenCalled();
+  });
+
+  it('does NOT toast for the currently-active session', () => {
+    const spy = vi.spyOn(window, 'dispatchEvent');
+    const { rerender } = renderHook(
+      ({ s }) => useAttentionQueue({ sessions: s, repoOf, previews, activeSessionId: 'blocked', onJump: vi.fn() }),
+      { initialProps: { s: [tab('blocked', 'running', 'working')] } },
+    );
+    spy.mockClear();
+    rerender({ s: [tab('blocked', 'running', 'awaiting-approval')] });
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it('does NOT toast for a state that already exists on first mount (cold-attach)', () => {
+    const spy = vi.spyOn(window, 'dispatchEvent');
+    // Session is ALREADY awaiting-approval on the very first populated render —
+    // a phone cold-attaching, not a fresh transition.
+    renderHook(() =>
+      useAttentionQueue({
+        sessions: [tab('blocked', 'running', 'awaiting-approval')],
+        repoOf, previews, activeSessionId: 'other', onJump: vi.fn(),
+      }),
+    );
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it('re-arms after Dismiss: a session that leaves then re-enters the same state re-surfaces', () => {
+    const { result, rerender } = renderHook(
+      ({ s }) => useAttentionQueue({ sessions: s, repoOf, previews, activeSessionId: null, onJump: vi.fn() }),
+      { initialProps: { s: [tab('blocked', 'running', 'awaiting-approval')] } },
+    );
+    act(() => result.current.acknowledge('blocked'));
+    expect(result.current.count).toBe(0);
+
+    // Agent proceeds (leaves the approval state) …
+    rerender({ s: [tab('blocked', 'running', 'working')] });
+    // … then hits another approval. It must re-surface, not stay muted.
+    rerender({ s: [tab('blocked', 'running', 'awaiting-approval')] });
+    expect(result.current.count).toBe(1);
+    expect(result.current.items[0].acknowledged).toBe(false);
+  });
+});

--- a/src/renderer/hooks/useAttentionQueue.ts
+++ b/src/renderer/hooks/useAttentionQueue.ts
@@ -1,0 +1,166 @@
+// Derives the cross-repo "who needs you" queue from session activity state and
+// fires a notification when a backgrounded agent starts needing attention.
+// This is the routing layer of the supervisory cockpit.
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import type { TabData } from '../components/ui/Tab';
+import type { SessionActivityState } from '../../shared/ipc-types';
+import type { SessionPreviewsApi } from './useSessionPreviews';
+import { dispatchToast } from '../components/ui/ToastContainer';
+
+/** Attention states, most-urgent first. Sessions in any other state (working,
+ *  idle, initializing, exited) are calm and never surface. */
+const ATTENTION_PRIORITY: Partial<Record<SessionActivityState, number>> = {
+  'awaiting-approval': 0,
+  'awaiting-input': 1,
+  errored: 2,
+  done: 3,
+};
+
+/** States urgent enough to actively pull the user back with a toast. 'done' is
+ *  surfaced in the queue but does not interrupt. */
+const TOAST_STATES = new Set<SessionActivityState>(['awaiting-approval', 'awaiting-input', 'errored']);
+
+/** The effective attention state of a session: a failed process is 'errored'
+ *  regardless of any stale activityState; otherwise the classifier's state. */
+export function effectiveAttentionState(s: TabData): SessionActivityState | undefined {
+  if (s.status === 'error') return 'errored';
+  if (s.status === 'exited') return undefined; // a stopped session doesn't nag
+  return s.activityState;
+}
+
+export function isAttentionState(state: SessionActivityState | undefined): boolean {
+  return state !== undefined && state in ATTENTION_PRIORITY;
+}
+
+export interface AttentionItem {
+  session: TabData;
+  repoId: string | null;
+  repoName: string;
+  state: SessionActivityState;
+  preview: string;
+  lastActivityAt: number;
+  acknowledged: boolean;
+}
+
+export interface AttentionQueueApi {
+  /** All attention-needing sessions, most-urgent first (acknowledged included, sorted last within rank). */
+  items: AttentionItem[];
+  /** Count of UNacknowledged attention sessions (for badges). */
+  count: number;
+  /** Mark a session seen so it stops re-alerting until its state changes again. */
+  acknowledge: (sessionId: string) => void;
+}
+
+export interface UseAttentionQueueOptions {
+  sessions: TabData[];
+  repoOf: (s: TabData) => { id: string; name: string } | null;
+  previews: SessionPreviewsApi;
+  activeSessionId: string | null;
+  onJump: (sessionId: string) => void;
+}
+
+function lastNonEmptyLine(lines: string[] | undefined): string {
+  if (!lines) return '';
+  for (let i = lines.length - 1; i >= 0; i--) {
+    const t = lines[i].trim();
+    if (t) return t;
+  }
+  return '';
+}
+
+export function useAttentionQueue(opts: UseAttentionQueueOptions): AttentionQueueApi {
+  const { sessions, repoOf, previews, activeSessionId, onJump } = opts;
+
+  // sessionId → the activityState at which it was acknowledged. A session is
+  // suppressed only while its state still equals the acknowledged state.
+  const [acked, setAcked] = useState<Record<string, SessionActivityState>>({});
+
+  const acknowledge = useCallback((sessionId: string) => {
+    const s = sessions.find(x => x.id === sessionId);
+    const state = s && effectiveAttentionState(s);
+    if (!state) return;
+    setAcked(prev => ({ ...prev, [sessionId]: state }));
+  }, [sessions]);
+
+  const items = useMemo<AttentionItem[]>(() => {
+    const list: AttentionItem[] = [];
+    for (const s of sessions) {
+      const state = effectiveAttentionState(s);
+      if (!isAttentionState(state)) continue;
+      const repo = repoOf(s);
+      list.push({
+        session: s,
+        repoId: repo?.id ?? null,
+        repoName: repo?.name ?? '',
+        state: state!,
+        preview: lastNonEmptyLine(previews.outputSnapshots[s.id]),
+        lastActivityAt: previews.lastActivityAt[s.id] ?? 0,
+        acknowledged: acked[s.id] === state,
+      });
+    }
+    // Unacknowledged first, then by urgency, then longest-waiting first.
+    return list.sort((a, b) => {
+      if (a.acknowledged !== b.acknowledged) return a.acknowledged ? 1 : -1;
+      const pa = ATTENTION_PRIORITY[a.state] ?? 9;
+      const pb = ATTENTION_PRIORITY[b.state] ?? 9;
+      if (pa !== pb) return pa - pb;
+      return a.lastActivityAt - b.lastActivityAt;
+    });
+  }, [sessions, repoOf, previews.outputSnapshots, previews.lastActivityAt, acked]);
+
+  const count = useMemo(() => items.filter(i => !i.acknowledged).length, [items]);
+
+  // Fire a toast when a BACKGROUNDED session newly enters an urgent state.
+  const prevStates = useRef<Map<string, SessionActivityState | undefined>>(new Map());
+  const seeded = useRef(false);
+  useEffect(() => {
+    // First populated pass: seed prior states WITHOUT toasting, so pre-existing
+    // states (a renderer reload, or a phone cold-attaching to running sessions)
+    // aren't mistaken for fresh transitions.
+    const seedingRun = !seeded.current && sessions.length > 0;
+
+    for (const s of sessions) {
+      const state = effectiveAttentionState(s);
+      const prev = prevStates.current.get(s.id);
+      prevStates.current.set(s.id, state);
+      if (seedingRun) continue;
+      if (state === prev) continue;
+      if (!state || !TOAST_STATES.has(state)) continue;
+      if (s.id === activeSessionId) continue;        // user is already looking at it
+      if (acked[s.id] === state) continue;           // already acknowledged this state
+      const label =
+        state === 'awaiting-approval' ? 'needs your approval'
+        : state === 'awaiting-input' ? 'is waiting for input'
+        : 'hit an error';
+      dispatchToast('', 'warning', 30000, {
+        title: `${s.name} ${label}`,
+        body: repoOf(s)?.name ?? '',
+        actions: [{ label: 'Jump', onClick: () => onJump(s.id), variant: 'primary' }],
+      });
+    }
+    if (seedingRun) seeded.current = true;
+
+    // Drop prevStates for sessions that no longer exist.
+    const live = new Set(sessions.map(s => s.id));
+    for (const id of prevStates.current.keys()) {
+      if (!live.has(id)) prevStates.current.delete(id);
+    }
+
+    // Re-arm acknowledgements: drop any acked entry whose session has LEFT the
+    // acknowledged state (changed state, went calm, or closed), so the next
+    // entry into an attention state alerts again instead of staying muted.
+    const staleAcked = Object.keys(acked).filter(id => {
+      const s = sessions.find(x => x.id === id);
+      return !s || effectiveAttentionState(s) !== acked[id];
+    });
+    if (staleAcked.length > 0) {
+      setAcked(prev => {
+        const next = { ...prev };
+        for (const id of staleAcked) delete next[id];
+        return next;
+      });
+    }
+  }, [sessions, activeSessionId, acked, repoOf, onJump]);
+
+  return { items, count, acknowledge };
+}

--- a/src/renderer/hooks/useSessionManager.ts
+++ b/src/renderer/hooks/useSessionManager.ts
@@ -26,6 +26,7 @@ function sessionMetadataToTabData(metadata: SessionMetadata): TabData {
     workingDirectory: metadata.workingDirectory,
     permissionMode: metadata.permissionMode,
     status: metadata.status === 'starting' ? 'running' : metadata.status,
+    activityState: metadata.activityState,
     worktreeBranch: metadata.worktreeInfo?.branch ?? null,
     mainRepoPath: metadata.worktreeInfo?.mainRepoPath ?? null,
     providerId: metadata.providerId,
@@ -92,6 +93,14 @@ export function useSessionManager(): UseSessionManagerReturn {
       ));
     });
 
+    // Live activity state from the session-state classifier — folded into the
+    // session's TabData so the rail/inspector/cockpit render the rich status.
+    const cleanupStateChanged = window.electronAPI.onSessionStateChanged((event) => {
+      setSessions(prev => prev.map(s =>
+        s.id === event.sessionId ? { ...s, activityState: event.state } : s
+      ));
+    });
+
     return () => {
       cleanupCreated();
       cleanupClosed();
@@ -99,6 +108,7 @@ export function useSessionManager(): UseSessionManagerReturn {
       cleanupUpdated();
       cleanupOutput();
       cleanupExited();
+      cleanupStateChanged();
     };
   }, []);
 

--- a/src/shared/ipc-contract.ts
+++ b/src/shared/ipc-contract.ts
@@ -32,6 +32,7 @@ import type {
   AppVersionInfo,
   ClaudeModel,
   ModelSwitchEvent,
+  SessionStateChangeEvent,
   RemoteAccessStatus,
   STTStatus,
   STTTranscribeRequest,
@@ -143,6 +144,7 @@ export interface IPCContractMap {
   onSessionOutput:     EventContract<'session:output',   SessionOutput>;
   onSessionExited:     EventContract<'session:exited',   SessionExitEvent>;
   onModelChanged:      EventContract<'model:changed',    ModelSwitchEvent>;
+  onSessionStateChanged: EventContract<'session:stateChanged', SessionStateChangeEvent>;
 
   // ── Dialogs & File system (invoke) ──
   browseDirectory:     InvokeContract<'dialog:browseDirectory', [],                              string | null>;
@@ -316,6 +318,7 @@ export const channels: { [K in keyof IPCContractMap]: ChannelOf<K> } = {
   onSessionOutput:     'session:output',
   onSessionExited:     'session:exited',
   onModelChanged:      'model:changed',
+  onSessionStateChanged: 'session:stateChanged',
 
   // Dialogs
   browseDirectory:     'dialog:browseDirectory',
@@ -479,6 +482,7 @@ export const contractKinds: { [K in keyof IPCContractMap]: KindOf<K> } = {
   onSessionOutput:     'event',
   onSessionExited:     'event',
   onModelChanged:      'event',
+  onSessionStateChanged: 'event',
 
   browseDirectory:     'invoke',
   showSaveDialog:      'invoke',

--- a/src/shared/ipc-types.ts
+++ b/src/shared/ipc-types.ts
@@ -25,6 +25,31 @@ export type LaunchMode = 'default' | 'bypass-permissions' | 'agents' | 'continue
 // Session status
 export type SessionStatus = 'starting' | 'running' | 'exited' | 'error';
 
+/**
+ * Fine-grained live activity state of a session, derived by the
+ * SessionStateClassifier from the PTY output stream (plus authoritative exit
+ * events). Distinct from the coarse process-lifecycle `SessionStatus`. This is
+ * the signal the attention-router cockpit routes on. Transient — never
+ * persisted; reset to 'initializing' on load.
+ */
+export type SessionActivityState =
+  | 'initializing'      // PTY up, CLI not yet at its ready banner
+  | 'working'           // actively producing output / interrupt affordance present
+  | 'awaiting-approval' // blocked on a permission/trust prompt — highest urgency
+  | 'awaiting-input'    // quiescent at a prompt carrying a pending question
+  | 'done'              // quiescent after a turn's output, unacknowledged
+  | 'errored'           // non-zero exit, or a fatal error banner while quiescent
+  | 'idle'              // quiescent, nothing new since last acknowledge
+  | 'exited';           // clean / user-initiated exit
+
+/** Emitted when a session's activity state changes (delta only). */
+export interface SessionStateChangeEvent {
+  sessionId: string;
+  state: SessionActivityState;
+  reason?: string; // optional human-readable cause (e.g. matched signal name)
+  at: number;      // epoch ms
+}
+
 // Claude model types
 export type ClaudeModel = 'sonnet' | 'opus' | 'haiku' | 'auto';
 
@@ -60,6 +85,7 @@ export interface SessionMetadata {
   model?: ClaudeModel; // The model the session was launched with (starting intent; restored on restart)
   launchMode?: LaunchMode; // The launch mode the session was created with (restored on restart)
   currentModel?: ClaudeModel | null; // null = not yet detected (live-detected, distinct from `model`)
+  activityState?: SessionActivityState; // Live classifier state (transient — never persisted)
   worktreeInfo?: import('./types/git-types').WorktreeInfo;
   providerId?: ProviderId; // Provider backing this session (defaults to 'claude')
   kind?: SessionKind; // undefined treated as 'agent' for back-compat

--- a/src/shared/line-reducer.test.ts
+++ b/src/shared/line-reducer.test.ts
@@ -1,0 +1,163 @@
+import { describe, it, expect } from 'vitest';
+import { reduceLines } from './line-reducer';
+
+describe('reduceLines', () => {
+  describe('plain multiline passthrough', () => {
+    it.each([
+      ['single line, no trailing newline', 'hello world', 'hello world'],
+      ['multiple lines, no trailing newline', 'line1\nline2\nline3', 'line1\nline2\nline3'],
+      [
+        'multiple lines, trailing newline is a trailing blank line (trimmed)',
+        'line1\nline2\nline3\n',
+        'line1\nline2\nline3',
+      ],
+      ['blank interior line is preserved', 'line1\n\nline3', 'line1\n\nline3'],
+    ])('%s', (_label, raw, expected) => {
+      expect(reduceLines(raw)).toBe(expected);
+    });
+  });
+
+  describe('carriage-return overwrite', () => {
+    it.each([
+      ['full overwrite of equal-length text', 'hello\rworld', 'world'],
+      ['partial overwrite keeps the un-overwritten tail', 'hello\rhi', 'hillo'],
+      [
+        'overwrite across a longer replacement extends the line',
+        'hi\rhello',
+        'hello',
+      ],
+      [
+        '\\r\\n pair behaves like a normal newline (returns then feeds)',
+        'foo\r\nbar',
+        'foo\nbar',
+      ],
+    ])('%s', (_label, raw, expected) => {
+      expect(reduceLines(raw)).toBe(expected);
+    });
+  });
+
+  describe('CSI K erase-in-line', () => {
+    it('CSI 2K (erase whole line) clears prior content before a repaint', () => {
+      // \r returns to col 0, 2K erases the whole line regardless of cursor
+      // position, then "xyz" is written fresh at col 0.
+      const raw = 'abcdef\r\x1b[2Kxyz';
+      expect(reduceLines(raw)).toBe('xyz');
+    });
+
+    it('CSI K / CSI 0K (default, erase to end of line)', () => {
+      // Position cursor at column 3 (1-based col 4) via CSI G, then erase to
+      // end of line — "def" should disappear, "abc" remains.
+      const raw = 'abcdef\x1b[4G\x1b[K';
+      expect(reduceLines(raw)).toBe('abc');
+
+      const rawExplicitZero = 'abcdef\x1b[4G\x1b[0K';
+      expect(reduceLines(rawExplicitZero)).toBe('abc');
+    });
+
+    it('CSI 1K (erase from start of line to cursor, inclusive)', () => {
+      // Cursor at column 3 (0-based), erase-to-cursor blanks columns 0..3,
+      // leaving the tail "ef" past the erased region.
+      const raw = 'abcdef\x1b[4G\x1b[1K';
+      expect(reduceLines(raw)).toBe('    ef');
+    });
+  });
+
+  describe('cursor movement (CSI A/B/G)', () => {
+    it('CSI G moves to an absolute column (1-based) for the next write', () => {
+      const raw = 'abcdef\x1b[1Gxy';
+      // Column 1 == index 0, so "xy" overwrites "ab".
+      expect(reduceLines(raw)).toBe('xycdef');
+    });
+
+    it('CSI A (cursor up) is clamped to the top of the buffer', () => {
+      // Cursor movement only changes the row, not the column — \r pins the
+      // column back to 0 so the overwrite lands predictably on "first".
+      const raw = 'first\nsecond\x1b[99A\rX';
+      // 99 rows up from row 1 clamps to row 0, "X" overwrites the "f".
+      expect(reduceLines(raw)).toBe('Xirst\nsecond');
+    });
+
+    it('CSI B (cursor down) is clamped to the bottom of the buffer', () => {
+      const raw = 'first\nsecond\x1b[5A\rX\x1b[99B\rY';
+      // Up 5 clamps to row 0 ("Xirst"), down 99 clamps back to the last
+      // existing row (row 1, "second"), "Y" overwrites the "s".
+      expect(reduceLines(raw)).toBe('Xirst\nYecond');
+    });
+  });
+
+  describe('the smear case: cursor-up + erase + repaint', () => {
+    it('replaces a multi-line approval box with a repainted prompt, no leftover box text', () => {
+      const box = 'Do you want to proceed?\n> Yes\n> No\n';
+      const redraw =
+        '\x1b[3A' + // back up to the top of the 3-line box
+        '\x1b[2K\x1b[1B' + // erase line 1, step down
+        '\x1b[2K\x1b[1B' + // erase line 2, step down
+        '\x1b[2K' + // erase line 3
+        '\x1b[3A' + // back up to the top again
+        'Continue? [y/n]: y'; // repaint a single-line prompt
+      const raw = box + redraw;
+
+      const result = reduceLines(raw);
+
+      expect(result).toBe('Continue? [y/n]: y');
+      expect(result).not.toContain('proceed');
+      expect(result).not.toContain('Yes');
+      expect(result).not.toContain('No');
+    });
+
+    it('a spinner line repainted in place via \\r + erase never accumulates frames', () => {
+      const raw =
+        'Working...\r' +
+        'Working.. \r' +
+        'Working.  \r' +
+        'Working   \r' +
+        '\x1b[K' + // erase-to-end clears the leftover spinner tail before the final write
+        'Done.';
+      expect(reduceLines(raw)).toBe('Done.');
+    });
+  });
+
+  describe('opaque escape sequences (SGR/color) are passed through, not re-rendered', () => {
+    it('keeps unknown CSI sequences inline as literal text', () => {
+      const raw = '\x1b[31mred text\x1b[0m';
+      expect(reduceLines(raw)).toBe(raw);
+    });
+
+    it('opaque sequences still occupy cursor cells and can be overwritten', () => {
+      const raw = '\x1b[31mred\x1b[0m\rXXX';
+      // \r returns to col 0; "XXX" overwrites the first 3 characters of the
+      // buffered line, whatever they are (here, the start of the SGR escape).
+      const withoutCr = '\x1b[31mred\x1b[0m';
+      expect(reduceLines(raw)).toBe('XXX' + withoutCr.slice(3));
+    });
+  });
+
+  describe('maxLines truncation', () => {
+    it('keeps only the last N lines, default 40', () => {
+      const lines = Array.from({ length: 50 }, (_, i) => `line${i + 1}`);
+      const raw = lines.join('\n');
+
+      const defaultResult = reduceLines(raw);
+      expect(defaultResult.split('\n')).toHaveLength(40);
+      expect(defaultResult.split('\n')[0]).toBe('line11');
+      expect(defaultResult.split('\n').at(-1)).toBe('line50');
+
+      const truncated = reduceLines(raw, 5);
+      expect(truncated).toBe('line46\nline47\nline48\nline49\nline50');
+    });
+
+    it('returns everything when under the limit', () => {
+      expect(reduceLines('a\nb\nc', 10)).toBe('a\nb\nc');
+    });
+  });
+
+  describe('empty input', () => {
+    it('returns an empty string for empty input', () => {
+      expect(reduceLines('')).toBe('');
+    });
+
+    it('returns an empty string for input that is only newlines', () => {
+      expect(reduceLines('\n\n\n')).toBe('');
+    });
+  });
+});

--- a/src/shared/line-reducer.ts
+++ b/src/shared/line-reducer.ts
@@ -1,0 +1,140 @@
+// Pure line-reducer for the session-state classifier's terminal tail.
+//
+// Models a small slice of a terminal's *visual* line buffer well enough that
+// in-place repaints (spinners, approval boxes redrawn as a prompt, etc.)
+// collapse to their final on-screen text instead of smearing every byte the
+// PTY ever emitted into one long scroll. It interprets a handful of control
+// sequences structurally — everything else (including SGR/color CSI
+// sequences) is written through as opaque text, never re-rendered.
+//
+// Pure, dependency-free, O(n) over the input. No imports from `src/main` —
+// this lives in `shared` and must stay side-effect free.
+
+/** Control sequences we understand structurally. Everything else is opaque text. */
+const CONTROL_CHAR_RE = /[\x1b\n\r]/;
+
+/** Matches one CSI sequence: ESC '[' params intermediates final-byte. */
+const CSI_RE = /^\x1b\[([0-9;:<=>?]*)([ -/]*)([@-~])/;
+
+/**
+ * Reduce a raw terminal byte stream to its final visual tail.
+ *
+ * Interprets, from the cursor's point of view:
+ *   - `\n`            start a new line (cursor to column 0 of a fresh row)
+ *   - `\r`             cursor to column 0 of the *current* row (overwrite mode)
+ *   - CSI `K`/`0K`/`1K`/`2K` erase-in-line (to end / to cursor / whole line)
+ *   - CSI `<n>A` / `<n>B` cursor up/down `n` rows, clamped within the buffer
+ *   - CSI `<n>G`      cursor to column `n` (1-based)
+ *   - anything else (plain text, other CSI/SGR sequences) is written verbatim
+ *     at the cursor, overwriting whatever cells it lands on.
+ *
+ * Returns the last `maxLines` visual lines (default 40), newline-joined, with
+ * trailing blank lines trimmed.
+ */
+export function reduceLines(raw: string, maxLines = 40): string {
+  const lines: string[] = [''];
+  let row = 0;
+  let col = 0;
+
+  const writeAt = (text: string): void => {
+    if (text.length === 0) return;
+    const line = lines[row] ?? '';
+    const padded = line.length < col ? line + ' '.repeat(col - line.length) : line;
+    lines[row] = padded.slice(0, col) + text + padded.slice(col + text.length);
+    col += text.length;
+  };
+
+  const eraseInLine = (param: number): void => {
+    const line = lines[row] ?? '';
+    if (param === 2) {
+      lines[row] = '';
+    } else if (param === 1) {
+      const eraseLen = col + 1;
+      lines[row] =
+        eraseLen >= line.length
+          ? ' '.repeat(line.length)
+          : ' '.repeat(eraseLen) + line.slice(eraseLen);
+    } else {
+      // param 0 (default): erase from cursor to end of line.
+      lines[row] = line.slice(0, col);
+    }
+  };
+
+  let i = 0;
+  const n = raw.length;
+  while (i < n) {
+    const ch = raw[i];
+
+    if (ch === '\n') {
+      row += 1;
+      col = 0;
+      if (row === lines.length) lines.push('');
+      i += 1;
+      continue;
+    }
+
+    if (ch === '\r') {
+      col = 0;
+      i += 1;
+      continue;
+    }
+
+    if (ch === '\x1b') {
+      const rest = raw.slice(i);
+      const m = CSI_RE.exec(rest);
+      if (m) {
+        const [full, paramStr, , final] = m;
+        const firstParam = paramStr.split(';')[0];
+        const param = firstParam === '' ? undefined : parseInt(firstParam, 10);
+        switch (final) {
+          case 'K':
+            eraseInLine(param === undefined || Number.isNaN(param) ? 0 : param);
+            break;
+          case 'A': {
+            const step = param === undefined || Number.isNaN(param) || param === 0 ? 1 : param;
+            row = Math.max(0, row - step);
+            break;
+          }
+          case 'B': {
+            const step = param === undefined || Number.isNaN(param) || param === 0 ? 1 : param;
+            row = Math.min(lines.length - 1, row + step);
+            break;
+          }
+          case 'G': {
+            const target = param === undefined || Number.isNaN(param) || param === 0 ? 1 : param;
+            col = Math.max(0, target - 1);
+            break;
+          }
+          default:
+            // Any other CSI (SGR colors, cursor position, etc.) — keep as
+            // opaque text written at the cursor. Do not attempt to render it.
+            writeAt(full);
+            break;
+        }
+        i += full.length;
+        continue;
+      }
+      // Non-CSI escape (e.g. lone ESC, or a 2-byte escape we don't parse):
+      // treat as opaque text so nothing is silently dropped.
+      const opaque = i + 1 < n ? raw.slice(i, i + 2) : raw.slice(i, i + 1);
+      writeAt(opaque);
+      i += opaque.length;
+      continue;
+    }
+
+    // Plain printable run: batch up to the next control character.
+    const rest = raw.slice(i);
+    const nextControl = rest.search(CONTROL_CHAR_RE);
+    const run = nextControl === -1 ? rest : rest.slice(0, nextControl);
+    writeAt(run);
+    i += run.length;
+  }
+
+  // Trim trailing fully-blank lines, then keep only the tail.
+  let end = lines.length;
+  while (end > 0 && lines[end - 1].trim() === '') end -= 1;
+  const trimmed = lines.slice(0, end);
+  const tail = trimmed.slice(Math.max(0, trimmed.length - maxLines));
+
+  return tail.join('\n');
+}

--- a/src/shared/session-state-types.ts
+++ b/src/shared/session-state-types.ts
@@ -1,0 +1,41 @@
+// Shared contract for the session-state classifier pieces. Kept in `shared`
+// (RegExp is fine here — StateSignals never crosses the IPC boundary, it is
+// only used in-process by the main-process classifier).
+
+/**
+ * Per-provider regex tables the classifier matches against the (reduced,
+ * ANSI-stripped) terminal tail. Each provider (Claude, Codex, …) supplies its
+ * own via `IProvider.getStateSignals()`.
+ */
+export interface StateSignals {
+  /** Agent is actively working — e.g. an interrupt affordance or spinner. */
+  working: RegExp[];
+  /** A permission/approval prompt is blocking on the user (highest urgency). */
+  approval: RegExp[];
+  /** An interactive prompt carrying a pending question for the user. */
+  awaitingInput: RegExp[];
+  /** A fatal error banner (rate limit, credit balance, API error). */
+  fatalError: RegExp[];
+}
+
+/**
+ * The subset of activity states the *pure text detector* can infer from the
+ * tail at a quiescence tick. It has no knowledge of PTY exit codes — the
+ * stateful classifier fuses those in separately (→ 'exited'/'errored'), and
+ * owns 'initializing'/'working' transitions on the leading edge.
+ */
+export type CandidateState =
+  | 'working'
+  | 'awaiting-approval'
+  | 'awaiting-input'
+  | 'done'
+  | 'errored'
+  | 'idle';
+
+/** Inputs to the pure detector at a quiescence evaluation. */
+export interface DetectContext {
+  /** Substantive output was produced since the user last viewed/acknowledged. */
+  hadOutputSinceView: boolean;
+  /** An interrupt affordance (e.g. "esc to interrupt") is currently present. */
+  interruptAffordance: boolean;
+}

--- a/src/shared/state-detector.test.ts
+++ b/src/shared/state-detector.test.ts
@@ -1,0 +1,256 @@
+import { describe, it, expect } from 'vitest';
+import { detectStateFromTail } from './state-detector';
+import type { StateSignals, DetectContext } from './session-state-types';
+
+// Synthetic, order-revealing signal tables. Each table matches a distinct,
+// non-overlapping keyword so priority-order tests are unambiguous.
+const signals: StateSignals = {
+  working: [/WORKING_SPINNER/],
+  approval: [/Do you want to proceed\?/, /APPROVAL_MARK/],
+  awaitingInput: [/AWAIT_INPUT_MARK/, /\? .*›/],
+  fatalError: [/FATAL_ERROR_MARK/, /rate limit/i],
+};
+
+function ctx(over: Partial<DetectContext> = {}): DetectContext {
+  return { hadOutputSinceView: false, interruptAffordance: false, ...over };
+}
+
+describe('detectStateFromTail', () => {
+  describe('rule 1: interrupt-affordance veto', () => {
+    it('returns working when interruptAffordance is set, even with no tail', () => {
+      expect(
+        detectStateFromTail('', signals, ctx({ interruptAffordance: true })),
+      ).toBe('working');
+    });
+
+    it('beats an approval match in the tail', () => {
+      const tail = 'Do you want to proceed?';
+      expect(
+        detectStateFromTail(tail, signals, ctx({ interruptAffordance: true })),
+      ).toBe('working');
+    });
+
+    it('beats an awaiting-input match in the tail', () => {
+      const tail = 'AWAIT_INPUT_MARK';
+      expect(
+        detectStateFromTail(tail, signals, ctx({ interruptAffordance: true })),
+      ).toBe('working');
+    });
+
+    it('beats a fatal-error match in the tail', () => {
+      const tail = 'FATAL_ERROR_MARK';
+      expect(
+        detectStateFromTail(tail, signals, ctx({ interruptAffordance: true })),
+      ).toBe('working');
+    });
+
+    it('beats a done classification (had output)', () => {
+      expect(
+        detectStateFromTail(
+          'some output',
+          signals,
+          ctx({ interruptAffordance: true, hadOutputSinceView: true }),
+        ),
+      ).toBe('working');
+    });
+  });
+
+  describe('rule 2: priority order (approval > awaiting-input > fatal error)', () => {
+    it('approval beats awaiting-input when both present', () => {
+      const tail = 'AWAIT_INPUT_MARK\nAPPROVAL_MARK';
+      expect(detectStateFromTail(tail, signals, ctx())).toBe(
+        'awaiting-approval',
+      );
+    });
+
+    it('approval beats fatal error when both present', () => {
+      const tail = 'FATAL_ERROR_MARK\nAPPROVAL_MARK';
+      expect(detectStateFromTail(tail, signals, ctx())).toBe(
+        'awaiting-approval',
+      );
+    });
+
+    it('awaiting-input beats fatal error when both present', () => {
+      const tail = 'FATAL_ERROR_MARK\nAWAIT_INPUT_MARK';
+      expect(detectStateFromTail(tail, signals, ctx())).toBe('awaiting-input');
+    });
+
+    it('all three present resolves to approval', () => {
+      const tail = 'FATAL_ERROR_MARK\nAWAIT_INPUT_MARK\nAPPROVAL_MARK';
+      expect(detectStateFromTail(tail, signals, ctx())).toBe(
+        'awaiting-approval',
+      );
+    });
+
+    it('lone approval → awaiting-approval', () => {
+      expect(
+        detectStateFromTail('Do you want to proceed?', signals, ctx()),
+      ).toBe('awaiting-approval');
+    });
+
+    it('lone awaiting-input → awaiting-input', () => {
+      expect(
+        detectStateFromTail('What is your name? foo ›', signals, ctx()),
+      ).toBe('awaiting-input');
+    });
+
+    it('lone fatal error → errored', () => {
+      expect(
+        detectStateFromTail('rate limit exceeded', signals, ctx()),
+      ).toBe('errored');
+    });
+  });
+
+  describe('tail-end anchoring', () => {
+    it('does NOT match a keyword buried far above the last 12 non-empty lines', () => {
+      const lines = [
+        'APPROVAL_MARK', // line 0 — far up, should be scrolled past
+      ];
+      for (let i = 0; i < 20; i++) {
+        lines.push(`filler output line ${i}`);
+      }
+      const tail = lines.join('\n');
+      // 20 filler lines sit between the mark and the end → mark is outside the
+      // trailing 12-line window. Had output, so falls through to 'done'.
+      expect(
+        detectStateFromTail(tail, signals, ctx({ hadOutputSinceView: true })),
+      ).toBe('done');
+    });
+
+    it('DOES match the same keyword when it sits at the tail end', () => {
+      const lines: string[] = [];
+      for (let i = 0; i < 20; i++) {
+        lines.push(`filler output line ${i}`);
+      }
+      lines.push('APPROVAL_MARK'); // at the very end — inside the window
+      const tail = lines.join('\n');
+      expect(
+        detectStateFromTail(tail, signals, ctx({ hadOutputSinceView: true })),
+      ).toBe('awaiting-approval');
+    });
+
+    it('ignores empty/blank lines when counting the trailing window', () => {
+      // Mark, then 11 non-empty lines but padded with many blank lines. Since
+      // blank lines are not counted, the mark stays inside the 12 non-empty
+      // window and still fires.
+      const lines = ['APPROVAL_MARK'];
+      for (let i = 0; i < 11; i++) {
+        lines.push('');
+        lines.push(`content ${i}`);
+        lines.push('');
+      }
+      const tail = lines.join('\n');
+      expect(detectStateFromTail(tail, signals, ctx())).toBe(
+        'awaiting-approval',
+      );
+    });
+
+    it('drops the mark once >12 non-empty lines follow it', () => {
+      const lines = ['APPROVAL_MARK'];
+      for (let i = 0; i < 13; i++) {
+        lines.push(`content ${i}`);
+      }
+      const tail = lines.join('\n');
+      expect(
+        detectStateFromTail(tail, signals, ctx({ hadOutputSinceView: true })),
+      ).toBe('done');
+    });
+  });
+
+  describe('rule 3: done vs idle fallback', () => {
+    it('no match + hadOutputSinceView → done (bias to surface)', () => {
+      expect(
+        detectStateFromTail(
+          'just some finished output\nnothing special',
+          signals,
+          ctx({ hadOutputSinceView: true }),
+        ),
+      ).toBe('done');
+    });
+
+    it('no match + no output since view → idle', () => {
+      expect(
+        detectStateFromTail(
+          'just some finished output\nnothing special',
+          signals,
+          ctx({ hadOutputSinceView: false }),
+        ),
+      ).toBe('idle');
+    });
+
+    it('empty tail with no output → idle', () => {
+      expect(detectStateFromTail('', signals, ctx())).toBe('idle');
+    });
+
+    it('empty tail with output flag → done', () => {
+      expect(
+        detectStateFromTail('', signals, ctx({ hadOutputSinceView: true })),
+      ).toBe('done');
+    });
+
+    it('whitespace-only tail with no output → idle', () => {
+      expect(
+        detectStateFromTail('   \n\n  \n', signals, ctx()),
+      ).toBe('idle');
+    });
+  });
+
+  describe('working table is not consulted by the pure detector', () => {
+    it('a working-spinner match without interruptAffordance does NOT force working', () => {
+      // The pure detector only promotes to 'working' via interruptAffordance;
+      // the working table is owned by the stateful classifier's leading edge.
+      expect(
+        detectStateFromTail(
+          'WORKING_SPINNER',
+          signals,
+          ctx({ hadOutputSinceView: true }),
+        ),
+      ).toBe('done');
+    });
+  });
+
+  describe('tail-end anchoring preserves original line order', () => {
+    // A multi-line signal (like the real Claude approval triad "1. Yes … 2. Yes,")
+    // must match across lines in READING order. Regression: the anchor used to
+    // reverse the kept lines, which broke ordered multi-line patterns.
+    const orderedSignals: StateSignals = {
+      working: [],
+      approval: [/\b1\.\s*Yes\b[\s\S]{0,120}\b2\.\s*Yes,/i],
+      awaitingInput: [],
+      fatalError: [],
+    };
+
+    it('matches a multi-line approval pattern when lines are in reading order', () => {
+      const tail = [
+        'Do you want to proceed?',
+        '❯ 1. Yes',
+        '  2. Yes, and don\'t ask again',
+        '  3. No',
+      ].join('\n');
+      expect(detectStateFromTail(tail, orderedSignals, ctx())).toBe('awaiting-approval');
+    });
+
+    it('only considers the last TAIL_END_LINES — a far-up match does not fire', () => {
+      const noise = Array.from({ length: 30 }, (_, i) => `log line ${i}`);
+      const tail = ['APPROVAL_MARK', ...noise].join('\n'); // marker scrolled far up
+      expect(detectStateFromTail(tail, signals, ctx({ hadOutputSinceView: true }))).toBe('done');
+    });
+
+    it('matches the same marker when it is at the tail end', () => {
+      const noise = Array.from({ length: 5 }, (_, i) => `log line ${i}`);
+      const tail = [...noise, 'APPROVAL_MARK'].join('\n');
+      expect(detectStateFromTail(tail, signals, ctx())).toBe('awaiting-approval');
+    });
+  });
+
+  describe('purity: repeated calls are stable', () => {
+    it('same inputs yield same output across calls (no regex state leak)', () => {
+      const tail = 'FATAL_ERROR_MARK';
+      const c = ctx();
+      const first = detectStateFromTail(tail, signals, c);
+      const second = detectStateFromTail(tail, signals, c);
+      expect(first).toBe('errored');
+      expect(second).toBe('errored');
+    });
+  });
+});

--- a/src/shared/state-detector.ts
+++ b/src/shared/state-detector.ts
@@ -1,0 +1,91 @@
+// Pure text detector for the session-state classifier. Given an already
+// line-reduced, ANSI-stripped terminal tail plus a small context, it infers a
+// CandidateState at a *quiescence tick* (output has gone quiet). It has no
+// side effects and allocates only what it needs to anchor to the tail end.
+
+import type {
+  StateSignals,
+  CandidateState,
+  DetectContext,
+} from './session-state-types';
+
+/**
+ * How many trailing non-empty lines of the tail we consider. Anchoring to the
+ * end prevents a scrolled-past prompt earlier in the buffer from re-firing.
+ */
+const TAIL_END_LINES = 12;
+
+/**
+ * Infer the candidate activity state from a quiet terminal tail.
+ *
+ * The tail is assumed to be ALREADY line-reduced and ANSI-stripped (plain
+ * text) — this function does not strip again.
+ *
+ * Rule order (bias-to-surface):
+ *   1. interruptAffordance vetoes any quiet-state promotion → 'working'.
+ *   2. Anchored to the tail end, first table to match wins, in priority:
+ *      approval → awaiting-input → fatal error.
+ *   3. Nothing matched: hadOutputSinceView → 'done' (surface it), else 'idle'.
+ */
+export function detectStateFromTail(
+  reducedTail: string,
+  signals: StateSignals,
+  ctx: DetectContext,
+): CandidateState {
+  // 1. An interrupt affordance means the agent is still busy on a slow/silent
+  //    tool call — veto any quiet-state promotion.
+  if (ctx.interruptAffordance) {
+    return 'working';
+  }
+
+  // 2. Anchor to the last ~12 non-empty lines so an old, scrolled-past prompt
+  //    does not re-fire. Build the anchored text once, then test tables in
+  //    priority order.
+  const anchored = anchorToTailEnd(reducedTail);
+
+  if (anyMatch(signals.approval, anchored)) {
+    return 'awaiting-approval';
+  }
+  if (anyMatch(signals.awaitingInput, anchored)) {
+    return 'awaiting-input';
+  }
+  if (anyMatch(signals.fatalError, anchored)) {
+    return 'errored';
+  }
+
+  // 3. Nothing matched — bias to surface real output as an unacknowledged
+  //    'done' turn; only fall back to 'idle' when there was nothing to show.
+  return ctx.hadOutputSinceView ? 'done' : 'idle';
+}
+
+/** Join the last TAIL_END_LINES non-empty lines back into a string, preserving
+ *  their ORIGINAL top-to-bottom order. Order matters: a provider signal may be
+ *  a multi-line regex (e.g. the Claude approval table matches "1. Yes … 2. Yes,"
+ *  in reading order), so the anchored text must not be reversed. */
+function anchorToTailEnd(reducedTail: string): string {
+  const lines = reducedTail.split('\n');
+  // Find the start index of the last TAIL_END_LINES non-empty lines, then slice
+  // forward so original order (and blank-line adjacency) is preserved.
+  let seen = 0;
+  let startIdx = 0;
+  for (let i = lines.length - 1; i >= 0; i--) {
+    if (lines[i].trim().length > 0) {
+      seen++;
+      if (seen >= TAIL_END_LINES) { startIdx = i; break; }
+    }
+  }
+  return lines.slice(startIdx).join('\n');
+}
+
+/** True if any regex in the table matches the text. */
+function anyMatch(table: RegExp[], text: string): boolean {
+  for (const re of table) {
+    // Reset lastIndex defensively in case a caller passes a /g or /y regex —
+    // .test() on a sticky/global regex is stateful and would otherwise skip.
+    re.lastIndex = 0;
+    if (re.test(text)) {
+      return true;
+    }
+  }
+  return false;
+}


### PR DESCRIPTION
Builds on the Phase 0 foundation (#54, merged). This is **rung one of the supervisory cockpit**: OmniDesk now classifies each session's live state from its PTY output and routes your attention to whichever agent needs you. Design: `docs/design/2026-07-19-agentic-cockpit-design.md`.

## Phase 1 — SessionStateClassifier (main process)

Each PTY stream → a `SessionActivityState` (`initializing / working / awaiting-approval / awaiting-input / done / errored / idle / exited`). Fuses output patterns + output-idle timing + alt-screen + authoritative exit code, with asymmetric hysteresis (instant on the leading edge, 2-tick dwell before settling) so it doesn't flap.

- Pure, table-tested modules in `src/shared`: `line-reducer` (collapses CR/erase/cursor repaints so an answered approval box leaves the tail), `state-detector` (tail-end-anchored, priority-ordered, bias-to-surface), and a main-side `alt-screen-tracker` (membership-tested DECSET, fixes audit R4.1).
- Per-provider marker tables behind `IProvider.getStateSignals()`. Claude authored from its real TUI; **Codex provisional** (flagged in-code — needs a live transcript).
- Wired into `SessionManager` at the single output tap; new `session:stateChanged` IPC event auto-derives across preload + remote WS.

## Phase 2 — rich rail status

Produces the status vocabulary that was defined but unreachable (audit R3.5): added `needs-approval`; `mapTabStatus` folds `activityState` 1:1; the Active group floats urgent sessions up (stable sort preserves drag order).

## Phase 3 — the attention cockpit

`useAttentionQueue` + `CockpitPanel` (⌘J): a cross-repo "who needs you" list sorted by urgency, with Jump/Dismiss. A backgrounded session entering an urgent state fires a persistent Jump toast (works on the phone via the existing remote fan-out); StatusBar shows an "N need you" pill.

## Adversarial review (built in)

A 4-dimension Opus review + independent verify pass found **12 confirmed defects**, all fixed in this PR — notably a stale-manager exit race that could tear down a healthy session, crashes being invisible (exited masking errored), a bare `·` pinning Claude sessions to `working`, and Dismiss never re-arming. See the Phase 3 commit body for the full list.

## Verification

- **670 tests** green (line-reducer, state-detector, alt-screen, classifier, useAttentionQueue, provider false-positive locks, session-manager stale-guard/crash-status).
- Both tsconfigs typecheck clean; both builds pass.
- No E2E (per standing preference to verify UI manually). **Recommend a manual smoke:** run a Codex session (renders, not blank) and confirm ⌘J + a backgrounded approval toast.

## Known limitations (deferred to Phase 4, per spec)

Agent sessions settle to `done` rather than `idle` (no `markViewed` signal yet); Codex signal tables are provisional pending a captured transcript; inline Approve-from-toast is out of scope for rung one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)