### PR TITLE
test(main): add coverage for file-utils.ts; fix misleading sanitizeFilePath doc

### DIFF
--- a/src/main/file-utils.test.ts
+++ b/src/main/file-utils.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import {
+  getFileCategory,
+  isBinaryFile,
+  getMimeType,
+  isLocalFile,
+  sanitizeFilePath,
+} from './file-utils';
+
+describe('getFileCategory', () => {
+  it('categorizes a representative extension per category', () => {
+    expect(getFileCategory('script.js')).toBe('code');
+    expect(getFileCategory('index.html')).toBe('markup');
+    expect(getFileCategory('notes.txt')).toBe('document');
+    expect(getFileCategory('photo.png')).toBe('image');
+    expect(getFileCategory('archive.zip')).toBe('binary');
+  });
+
+  it('is case-insensitive on the extension', () => {
+    expect(getFileCategory('PHOTO.PNG')).toBe('image');
+    expect(getFileCategory('Script.JS')).toBe('code');
+  });
+
+  it('returns "other" for a file with no extension', () => {
+    expect(getFileCategory('README')).toBe('other');
+  });
+
+  it('returns "other" for an unknown extension', () => {
+    expect(getFileCategory('file.xyz123')).toBe('other');
+  });
+
+  it('returns "other" for a dotfile (no extension by Node semantics)', () => {
+    expect(getFileCategory('.gitignore')).toBe('other');
+  });
+});
+
+describe('getMimeType', () => {
+  it('returns the MIME type for a known extension', () => {
+    expect(getMimeType('page.html')).toBe('text/html');
+    expect(getMimeType('data.json')).toBe('application/json');
+  });
+
+  it('returns undefined for an unknown extension', () => {
+    expect(getMimeType('file.xyz123')).toBeUndefined();
+  });
+
+  it('is case-insensitive on the extension', () => {
+    expect(getMimeType('IMAGE.PNG')).toBe('image/png');
+  });
+});
+
+describe('isLocalFile', () => {
+  it('rejects http/https/ftp/file URLs', () => {
+    expect(isLocalFile('http://example.com/a.txt')).toBe(false);
+    expect(isLocalFile('https://example.com/a.txt')).toBe(false);
+    expect(isLocalFile('ftp://example.com/a.txt')).toBe(false);
+    expect(isLocalFile('file:///etc/passwd')).toBe(false);
+  });
+
+  it('accepts a plain absolute or relative path', () => {
+    expect(isLocalFile(path.resolve('/tmp/a.txt'))).toBe(true);
+    expect(isLocalFile('relative/a.txt')).toBe(true);
+  });
+
+  it('rejects Windows UNC paths only on win32', () => {
+    const original = process.platform;
+    Object.defineProperty(process, 'platform', { value: 'win32' });
+    try {
+      expect(isLocalFile('\\\\server\\share\\file.txt')).toBe(false);
+    } finally {
+      Object.defineProperty(process, 'platform', { value: original });
+    }
+  });
+
+  it('does not reject UNC-style paths on non-win32 platforms', () => {
+    const original = process.platform;
+    Object.defineProperty(process, 'platform', { value: 'linux' });
+    try {
+      expect(isLocalFile('\\\\server\\share\\file.txt')).toBe(true);
+    } finally {
+      Object.defineProperty(process, 'platform', { value: original });
+    }
+  });
+});
+
+describe('sanitizeFilePath', () => {
+  it('returns an absolute path', () => {
+    expect(path.isAbsolute(sanitizeFilePath('relative/path.txt'))).toBe(true);
+  });
+
+  it('collapses ".." segments but does not confine the result to a base directory', () => {
+    const base = path.resolve(path.sep + path.join('base', 'dir'));
+    const escaped = sanitizeFilePath(path.join(base, '..', '..', 'etc', 'passwd'));
+    expect(escaped).toBe(path.resolve(path.sep + path.join('etc', 'passwd')));
+  });
+});
+
+describe('isBinaryFile', () => {
+  let tmpDir: string;
+
+  afterEach(() => {
+    if (tmpDir) fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function tempFile(name: string, data: string | Buffer): string {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'file-utils-'));
+    const filePath = path.join(tmpDir, name);
+    fs.writeFileSync(filePath, data);
+    return filePath;
+  }
+
+  it('returns false for a UTF-8 text file', () => {
+    const filePath = tempFile('text.txt', 'hello world\nline two\n');
+    expect(isBinaryFile(filePath)).toBe(false);
+  });
+
+  it('returns true for a file containing a null byte', () => {
+    const filePath = tempFile('binary.bin', Buffer.from([0x68, 0x69, 0x00, 0x21]));
+    expect(isBinaryFile(filePath)).toBe(true);
+  });
+
+  it('returns false for an empty file', () => {
+    const filePath = tempFile('empty.txt', '');
+    expect(isBinaryFile(filePath)).toBe(false);
+  });
+
+  it('returns true (assume binary) when the path does not exist', () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'file-utils-'));
+    const missing = path.join(tmpDir, 'does-not-exist.txt');
+    expect(isBinaryFile(missing)).toBe(true);
+  });
+});

--- a/src/main/file-utils.ts
+++ b/src/main/file-utils.ts
@@ -182,9 +182,14 @@ export function isLocalFile(filePath: string): boolean {
 }
 
 /**
- * Sanitize file path for security
+ * Normalize a file path to an absolute path.
+ *
+ * Note: this does NOT confine the result to any base directory or prevent
+ * path traversal — `path.resolve()` collapses `..` segments but happily
+ * resolves them past any starting point (e.g. `path.resolve('/base', '../../etc/passwd')`
+ * yields `/etc/passwd`). Callers that need traversal protection must add
+ * their own base-directory containment check.
  */
 export function sanitizeFilePath(filePath: string): string {
-  // Resolve to absolute path to prevent path traversal
   return path.resolve(filePath);
 }


### PR DESCRIPTION
Closes #71

## Summary
`src/main/file-utils.ts` (drag-and-drop file pipeline: category detection, MIME lookup, binary-file heuristic, local-file validation, path sanitization) had zero test coverage. This adds `src/main/file-utils.test.ts` and fixes a misleading doc comment.

- **Tests added** (`src/main/file-utils.test.ts`, 18 cases):
  - `getFileCategory`: one hit per category (code/markup/document/image/binary), case-insensitivity, no-extension, unknown-extension, and dotfile (`.gitignore`) all falling back to `'other'` (Node's `path.extname` treats a leading-dot-only name as having no extension).
  - `getMimeType`: known extension, unknown → `undefined`, case-insensitivity.
  - `isLocalFile`: rejects `http/https/ftp/file://`; accepts plain absolute/relative paths; UNC-path rejection is exercised only on `win32` (and confirmed *not* rejected on other platforms) via a temporary `process.platform` stub, restored in a `finally`.
  - `sanitizeFilePath`: returns an absolute path; demonstrates `..` segments are collapsed but not confined to any base directory (the traversal case called out below).
  - `isBinaryFile`: real temp files via `fs.mkdtempSync` — UTF-8 text → `false`, null-byte content → `true`, empty file → `false`, nonexistent path → `true` (error path; the module's own `console.error` fires here, which is expected and appears in test stderr).

- **Doc fix**: `sanitizeFilePath`'s comment said resolving to an absolute path "prevent[s] path traversal." It doesn't — `path.resolve('/base', '../../etc/passwd')` yields `/etc/passwd`. Reworded to state what the function actually guarantees (absolute-path normalization only) and that callers needing traversal protection must add their own base-directory containment check. No behavior change; `sanitizeFilePath` still just calls `path.resolve()`.

No dependency changes. No production behavior changes — `file-utils.ts`'s only edit is the comment.

## Verification
- `npx vitest run --config vitest.workspace.ts --project main src/main/file-utils.test.ts` → 18/18 passed
- `npm test` (full suite) → 88 files / 844 tests passed (was 826 before this PR)
- `npx tsc --noEmit -p tsconfig.json` → clean
- `npx tsc --noEmit -p tsconfig.main.json` → clean