### PR TITLE
fix(session-pool): reset isInitialized on disable so re-enable restores the pool

### DIFF
--- a/src/main/session-pool.test.ts
+++ b/src/main/session-pool.test.ts
@@ -1,0 +1,191 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// Mock cli-manager so no real shell processes ever spawn.
+vi.mock('./cli-manager', () => {
+  const CLIManager = vi.fn();
+  CLIManager.prototype.spawnShell = vi.fn().mockResolvedValue(undefined);
+  CLIManager.prototype.destroy = vi.fn();
+  return { CLIManager };
+});
+
+import { SessionPool } from './session-pool';
+import { CLIManager } from './cli-manager';
+
+function createPool(overrides: Partial<{ size: number; enabled: boolean; maxIdleTimeMs: number }> = {}) {
+  return new SessionPool({
+    size: 2,
+    enabled: true,
+    maxIdleTimeMs: 5 * 60 * 1000,
+    ...overrides,
+  });
+}
+
+describe('SessionPool', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe('initialize()', () => {
+    it('spawns config.size idle sessions', async () => {
+      const pool = createPool({ size: 2 });
+      await pool.initialize();
+
+      expect(CLIManager.prototype.spawnShell).toHaveBeenCalledTimes(2);
+      expect(pool.getStatus().idleCount).toBe(2);
+    });
+
+    it('is a no-op when disabled', async () => {
+      const pool = createPool({ enabled: false, size: 2 });
+      await pool.initialize();
+
+      expect(CLIManager.prototype.spawnShell).not.toHaveBeenCalled();
+      expect(pool.getStatus().idleCount).toBe(0);
+    });
+
+    it('is a no-op when size is 0', async () => {
+      const pool = createPool({ size: 0 });
+      await pool.initialize();
+
+      expect(CLIManager.prototype.spawnShell).not.toHaveBeenCalled();
+      expect(pool.getStatus().idleCount).toBe(0);
+    });
+
+    it('is idempotent - a second call does not double-spawn', async () => {
+      const pool = createPool({ size: 2 });
+      await pool.initialize();
+      await pool.initialize();
+
+      expect(CLIManager.prototype.spawnShell).toHaveBeenCalledTimes(2);
+      expect(pool.getStatus().idleCount).toBe(2);
+    });
+  });
+
+  describe('claim()', () => {
+    it('returns a pooled session and triggers async replenishment back to size', async () => {
+      const pool = createPool({ size: 2 });
+      await pool.initialize();
+      vi.mocked(CLIManager.prototype.spawnShell).mockClear();
+
+      const claimed = pool.claim();
+      expect(claimed).not.toBeNull();
+      expect(pool.getStatus().idleCount).toBe(1);
+
+      // Replenishment is fired-and-forgotten inside claim(); flush microtasks.
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(CLIManager.prototype.spawnShell).toHaveBeenCalledTimes(1);
+      expect(pool.getStatus().idleCount).toBe(2);
+    });
+
+    it('returns null when disabled', () => {
+      const pool = createPool({ enabled: false, size: 2 });
+      expect(pool.claim()).toBeNull();
+    });
+
+    it('returns null when the queue is empty', () => {
+      const pool = createPool({ size: 0 });
+      expect(pool.claim()).toBeNull();
+    });
+  });
+
+  describe('updateConfig()', () => {
+    it('spawns the difference when size increases', async () => {
+      const pool = createPool({ size: 1 });
+      await pool.initialize();
+      vi.mocked(CLIManager.prototype.spawnShell).mockClear();
+
+      pool.updateConfig({ size: 3 });
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(CLIManager.prototype.spawnShell).toHaveBeenCalledTimes(2);
+      expect(pool.getStatus().idleCount).toBe(3);
+    });
+
+    it('destroys the excess when size decreases', async () => {
+      const pool = createPool({ size: 3 });
+      await pool.initialize();
+
+      pool.updateConfig({ size: 1 });
+
+      expect(CLIManager.prototype.destroy).toHaveBeenCalledTimes(2);
+      expect(pool.getStatus().idleCount).toBe(1);
+    });
+
+    it('disable destroys all idle sessions and stops the cleanup interval', async () => {
+      vi.useFakeTimers();
+      const pool = createPool({ size: 2 });
+      await pool.initialize();
+
+      pool.updateConfig({ enabled: false });
+
+      expect(CLIManager.prototype.destroy).toHaveBeenCalledTimes(2);
+      expect(pool.getStatus().idleCount).toBe(0);
+
+      // Cleanup interval must be stopped: advancing well past it should not
+      // touch the (already-empty) queue or spawn anything.
+      vi.mocked(CLIManager.prototype.destroy).mockClear();
+      vi.advanceTimersByTime(120_000);
+      expect(CLIManager.prototype.destroy).not.toHaveBeenCalled();
+    });
+
+    it('re-enable after disable restores the pool (regression for #73)', async () => {
+      const pool = createPool({ size: 2 });
+      await pool.initialize();
+      expect(pool.getStatus().idleCount).toBe(2);
+
+      pool.updateConfig({ enabled: false });
+      expect(pool.getStatus().idleCount).toBe(0);
+
+      pool.updateConfig({ enabled: true });
+      // initialize() is fired-and-forgotten from the re-enable branch.
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(pool.getStatus().idleCount).toBe(pool.getStatus().size);
+      expect(pool.getStatus().idleCount).toBe(2);
+    });
+  });
+
+  describe('cleanupStale()', () => {
+    it('destroys sessions older than maxIdleTimeMs and replenishes', async () => {
+      vi.useFakeTimers();
+      const pool = createPool({ size: 2, maxIdleTimeMs: 1000 });
+      await pool.initialize();
+      vi.mocked(CLIManager.prototype.spawnShell).mockClear();
+
+      // Age the idle sessions past maxIdleTimeMs, then let the 60s cleanup
+      // interval fire exactly once. advanceTimersByTimeAsync flushes the
+      // microtasks from the async replenishPool() kicked off inside
+      // cleanupStale() as it goes, so the interval isn't re-entered.
+      await vi.advanceTimersByTimeAsync(61_500);
+
+      expect(CLIManager.prototype.destroy).toHaveBeenCalledTimes(2);
+      expect(CLIManager.prototype.spawnShell).toHaveBeenCalledTimes(2);
+      expect(pool.getStatus().idleCount).toBe(2);
+    });
+  });
+
+  describe('destroy()', () => {
+    it('stops the interval and empties the queue', async () => {
+      vi.useFakeTimers();
+      const pool = createPool({ size: 2 });
+      await pool.initialize();
+
+      pool.destroy();
+
+      expect(CLIManager.prototype.destroy).toHaveBeenCalledTimes(2);
+      expect(pool.getStatus().idleCount).toBe(0);
+
+      vi.mocked(CLIManager.prototype.destroy).mockClear();
+      vi.advanceTimersByTime(120_000);
+      expect(CLIManager.prototype.destroy).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/main/session-pool.ts
+++ b/src/main/session-pool.ts
@@ -109,6 +109,10 @@ export class SessionPool {
       } catch (err) { /* Ignore EPIPE */ }
       this.destroyAllIdle();
       this.stopCleanupInterval();
+      // The pool is genuinely un-initialized once disabled: reset the flag so a
+      // subsequent re-enable's initialize() call actually re-spawns idle sessions
+      // and restarts the cleanup interval instead of early-returning.
+      this.isInitialized = false;
       return;
     }
 


### PR DESCRIPTION
Closes #73

## Bug

`SessionPool.updateConfig()` destroys all idle sessions and stops the
cleanup interval when pooling is disabled, but never reset the
`isInitialized` flag. When the pool was later re-enabled,
`updateConfig()` calls `this.initialize()`, which early-returns
because `isInitialized` is still `true` from the original startup —
so no idle sessions are ever re-spawned and the cleanup interval never
restarts. The pool stays permanently dead after a disable/enable
toggle.

## Fix

Minimal fix (as proposed in the issue): reset `this.isInitialized =
false` in the disable branch of `updateConfig()`, so the guarded
`initialize()` call on re-enable actually runs again.

## Tests

Added `src/main/session-pool.test.ts` (13 tests, new file — this
class previously had no dedicated test coverage). Covers:
- `initialize()`: spawns configured size, no-op when disabled/size 0,
  idempotent on second call
- `claim()`: returns a session and fires async replenishment back to
  size; returns `null` when disabled or empty
- `updateConfig()`: spawns the diff on size increase, destroys excess
  on size decrease, disable destroys all idle sessions and stops the
  cleanup interval, and the disable→enable round trip restores the
  pool (regression test for #73)
- `cleanupStale()`: destroys sessions older than `maxIdleTimeMs` and
  replenishes
- `destroy()`: stops the interval and empties the queue

`CLIManager` is mocked so no real shell processes spawn.

## Verification

- `npm test` (full workspace, all projects): **839 passed / 839, 88
  files passed / 88** — no regressions.
- `npx tsc -p tsconfig.main.json --noEmit`: clean.
- `npx tsc --noEmit` (renderer/default config): clean.

No new dependencies added.