### PR TITLE
fix(cockpit): defer agent classification to a headless-emulator rewrite

### DIFF
--- a/docs/design/2026-07-19-agentic-cockpit-design.md
+++ b/docs/design/2026-07-19-agentic-cockpit-design.md
@@ -4,6 +4,32 @@
 **Status:** Approved direction; ready for implementation planning
 **Rung:** One (attention router + its foundation) of the supervisory-cockpit ladder
 
+> ## ⚠️ Update (2026-07-19) — agent classification deferred; headless emulator required
+>
+> Live testing against **Claude Code v2.1.x** proved the tail-based classifier
+> (§4: rolling byte tail + output quiescence) **cannot classify agent CLIs**.
+> Confirmed from instrumented logs: Claude Code renders its entire REPL in the
+> terminal's **alternate-screen buffer** (`?1049h`) and **repaints continuously**
+> — even when idle (footer/token counter). So the classifier never observes a
+> "quiet" tail to settle on, and the alt-screen guard holds it pinned. This is
+> the §8 "repaint/alt-buffer" risk — but it applies to Claude's **normal** REPL,
+> not only `agents` mode as originally scoped.
+>
+> **Decision:** ship the cockpit **plumbing** (rail vocabulary, ⌘J overlay,
+> toasts, IPC, StatusBar pill) plus **shell-session** classification, and gate
+> the classifier to `kind === 'shell'` (see `SessionManager.setupClassifier`).
+> Agent sessions surface only their process lifecycle for now (running via the
+> rail default; errored/exited via `SessionMetadata.status`).
+>
+> **Correct fix (next):** classify the **rendered screen**, not a byte tail —
+> feed each PTY into a headless terminal emulator (`@xterm/headless`, the pure-JS
+> sibling of the renderer's xterm) and match markers against the visible buffer
+> on a fixed interval. xterm handles the alt-screen + absolute-cursor repaints
+> internally, so no quiescence is needed and what we classify equals what the
+> user sees. This reuses `IProvider.getStateSignals()` + the pure detector and
+> replaces `line-reducer` + `alt-screen-tracker`. It is the Phase-4 "headless
+> emulator" item, promoted to required for agent classification.
+
 ## 1. Problem & Direction
 
 OmniDesk today is a **session host**: a human opens a repo, spawns a Claude/Codex session per worktree, and drives each terminal by hand. The human is the orchestrator. We are pivoting OmniDesk toward being a **supervisory cockpit** — the app classifies each session's live state from its PTY output and routes the user's attention to whichever agent needs them (needs-approval / waiting-for-input / errored / done), so the user supervises a fleet instead of babysitting terminals.

--- a/src/main/providers/claude-provider.test.ts
+++ b/src/main/providers/claude-provider.test.ts
@@ -236,8 +236,13 @@ describe('ClaudeProvider.getStateSignals', () => {
   const sig = provider.getStateSignals();
   const anyMatch = (table: RegExp[], s: string) => table.some(re => { re.lastIndex = 0; return re.test(s); });
 
-  it('working does NOT match a bare middle-dot (would pin every session to working)', () => {
+  it('working does NOT match decorative glyph bullets that persist in the tail', () => {
+    // The exact regression: Claude prints a star bullet on completed-turn and
+    // status lines that STAY in the tail; matching it pinned sessions to working.
+    expect(anyMatch(sig.working, '✳ Brewed for 29s')).toBe(false);
+    expect(anyMatch(sig.working, '✳ Elucidating… (17s · ↓ 106 tokens)')).toBe(false);
     expect(anyMatch(sig.working, '1,234 tokens · $0.12')).toBe(false);
+    // The transient, reliable signal still matches.
     expect(anyMatch(sig.working, 'esc to interrupt')).toBe(true);
   });
 

--- a/src/main/providers/claude-provider.ts
+++ b/src/main/providers/claude-provider.ts
@@ -10,15 +10,16 @@ import type { StateSignals } from '../../shared/session-state-types';
 // State-classifier marker tables for Claude Code's TUI. Matched against the
 // line-reduced, ANSI-stripped tail of the session's output.
 const CLAUDE_STATE_SIGNALS: StateSignals = {
-  // In-flight markers that survive in-place repaints. "esc to interrupt" is the
-  // reliable one; the spinner glyphs are the distinctive star + braille frames.
-  // A bare middle-dot '·' is deliberately NOT here — it appears in ordinary
-  // output/footers and would pin every session to 'working'.
+  // In-flight markers. "esc to interrupt" is the reliable, transient one — it
+  // shows only while a turn is generating. Decorative glyphs are NOT used: Claude
+  // prints the SAME star glyphs (✻✽✳✢) as static bullets on completed-turn lines
+  // ("✳ Brewed for 29s"), which persist in the tail and would pin the session to
+  // 'working' forever. The braille frames are animation-only but dropped for the
+  // same reason — glyph-anywhere matching is fragile. Active generation is held
+  // as 'working' by the leading-edge output detector, not by a glyph.
   working: [
     /esc to interrupt/i,
     /\besc\b\s+to\s+interrupt/i,
-    /[⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏]/,
-    /[✻✽✳✢]/,
   ],
   // Permission / trust prompts, anchored to the tail end by the detector. The
   // structural numbered selector is the strong, box-specific signal; the verb

--- a/src/main/session-manager.ts
+++ b/src/main/session-manager.ts
@@ -353,35 +353,29 @@ export class SessionManager {
     return metadata;
   }
 
-  /** Wire a CLIManager's model-change / output / exit callbacks to session
-   *  state. Used by BOTH createSession and restartSession so the two paths
-   *  cannot drift (they previously had — restart silently dropped the
-   *  scrollback append and the session-end notification). This is also the
-   *  single output tap the session-state classifier will hook into. */
-  /** Resolve the state-signal tables for a session's provider (empty for shells
-   *  or when the provider can't be resolved). */
-  private stateSignalsFor(sessionId: string): StateSignals {
-    const meta = this.sessions.get(sessionId)?.metadata;
-    if (!meta || meta.kind === 'shell') return EMPTY_STATE_SIGNALS;
-    try {
-      return this.providerRegistry?.get(meta.providerId ?? 'claude')?.getStateSignals() ?? EMPTY_STATE_SIGNALS;
-    } catch {
-      return EMPTY_STATE_SIGNALS;
-    }
-  }
-
-  /** Create (replacing any prior) the activity-state classifier for a session
-   *  and broadcast its transitions. */
-  private setupClassifier(sessionId: string): SessionStateClassifier {
+  /** Create (replacing any prior) the activity-state classifier for a session.
+   *
+   *  Currently only SHELL sessions are classified. Agent CLIs (Claude Code,
+   *  Codex) render as full-screen TUIs in the terminal's ALTERNATE-SCREEN buffer
+   *  and repaint continuously (even when idle), which the output-tail +
+   *  quiescence model cannot classify — it can never observe "quiet", and the
+   *  alt-screen holds it pinned. Their live state (working / awaiting-approval /
+   *  done) is DEFERRED to a headless-terminal-emulator rewrite that classifies
+   *  the rendered screen instead of a byte tail. Until then agent sessions
+   *  surface only their process lifecycle: running (rail default) and
+   *  errored/exited via SessionMetadata.status. See the design doc's
+   *  "Known limitations". */
+  private setupClassifier(sessionId: string): void {
     this.classifiers.get(sessionId)?.dispose();
+    this.classifiers.delete(sessionId);
     const kind = this.sessions.get(sessionId)?.metadata.kind;
+    if (kind !== 'shell') return;
     const classifier = new SessionStateClassifier({
-      signals: this.stateSignalsFor(sessionId),
+      signals: EMPTY_STATE_SIGNALS,
       kind,
       onStateChange: (state, reason) => this.emitActivityState(sessionId, state, reason),
     });
     this.classifiers.set(sessionId, classifier);
-    return classifier;
   }
 
   /** Record + broadcast a session's live activity state (transient, not persisted). */


### PR DESCRIPTION
## What live testing found

The tail-based `SessionStateClassifier` (from #55) **cannot classify Claude/Codex sessions**. Instrumented logs proved it:

```
[cls d6a6b0] quiesce: SUPPRESSED (alt-screen active), holding working   ← forever
[cls 071698] output #200 altScreen=true last="…bypass permissions on…"
```

**Claude Code v2.1.x renders its whole REPL in the terminal's alternate-screen buffer and repaints continuously — even when idle.** So the output-quiescence model never sees a settled tail, and the alt-screen guard pins the session to `working`/`live` forever. Shells work (different code path). This is the design's own §8 "repaint/alt-buffer" risk — it just applies to Claude's *normal* REPL, not only `agents` mode.

## This PR (the deferral the user chose)

- **Gate the classifier to `kind === 'shell'`** (`SessionManager.setupClassifier`). Agent sessions are no longer classified — no misleading pinned state, no wasted per-second timer. They surface **running** (rail default) and **errored/exited** via `SessionMetadata.status`, which is independent of output parsing and still works.
- **Keep all cockpit plumbing**: rail status vocabulary, ⌘J overlay, background toasts, IPC event, StatusBar "N need you" pill, and shell classification.
- **Drop the ✳ star glyphs** from Claude's `working` table — Claude uses the same glyph as a static bullet on completed-turn lines (`✳ Brewed for 29s`), a latent false-veto for the coming rewrite. Locked with a provider test.
- **Document the finding + correct fix** in the design-doc callout.

## The correct fix (next PR — promoted Phase 4, now required)

Classify the **rendered screen**, not a byte tail: feed each PTY into **`@xterm/headless`** (pure-JS sibling of the renderer's xterm) and match markers against the visible buffer on a fixed interval. xterm handles the alt-screen + absolute-cursor repaints internally, so no quiescence is needed and what we classify equals what the user sees. Reuses `getStateSignals()` + the detector; replaces `line-reducer` + `alt-screen-tracker`.

## Verification

- Full suite **670 green**; both tsconfigs + both builds clean.
- Shells classify (`working` → `idle`); agents show `live` while running and `errored` on a non-zero exit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)