### PR TITLE
refactor(ansi): consolidate stripAnsi into shared util

### DIFF
--- a/src/main/history-manager.ts
+++ b/src/main/history-manager.ts
@@ -5,7 +5,7 @@
 import * as fs from 'fs/promises';
 import * as path from 'path';
 import { app } from 'electron';
-import { stripAnsi } from './ansi-strip';
+import { stripAnsi } from '../shared/ansi-strip';
 import { isClaudeReady as checkClaudeReadyPatterns, findClaudeOutputStart } from '../shared/claude-detector';
 import type { SessionKind } from '../shared/ipc-types';
 import type {

--- a/src/main/session-state/classifier.ts
+++ b/src/main/session-state/classifier.ts
@@ -14,7 +14,7 @@
 
 import { reduceLines } from '../../shared/line-reducer';
 import { detectStateFromTail } from '../../shared/state-detector';
-import { stripAnsi } from '../ansi-strip';
+import { stripAnsi } from '../../shared/ansi-strip';
 import { AltScreenTracker } from './alt-screen-tracker';
 import type { StateSignals } from '../../shared/session-state-types';
 import type { SessionActivityState, SessionKind } from '../../shared/ipc-types';

--- a/src/renderer/hooks/useSessionPreviews.ts
+++ b/src/renderer/hooks/useSessionPreviews.ts
@@ -2,13 +2,9 @@
 // for the Grid tiles. Strips ANSI escape sequences. Tracks last-activity
 // timestamp per session as a side effect.
 import { useEffect, useRef, useState, useCallback } from 'react';
+import { stripAnsi } from '../../shared/ansi-strip';
 
 const MAX_LINES = 8;
-const ANSI_RE = /\x1b\[[0-9;?]*[A-Za-z]/g;
-
-function stripAnsi(s: string): string {
-  return s.replace(ANSI_RE, '').replace(/\r/g, '');
-}
 
 export interface SessionPreviewsApi {
   outputSnapshots: Record<string, string[]>;

--- a/src/shared/ansi-strip.test.ts
+++ b/src/shared/ansi-strip.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest';
+import { stripAnsi } from './ansi-strip';
+
+describe('stripAnsi', () => {
+  it('strips CSI color/SGR codes', () => {
+    const raw = '\x1b[31mred text\x1b[0m';
+    expect(stripAnsi(raw)).toBe('red text');
+  });
+
+  it('strips an OSC title sequence terminated by BEL', () => {
+    const raw = '\x1b]0;my window title\x07visible text';
+    expect(stripAnsi(raw)).toBe('visible text');
+  });
+
+  it('strips an OSC title sequence terminated by ST (ESC-backslash)', () => {
+    const raw = '\x1b]0;my window title\x1b\\visible text';
+    expect(stripAnsi(raw)).toBe('visible text');
+  });
+
+  it('strips CSI private-mode sequences (cursor show/hide)', () => {
+    const raw = 'before\x1b[?25hafter';
+    expect(stripAnsi(raw)).toBe('beforeafter');
+  });
+
+  it('normalizes \\r\\n to \\n', () => {
+    expect(stripAnsi('line1\r\nline2')).toBe('line1\nline2');
+  });
+
+  it('normalizes a lone \\r to \\n', () => {
+    expect(stripAnsi('line1\rline2')).toBe('line1\nline2');
+  });
+
+  it('passes plain text through unchanged', () => {
+    expect(stripAnsi('hello world')).toBe('hello world');
+  });
+
+  it('handles empty input', () => {
+    expect(stripAnsi('')).toBe('');
+  });
+});

--- a/src/shared/ansi-strip.ts
+++ b/src/shared/ansi-strip.ts
@@ -1,6 +1,9 @@
 /**
  * ANSI escape code stripping utility
  * Removes ANSI color codes, cursor movements, and control sequences from terminal output
+ *
+ * Lives under src/shared so it can be imported from main, renderer, and shared
+ * code alike. This is the single canonical implementation - do not fork it.
  */
 
 // ANSI CSI (Control Sequence Introducer) pattern

--- a/src/shared/model-detector.ts
+++ b/src/shared/model-detector.ts
@@ -6,6 +6,8 @@
  * 2. Switch detection: Parse /model command confirmations
  */
 
+import { stripAnsi } from './ansi-strip';
+
 export type ClaudeModel = 'sonnet' | 'opus' | 'haiku' | 'auto';
 
 export interface ModelDetectionResult {
@@ -36,18 +38,6 @@ export const WELCOME_PATTERNS = [
   /Model[: ]+(\w+)/i,
   /\((\w+)\s+\d+\.\d+\)/i, // e.g., "(Sonnet 4.5)"
 ];
-
-/**
- * Strip ANSI escape sequences from terminal output.
- * Handles CSI sequences (\x1b[...X), OSC sequences (\x1b]...\x07), and single-char escapes.
- */
-function stripAnsi(text: string): string {
-  return text
-    .replace(/\x1b\[[0-9;]*[a-zA-Z]/g, '')   // CSI sequences (colors, cursor, etc.)
-    .replace(/\x1b\][^\x07]*\x07/g, '')        // OSC sequences (title, etc.)
-    .replace(/\x1b[()][A-Z0-9]/g, '')          // Character set selection
-    .replace(/\x1b[=>]/g, '');                  // Keypad mode
-}
 
 /**
  * Detect model from terminal output.


### PR DESCRIPTION
## Summary

Closes #69.

Three divergent `stripAnsi` implementations existed:
- `src/main/ansi-strip.ts` (the most complete one — handles CSI + OSC + \r normalization)
- a local copy inside `src/renderer/hooks/useSessionPreviews.ts` (only stripped CSI, never OSC, and just deleted `\r` instead of normalizing it)
- a local copy inside `src/shared/model-detector.ts` (handled CSI/OSC but missed some CSI private-mode edge cases the canonical version covers)

The renderer copy not stripping OSC sequences is a real bug: Grid tile previews were leaking raw OSC title-sequence text (e.g. `]0;my window title`) into the preview lines shown to users.

## Changes

- Moved the canonical implementation to `src/shared/ansi-strip.ts` (git detects this as a rename from `src/main/ansi-strip.ts`) so it can be imported from main, renderer, and shared code alike.
- Updated `src/main/history-manager.ts` and `src/main/session-state/classifier.ts` to import from the new shared path.
- Removed the local duplicate in `src/renderer/hooks/useSessionPreviews.ts` — now imports the shared `stripAnsi`. This fixes the Grid-preview OSC-leak bug.
- Removed the local duplicate in `src/shared/model-detector.ts` — now imports the shared `stripAnsi` from the same directory.
- Added `src/shared/ansi-strip.test.ts` with cases for: CSI color/SGR codes, OSC sequences terminated by BEL, OSC sequences terminated by ST (ESC-backslash), CSI private-mode sequences (cursor show/hide), `\r\n` → `\n` normalization, lone `\r` → `\n` normalization, plain-text passthrough, and empty input.

No new dependencies added.

## Verification

- `npm test` (full vitest workspace): **87 test files passed, 826 tests passed**, including the new `src/shared/ansi-strip.test.ts` (8 tests).
- `npx tsc --noEmit` (renderer/default config): clean, no errors.
- `npx tsc -p tsconfig.main.json --noEmit` (main-process config): clean, no errors.
- Confirmed via `grep -rn "stripAnsi|ansi-strip" src` that exactly one canonical definition remains and all 4 call sites import from it.