### PR TITLE
ci(build): use npm ci instead of bun install in the build job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,33 +19,28 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - name: Setup Bun
-      uses: oven-sh/setup-bun@v2
-      with:
-        bun-version: latest
-
     - name: Use Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v4
       with:
         node-version: ${{ matrix.node-version }}
 
     - name: Install dependencies
-      run: bun install
+      run: npm ci
 
     - name: Type check (renderer + shared)
-      run: bun run tsc --noEmit
+      run: npx tsc --noEmit
 
     - name: Type check (main process)
-      run: bun run tsc -p tsconfig.main.json --noEmit
+      run: npx tsc -p tsconfig.main.json --noEmit
 
     - name: Build TypeScript (main process)
-      run: bun run build:electron
+      run: npm run build:electron
 
     - name: Build React app (renderer)
-      run: bun run build
+      run: npm run build
 
     - name: Run tests
-      run: bun run test:ci
+      run: npm run test:ci
 
     - name: Upload coverage
       if: matrix.os == 'ubuntu-latest' && matrix.node-version == '20.x'
@@ -56,7 +51,7 @@ jobs:
         if-no-files-found: warn
 
   # E2E tests require Electron + node-pty native module which can't launch in CI.
-  # Run locally with: bun run test:e2e
+  # Run locally with: npm run test:e2e
 
   # Packaging is heavy (full electron-builder across 3 OSes) and redundant on
   # PRs — release.yml builds and publishes installers on v* tags. Run it only on


### PR DESCRIPTION
Closes #62

## What changed

The CI `build` job in `.github/workflows/ci.yml` used `bun install` while every other install site in the repo — the `package` job in the same workflow, both jobs in `release.yml`, and the `npm install` instructions in `README.md` and `CONTRIBUTING.md` — uses npm. Because no `bun.lockb` is committed, `bun install` re-resolved the semver ranges in `package.json` on every run, so the build/test job could be exercising different transitive dependency versions than what `npm ci` produces on contributor machines, in the `package` job below it, and in `release.yml`. Native modules like `node-pty` and `@xenova/transformers` are especially sensitive to that drift.

This PR aligns the `build` job with the rest of the repo:

- drop the `Setup Bun` step and the `oven-sh/setup-bun@v2` dependency
- replace `bun install` with `npm ci`
- replace `bun run tsc --noEmit`, `bun run tsc -p tsconfig.main.json --noEmit`, `bun run build:electron`, `bun run build`, and `bun run test:ci` with their `npx tsc` / `npm run …` equivalents
- update the local-only e2e comment from `bun run test:e2e` to `npm run test:e2e` (matches what `README.md` L267 and `CONTRIBUTING.md` L236 already document)

The `package` job and `release.yml` are unchanged. No `bun.lockb` is introduced. `README.md` and `CONTRIBUTING.md` already document `npm install` and remain accurate.

## Why this and not the alternative

The issue notes an alternative fix: commit `bun.lockb`, switch all jobs and `release.yml` to `bun install --frozen-lockfile`, drop `package-lock.json`, and update the docs. That is a much larger change and was explicitly declared out of scope on the issue, so this PR takes the narrower fix. No new dependencies added.

## Verification

Ran the exact commands the updated build job runs, locally on Windows against Node 22.x:

- `npm ci` — installed 661 packages cleanly against the committed `package-lock.json`
- `npx tsc --noEmit` — exit 0
- `npx tsc -p tsconfig.main.json --noEmit` — exit 0
- `npm run build:electron` — exit 0
- `npm run build` — exit 0, vite build succeeded
- `npm run test:ci` — exit 0, `<testsuites tests="818" failures="0" errors="0">`

The three-OS × Node 20.x/22.x matrix will be exercised by this PR's own CI run, which is now the same install path as the `package` job and `release.yml`.

## Acceptance criteria

- [x] `ci.yml` `build` job installs deps with `npm ci` (no `bun install`, no `setup-bun` step)
- [x] All script invocations in the `build` job use `npm run …` / `npx …` — no `bun run` remains in `ci.yml`
- [x] `build` and `package` jobs in `ci.yml` use the same install tool as each other and as `release.yml`
- [ ] CI passes on ubuntu / windows / macos × Node 20.x / 22.x — verified by this PR's CI
- [x] No new lockfile introduced (`bun.lockb` not committed)
- [x] `README.md` and `CONTRIBUTING.md` `npm install` instructions remain accurate — no changes needed