### PR TITLE
probe(cockpit): BEL-as-attention-signal instrumentation + findings (GO)

### DIFF
--- a/docs/experiments/2026-07-19-bell-attention-probe.md
+++ b/docs/experiments/2026-07-19-bell-attention-probe.md
@@ -1,0 +1,79 @@
+# Bell-as-attention-signal probe — findings (2026-07-19)
+
+**Question:** can the terminal bell (`\x07`/BEL) give the attention cockpit a reliable
+"this agent session needs you" signal for Claude Code sessions, sidestepping the
+alt-screen-repaint problem that blocks the tail classifier (see the deferral callout in
+`docs/design/2026-07-19-agentic-cockpit-design.md`)?
+
+**Answer: yes — GO on the bell path.** With one required setting and one required filter,
+the bell fires at exactly the moments the cockpit needs and stays silent otherwise.
+
+## Environment (results are bounded to this)
+
+- Claude Code **v2.1.215**, launched by OmniDesk (instrumented build from this branch),
+  Windows 11, session launch mode **bypass-permissions** (the user's normal mode).
+- Probe: `BellScanner` in the `wireCliManager` PTY tap, enabled via `OMNIDESK_DEBUG_BELL`,
+  logging every `\x07` with timestamp + ~40 chars of surrounding bytes.
+- Probe control-tested end-to-end: a deliberate `\x07` from a plain shell session was
+  captured byte-for-byte before any conclusions were drawn.
+
+## Observed (real bytes, live driven session)
+
+| Moment | Bell? | Evidence |
+|---|---|---|
+| Claude working (3 full turns incl. multi-minute tool use) | **silent** | zero probe hits mid-turn |
+| **Turn finished, back at prompt** | **rings** | 2/2 turns; bare BEL right after the final repaint frame (`…\x1b[?25h\x1b[?2026l⟬BEL⟭`); arrives at completion or within ~1 min (may be the "waiting for input" notification — either serves supervision) |
+| **AskUserQuestion picker on screen** | **rings** | bare BEL as the dialog painted (`… to cancel…⟬BEL⟭`) |
+| Option selected in the picker | **false positive** | BEL was the terminator of an OSC 52 clipboard sequence (base64 payload immediately before it) — not a notification |
+| Any of the above with **default settings** | **never rings** | full turn observed pre-setting: zero hits. `preferredNotifChannel: "terminal_bell"` is **required** (docs agree: bell is opt-in outside Ghostty/Kitty/iTerm2) |
+
+Not observed (honestly untested):
+
+- **Permission approval box** — the user runs bypass mode, so none appeared. Docs state the
+  notification fires on permission pauses; treat as likely-but-unverified.
+- **Idle re-ring cadence** — whether the bell repeats while a session stays ignored is unknown.
+
+## The two mandatory conditions
+
+1. **`preferredNotifChannel: "terminal_bell"`** in the active profile's `settings.json`
+   (now set in both `~/.claude-work` and `~/.claude-personal`). Without it: zero bells, ever.
+   Product implication: OmniDesk must check/offer this setting or the cockpit stays dark.
+2. **Escape-sequence-aware BEL discrimination.** BEL doubles as the OSC string terminator
+   (`ESC]…\x07` — window titles, OSC 52 clipboard writes). A naive `\x07` counter misfires;
+   observed live (finding #3). The detector must track "inside OSC string" state and count
+   only bare BELs — a small parser in the spirit of the existing `alt-screen-tracker`.
+
+## Claude Code hooks (assessed, not built)
+
+Hooks are the richer sibling and work regardless of the bell setting:
+
+- `Stop` fires every turn end; `Notification` has matchers `permission_prompt`,
+  `idle_prompt`, and (v2.1.198+) `agent_needs_input` / `agent_completed`. Payload is JSON on
+  stdin with `session_id` — a hook writing a marker file (or hitting a localhost endpoint)
+  would give OmniDesk **differentiated** events (approval vs question vs done) instead of one
+  undifferentiated ding. The user's profiles already run Stop/SessionStart hooks (brain,
+  stoke monitor), so the mechanism is proven in this environment.
+- Cost: no documented per-invocation injection (no CLI flag/env var) — OmniDesk would have
+  to write into settings files (user profile or repo-local `.claude/settings.local.json`)
+  and correlate `session_id`→PTY. Feasible, but real config-management surface.
+
+## Recommendation
+
+1. **GO — ship the bell path now** (small, provider-agnostic, reuses everything):
+   detect bare BEL (OSC-aware) in the existing tap for `kind === 'agent'` sessions →
+   `emitActivityState(sessionId, 'awaiting-input', 'bell')` through the already-built
+   `onSessionStateChanged` → cockpit/toasts light up with zero renderer changes. Clear the
+   state when the user sends input to that session. The bell can't distinguish "done" from
+   "question waiting", so it maps to one honest "needs you" state — which is the cockpit's
+   core promise.
+2. **Hooks as the phase-2 upgrade** if differentiated states or bell-independence prove
+   worth the config-injection cost.
+3. **Headless-emulator rewrite: not needed for the attention signal.** Keep it parked;
+   it only pays if we later want screen-content states (e.g. error banners) beyond
+   needs-you/working.
+
+## Probe artifacts
+
+- `src/main/session-state/bell-probe.ts` (+ unit tests) — kept behind `OMNIDESK_DEBUG_BELL`
+  as a debugging affordance; zero effect when the flag is unset.
+- Wiring: ~15 lines in `SessionManager.wireCliManager`.

--- a/src/main/session-manager.ts
+++ b/src/main/session-manager.ts
@@ -16,6 +16,8 @@ import {
   SessionActivityState,
 } from '../shared/ipc-types';
 import { SessionStateClassifier } from './session-state/classifier';
+import { BellScanner } from './session-state/bell-probe';
+import { appendFile } from 'fs';
 import type { StateSignals } from '../shared/session-state-types';
 import {
   loadSessionState,
@@ -396,6 +398,12 @@ export class SessionManager {
     // current one, so a stale manager can't tear down or feed a live session.
     const isStale = () => this.sessions.get(sessionId)?.cliManager !== mgr;
 
+    // OMNIDESK_DEBUG_BELL: probe instrumentation for the "BEL as agent
+    // attention signal" experiment — logs every \x07 with context. Set to a
+    // file path to also append there; any other value logs to console only.
+    const bellEnv = process.env.OMNIDESK_DEBUG_BELL;
+    const bellScanner = bellEnv ? new BellScanner() : null;
+
     mgr.onModelChange((model: ClaudeModel) => {
       const session = this.sessions.get(sessionId);
       if (!session || isStale()) return;
@@ -422,6 +430,19 @@ export class SessionManager {
 
       // Feed the activity-state classifier (the attention-router signal).
       this.classifiers.get(sessionId)?.onOutput(data);
+
+      if (bellScanner) {
+        const sessKind = this.sessions.get(sessionId)?.metadata.kind ?? 'agent';
+        for (const ev of bellScanner.feed(data)) {
+          const line =
+            `[bell-probe] ${new Date().toISOString()} session=${sessionId} ` +
+            `kind=${sessKind} #${ev.seq} ctx=${ev.context}`;
+          console.log(line);
+          if (bellEnv && /[\\/]/.test(bellEnv)) {
+            appendFile(bellEnv, line + '\n', () => {});
+          }
+        }
+      }
 
       // Record to history (async, non-blocking). Pass kind so shells skip the
       // Claude-ready gate (and don't leak an unbounded pre-ready buffer).

--- a/src/main/session-state/bell-probe.test.ts
+++ b/src/main/session-state/bell-probe.test.ts
@@ -1,0 +1,76 @@
+// Tests for the BEL (\x07) probe scanner — experiment instrumentation for the
+// "bell as agent attention signal" investigation (OMNIDESK_DEBUG_BELL).
+import { describe, it, expect } from 'vitest';
+import { BellScanner } from './bell-probe';
+
+describe('BellScanner', () => {
+  it('returns no events for chunks without a BEL', () => {
+    const s = new BellScanner();
+    expect(s.feed('hello world')).toEqual([]);
+    expect(s.feed('\x1b[2Jmore output')).toEqual([]);
+  });
+
+  it('detects a single BEL with surrounding context', () => {
+    const s = new BellScanner();
+    const events = s.feed('before-the-bell\x07after-the-bell');
+    expect(events).toHaveLength(1);
+    expect(events[0].seq).toBe(1);
+    expect(events[0].context).toContain('before-the-bell');
+    expect(events[0].context).toContain('after-the-bell');
+    expect(events[0].context).toContain('⟬BEL⟭');
+  });
+
+  it('bounds context to ~40 chars each side', () => {
+    const s = new BellScanner();
+    const before = 'A'.repeat(100);
+    const after = 'B'.repeat(100);
+    const [ev] = s.feed(`${before}\x07${after}`);
+    const [pre, post] = ev.context.split('⟬BEL⟭');
+    expect(pre.length).toBeLessThanOrEqual(40);
+    expect(post.length).toBeLessThanOrEqual(40);
+    expect(pre).toBe('A'.repeat(40));
+    expect(post).toBe('B'.repeat(40));
+  });
+
+  it('detects multiple BELs in one chunk with incrementing seq', () => {
+    const s = new BellScanner();
+    const events = s.feed('one\x07two\x07three');
+    expect(events).toHaveLength(2);
+    expect(events.map(e => e.seq)).toEqual([1, 2]);
+    expect(events[0].context).toContain('one');
+    expect(events[0].context).toContain('two');
+    expect(events[1].context).toContain('three');
+  });
+
+  it('carries context across chunk boundaries (16ms flush split)', () => {
+    const s = new BellScanner();
+    expect(s.feed('tail-of-previous-chunk')).toEqual([]);
+    const [ev] = s.feed('\x07start-of-next');
+    // Leading context must come from the PREVIOUS chunk's tail.
+    expect(ev.context).toContain('tail-of-previous-chunk');
+    expect(ev.context).toContain('start-of-next');
+  });
+
+  it('increments seq across separate feeds', () => {
+    const s = new BellScanner();
+    s.feed('x\x07y');
+    const [ev] = s.feed('z\x07w');
+    expect(ev.seq).toBe(2);
+  });
+
+  it('escapes control characters in context so logs stay one-line readable', () => {
+    const s = new BellScanner();
+    const [ev] = s.feed('\x1b[31mred\x1b[0m\x07\r\nnext');
+    expect(ev.context).not.toMatch(/[\x00-\x1f]/); // no raw control bytes
+    expect(ev.context).toContain('\\x1b'); // ESC rendered as escape sequence
+    expect(ev.context).toContain('\\r\\n');
+  });
+
+  it('counts a BEL as exactly one event even at the very end of a chunk', () => {
+    const s = new BellScanner();
+    const events = s.feed('ends-with-bell\x07');
+    expect(events).toHaveLength(1);
+    // Following chunk must not re-report it.
+    expect(s.feed('later output')).toEqual([]);
+  });
+});

--- a/src/main/session-state/bell-probe.ts
+++ b/src/main/session-state/bell-probe.ts
@@ -1,0 +1,58 @@
+// BEL (\x07) probe scanner — EXPERIMENT instrumentation, enabled only via the
+// OMNIDESK_DEBUG_BELL env flag (see SessionManager.wireCliManager).
+//
+// Hypothesis under test: agent CLIs (Claude Code) ring the terminal bell at
+// "needs the user" moments (permission prompt, turn finish), giving the
+// attention-router a byte-cheap signal that sidesteps the alt-screen repaint
+// problem that blocks tail classification. This scanner only OBSERVES: it
+// reports every BEL with ~40 chars of surrounding context so a real session
+// can be recorded byte-for-byte. No classification, no state changes.
+
+/** Context window kept on each side of a BEL (chars). */
+const CONTEXT = 40;
+
+export interface BellEvent {
+  /** 1-based ordinal of this BEL within the session. */
+  seq: number;
+  /** Escaped, one-line context: ≤40 chars before + '⟬BEL⟭' + ≤40 chars after. */
+  context: string;
+}
+
+/** Render control bytes as printable escapes so log lines stay single-line. */
+function escapeControl(text: string): string {
+  return text.replace(/[\x00-\x1f\x7f]/g, ch => {
+    if (ch === '\r') return '\\r';
+    if (ch === '\n') return '\\n';
+    if (ch === '\t') return '\\t';
+    return `\\x${ch.charCodeAt(0).toString(16).padStart(2, '0')}`;
+  });
+}
+
+/**
+ * Stateful per-session scanner. Feed it every flushed PTY chunk; it returns a
+ * BellEvent per \x07 found. Keeps the previous chunk's tail so a BEL landing
+ * right after a 16ms flush boundary still gets leading context.
+ */
+export class BellScanner {
+  private tail = '';
+  private seq = 0;
+
+  feed(data: string): BellEvent[] {
+    if (!data.includes('\x07')) {
+      this.tail = (this.tail + data).slice(-CONTEXT);
+      return [];
+    }
+    const buf = this.tail + data;
+    const offset = this.tail.length;
+    const events: BellEvent[] = [];
+    for (let i = 0; i < data.length; i++) {
+      if (data[i] !== '\x07') continue;
+      const pos = offset + i;
+      const before = escapeControl(buf.slice(Math.max(0, pos - CONTEXT), pos));
+      const after = escapeControl(buf.slice(pos + 1, pos + 1 + CONTEXT));
+      events.push({ seq: ++this.seq, context: `${before}⟬BEL⟭${after}` });
+    }
+    this.tail = buf.slice(-CONTEXT);
+    return events;
+  }
+}


### PR DESCRIPTION
## What

Experiment probe for the deferred agent-session classification (#56): can the terminal bell (\x07) give the attention cockpit a reliable "needs you" signal for Claude Code sessions?

- `BellScanner` (`src/main/session-state/bell-probe.ts`, 8 unit tests): scans PTY chunks for BEL with ~40-char context, chunk-boundary safe. Active only under `OMNIDESK_DEBUG_BELL`; zero effect otherwise.
- ~15 lines of wiring in `SessionManager.wireCliManager`.
- Findings note: `docs/experiments/2026-07-19-bell-attention-probe.md`.

## Findings (live-driven Claude Code v2.1.215 session, byte-for-byte)

| Moment | Bell? |
|---|---|
| Working (3 turns) | silent |
| Turn finished | rings (2/2) |
| AskUserQuestion picker | rings |
| Option selected | false positive — BEL as OSC 52 terminator |
| Default settings | never — `preferredNotifChannel: "terminal_bell"` required |

**Recommendation: GO on the cheap bell path** (OSC-aware bare-BEL detection → existing `onSessionStateChanged`), hooks as phase-2 for differentiated states, headless-emulator rewrite not needed for the attention signal. Details + honest gaps (approval prompt untested, idle cadence unknown) in the findings note.

## Verification

- TDD; full suite green (71 files / 678 tests), both typechecks, both builds (CI-mirrored preflight).
- Probe control-tested end-to-end with a deliberate shell BEL before trusting any negative result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)