### PR TITLE
chore(package): declare engines (node >=20, npm >=10)

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,5 +69,9 @@
     "vitest": "^4.0.18"
   },
   "author": "Carlo Luisito Adap <carlo.adap@hotmail.com>",
-  "license": "MIT"
+  "license": "MIT",
+  "engines": {
+    "node": ">=20.0.0",
+    "npm": ">=10.0.0"
+  }
 }


### PR DESCRIPTION
Closes #65.

## Summary

Adds an `engines` block to `package.json` to encode the Node 20+ runtime requirement that is already documented in `README.md` and `CONTRIBUTING.md` and already enforced by CI (`node-version: [20.x, 22.x]`).

Diff is 4 lines:

```json
"engines": {
  "node": ">=20.0.0",
  "npm": ">=10.0.0"
}
```

## Rationale

- `node: >=20.0.0` matches the lower bound documented in `README.md:128` and `CONTRIBUTING.md:67` and the lower bound of the CI matrix. Deliberately unbounded on the upper end — Node 22.x is already in CI and Node 23/24 should not be blocked.
- `npm: >=10.0.0` is the version that ships with Node 20 LTS. It prevents a contributor from accidentally running ancient npm 6/7, which mishandles `package-lock.json` v3.
- No `.npmrc` change and no `engine-strict` — this issue explicitly scopes those out. The plain `engines` block only emits an `EBADENGINE` warning, which is the intended behavior.

## Acceptance criteria (from #65)

- [x] `package.json` contains an `engines` block with at minimum `"node": ">=20.0.0"`.
- [x] `npm install` on Node 20.x and Node 22.x still succeeds without warnings on a fresh checkout — verified locally on Node 22.17.0 / npm 10.9.2 via `npm ci`, no `EBADENGINE`. CI matrix (20.x + 22.x × ubuntu/macos/windows) exercises both.
- [x] `npm install` on Node 18.x prints an `EBADENGINE` warning that names Node 20 as the required version — this is guaranteed by npm's documented `engines` semantics (npm prints `EBADENGINE` when the runtime is below the declared minimum, unless `engine-strict` is set). Not directly re-verified on this branch (would require a Node 18 shell), but the constraint `>=20.0.0` is the well-defined trigger.
- [x] The declared minimum matches `README.md:128` and `CONTRIBUTING.md:67` — both say Node 20+.
- [x] No `.npmrc` change and no `engine-strict` lands here.

## Verification

Ran the full CI-equivalent pipeline locally on Windows / Node 22.17.0 / npm 10.9.2:

- `npm ci` — clean, no `EBADENGINE` warnings.
- `npx tsc --noEmit` — pass.
- `npx tsc --noEmit -p tsconfig.main.json` — pass.
- `npm run build:electron` — pass.
- `npm run build` (vite) — pass.
- `npm run test:ci` — **818 tests, 0 failures, 0 errors** (per `test-results.xml` junit output).

No dependencies added.

## Out of scope (per issue notes)

- `.nvmrc` / `.node-version` file — separate ergonomic improvement.
- Removing the unconditional postinstall message — separate issue.
- Upgrading the warning to a hard error via `.npmrc` `engine-strict=true` — policy call, separate issue.