### PR TITLE
docs(readme): replace hardcoded version/tests badges with dynamic shield

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,7 @@
 
 ![License](https://img.shields.io/badge/license-MIT-blue.svg)
 ![Platform](https://img.shields.io/badge/platform-Windows%20%7C%20macOS%20%7C%20Linux-lightgrey.svg)
-![Version](https://img.shields.io/badge/version-2.4.0-green.svg)
-![Tests](https://img.shields.io/badge/tests-670%20passing-brightgreen.svg)
+![Version](https://img.shields.io/github/package-json/v/carloluisito/omnidesk)
 
 > A multi-provider desktop terminal for AI coding CLIs, organized around a flat **repo → session** workflow.
 


### PR DESCRIPTION
Closes #63.

## Summary

`README.md` hardcoded two shields.io badges with values that live elsewhere and drift on every release:

```md
![Version](https://img.shields.io/badge/version-2.4.0-green.svg)
![Tests](https://img.shields.io/badge/tests-670%20passing-brightgreen.svg)
```

`package.json` has been at `2.5.0` since `c0e66a7 release: v2.5.0`, so the Version badge was already wrong. The Tests badge is a hand-typed count from whenever it was added, with nothing keeping it in sync as the suite grows.

## Change

Per the issue's own recommendation:

- **Version → option (b):** replaced with `https://img.shields.io/github/package-json/v/carloluisito/omnidesk`, a live GitHub-hosted shield that reads `package.json` at HEAD directly. Zero maintenance, can't drift, no CI change needed.
- **Tests → option (a):** dropped entirely. The exact count is trivia, and shields.io has no first-class test-count endpoint without a CI job emitting a JSON/badge — out of scope here per the issue notes.

Diff is 1 file, -2/+1 lines, README only. No behavior change, no test change, no dependencies added.

## Verification

- Confirmed the new shield URL resolves: `curl -o /dev/null -w '%{http_code}' https://img.shields.io/github/package-json/v/carloluisito/omnidesk` → `200`.
- Checked `.github/workflows/ci.yml` — no job touches `README.md` or runs markdown lint, so this change has no CI surface.
- Spot-checked the remaining badge block (`License`, `Platform`) — both are static/evergreen values not tied to a file the release process updates; issue's acceptance criteria only scoped Version and Tests, so left as-is to keep the change minimal.

## Acceptance criteria (from #63)

- [x] `README.md:5` no longer hardcodes `version-2.4.0`; now reads `package.json` live via shields.io.
- [x] `README.md:6` (`tests-670%20passing`) removed entirely.
- [x] Rendered README on `main` will show a Version badge matching `package.json` (2.5.0) automatically, including on future releases.
- [x] Spot-checked remaining badges for hardcoded drift — none found in scope.