### PR TITLE
docs(readme): use dynamic version shield and drop hardcoded test count

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,7 @@
 
 ![License](https://img.shields.io/badge/license-MIT-blue.svg)
 ![Platform](https://img.shields.io/badge/platform-Windows%20%7C%20macOS%20%7C%20Linux-lightgrey.svg)
-![Version](https://img.shields.io/badge/version-2.4.0-green.svg)
-![Tests](https://img.shields.io/badge/tests-670%20passing-brightgreen.svg)
+![Version](https://img.shields.io/github/package-json/v/carloluisito/omnidesk)
 
 > A multi-provider desktop terminal for AI coding CLIs, organized around a flat **repo → session** workflow.
 


### PR DESCRIPTION
Closes #63.

The `Version` badge hardcoded `2.4.0` in the shields.io URL and had already drifted from `package.json` (2.5.0). This swaps it for `img.shields.io/github/package-json/v/carloluisito/omnidesk`, which reads the version from the repo at render time, and drops the hand-typed `tests-670 passing` badge that has no mechanism keeping it honest. README-only, no behavior or test changes.