### PR TITLE
fix(git): surface unstaged changes on renamed-then-modified/deleted files

### DIFF
--- a/src/main/git-manager.test.ts
+++ b/src/main/git-manager.test.ts
@@ -122,7 +122,39 @@ describe('GitManager', () => {
       mockGitResponse('# branch.head main\n2 R. N... 100644 100644 100644 abc123 def456 R100 new.ts\told.ts\n', '', 0);
       const status = await manager.getStatus('/test');
       expect(status.stagedCount).toBe(1);
+      expect(status.unstagedCount).toBe(0);
+      expect(status.files).toHaveLength(1);
       expect(status.files[0].indexStatus).toBe('renamed');
+    });
+
+    it('parses renamed-then-modified entries (RM) as both staged and unstaged', async () => {
+      mockGitResponse('true', '', 0);
+      mockGitResponse('# branch.head main\n2 RM N... 100644 100644 100644 abc123 def456 R100 new.ts\told.ts\n', '', 0);
+      const status = await manager.getStatus('/test');
+      expect(status.stagedCount).toBe(1);
+      expect(status.unstagedCount).toBe(1);
+      expect(status.files).toHaveLength(2);
+
+      const staged = status.files.find(f => f.area === 'staged');
+      expect(staged?.indexStatus).toBe('renamed');
+      expect(staged?.originalPath).toBe('old.ts');
+
+      const unstaged = status.files.find(f => f.area === 'unstaged');
+      expect(unstaged?.workTreeStatus).toBe('modified');
+      expect(unstaged?.originalPath).toBe('old.ts');
+      expect(unstaged?.path).toBe('new.ts');
+    });
+
+    it('parses renamed-then-deleted entries (RD) as an unstaged deletion', async () => {
+      mockGitResponse('true', '', 0);
+      mockGitResponse('# branch.head main\n2 RD N... 100644 100644 100644 abc123 def456 R100 new.ts\told.ts\n', '', 0);
+      const status = await manager.getStatus('/test');
+      expect(status.stagedCount).toBe(1);
+      expect(status.unstagedCount).toBe(1);
+
+      const unstaged = status.files.find(f => f.area === 'unstaged');
+      expect(unstaged?.workTreeStatus).toBe('deleted');
+      expect(unstaged?.originalPath).toBe('old.ts');
     });
 
     it('parses unmerged entries', async () => {

--- a/src/main/git-manager.ts
+++ b/src/main/git-manager.ts
@@ -257,6 +257,22 @@ export class GitManager {
             });
             status.stagedCount++;
           }
+
+          // Renamed-then-modified (RM) or renamed-then-deleted (RD): the
+          // worktree half is a separate, still-pending change and must be
+          // surfaced as its own unstaged entry, mirroring the format-1 branch
+          // above. Without this, a rename staged over a subsequently edited
+          // file hides the pending edit entirely.
+          if (xy[1] !== '.') {
+            status.files.push({
+              path: filePath,
+              originalPath,
+              indexStatus: 'renamed',
+              workTreeStatus: this.charToStatus(xy[1]),
+              area: 'unstaged',
+            });
+            status.unstagedCount++;
+          }
         }
         continue;
       }


### PR DESCRIPTION
## Summary

`GitManager.parseStatus`'s handling of porcelain v2 **format-2** lines
(`2 XY N1 N2 N3 hH hI Rxx path\torigPath`, renamed/copied entries) only ever
emitted a single `staged` file entry built from the rename. It never checked
the worktree half of the `XY` code, unlike the format-1 branch which already
handles this correctly for ordinary entries.

Practical effect: if a file is renamed (staged) and then further modified or
deleted in the worktree (status codes `RM` / `RD`), the worktree change was
silently dropped from the parsed `GitStatus` — the UI would show the rename
as staged but have no idea there was still a pending edit/deletion on top of
it.

## Fix

Mirror the format-1 branch's logic: after pushing the existing `staged`
entry, if `xy[1] !== '.'` also push a second `unstaged` entry (same
`path`/`originalPath`, `indexStatus: 'renamed'`, `workTreeStatus` mapped from
the worktree status char). This matches how ordinary (non-renamed) combined
staged+unstaged changes are already represented.

No type or IPC changes needed — `GitFileEntry` already supports
`workTreeStatus`, `originalPath`, and `area` for exactly this shape.

Closes #83

## Tests

Extended the existing "parses renamed entries" describe block in
`git-manager.test.ts`:
- Tightened the original clean-rename (`R.`) case to assert
  `unstagedCount === 0` and exactly one file entry (no regression).
- Added a case for `RM` (renamed-then-modified): asserts one `staged` entry
  (the rename) and one `unstaged` entry (`workTreeStatus: 'modified'`), both
  carrying the correct `originalPath`/`path`.
- Added a case for `RD` (renamed-then-deleted): asserts the `unstaged` entry
  has `workTreeStatus: 'deleted'`.

## Verification

- `npx tsc --noEmit -p tsconfig.json` — clean
- `npx tsc --noEmit -p tsconfig.main.json` — clean
- `npx vitest run --config vitest.workspace.ts --project main -t "renamed"` — 3/3 passing
- `npm test` (full suite, all workspace projects) — 89 test files / 859 tests passing, 0 failures