### PR TITLE
fix(integrations): use isPathWithin for per-repo mute matching

### DIFF
--- a/src/main/integrations/integration-manager.test.ts
+++ b/src/main/integrations/integration-manager.test.ts
@@ -101,6 +101,39 @@ describe('IntegrationManager', () => {
     m.dispose();
   });
 
+  it('mutes an exact repoPath match', async () => {
+    const { registry, delivered } = fakeRegistry();
+    const settings = settingsWith({ perRepo: { 'C:/repos/omnidesk': { muted: true } } });
+    const m = new IntegrationManager(makeDeps(settings), { registry });
+    m.handleStateChange(evt({}), meta({ workingDirectory: 'C:/repos/omnidesk' }));
+    await vi.runAllTimersAsync();
+    expect(delivered).toEqual([]);
+    m.dispose();
+  });
+
+  it('does not mute a sibling repo that merely shares a path prefix', async () => {
+    const { registry, delivered } = fakeRegistry();
+    const settings = settingsWith({ perRepo: { 'C:/repos/omnidesk': { muted: true } } });
+    const m = new IntegrationManager(makeDeps(settings), { registry });
+    m.handleStateChange(evt({}), meta({ workingDirectory: 'C:/repos/omnidesk-crew' }));
+    await vi.runAllTimersAsync();
+    expect(delivered.map((d) => d.id)).toEqual(['telegram']);
+    m.dispose();
+  });
+
+  it.skipIf(process.platform !== 'win32')(
+    'mutes when the stored key uses backslashes and the workingDirectory uses forward slashes / differing case (win32 only)',
+    async () => {
+      const { registry, delivered } = fakeRegistry();
+      const settings = settingsWith({ perRepo: { 'C:\\repos\\Omnidesk': { muted: true } } });
+      const m = new IntegrationManager(makeDeps(settings), { registry });
+      m.handleStateChange(evt({}), meta({ workingDirectory: 'c:/repos/omnidesk/src' }));
+      await vi.runAllTimersAsync();
+      expect(delivered).toEqual([]);
+      m.dispose();
+    }
+  );
+
   it('gates done/errored on their toggles without consuming the attention arm', async () => {
     const { registry, delivered } = fakeRegistry();
     const settings = settingsWith({ notify: { attention: true, done: false, errored: true, debounceSeconds: 0 } });

--- a/src/main/integrations/integration-manager.ts
+++ b/src/main/integrations/integration-manager.ts
@@ -17,6 +17,7 @@ import { AttentionPolicy } from './attention-policy';
 import { ConnectorRegistry } from './connector-registry';
 import { DeliveryQueue } from './delivery-queue';
 import { formatMessage } from './message-format';
+import { isPathWithin } from '../path-access';
 
 export interface IntegrationManagerDeps {
   getSettings(): IntegrationsSettings;
@@ -138,7 +139,7 @@ export class IntegrationManager {
 
   private isMuted(settings: IntegrationsSettings, workingDirectory: string): boolean {
     return Object.entries(settings.perRepo).some(
-      ([repoPath, cfg]) => cfg?.muted && workingDirectory.startsWith(repoPath)
+      ([repoPath, cfg]) => cfg?.muted && isPathWithin(workingDirectory, repoPath)
     );
   }
 


### PR DESCRIPTION
## Problem

`IntegrationManager.isMuted` (`src/main/integrations/integration-manager.ts`) matched
per-repo mutes with a raw `workingDirectory.startsWith(repoPath)` check:

```ts
private isMuted(settings: IntegrationsSettings, workingDirectory: string): boolean {
  return Object.entries(settings.perRepo).some(
    ([repoPath, cfg]) => cfg?.muted && workingDirectory.startsWith(repoPath)
  );
}
```

Two bugs fell out of that: (1) no path boundary, so muting `C:/repos/omnidesk` also
silently muted siblings like `C:/repos/omnidesk-crew`; (2) no normalization, so a
mute key stored with backslashes (`C:\repos\omnidesk`) failed to match a
`workingDirectory` reported with forward slashes or a different drive-letter case
on Windows.

## Fix

Reuse the existing boundary + normalization helper `isPathWithin` from
`src/main/path-access.ts` (already used elsewhere in the codebase for the same
kind of check) instead of re-implementing prefix logic:

```ts
private isMuted(settings: IntegrationsSettings, workingDirectory: string): boolean {
  return Object.entries(settings.perRepo).some(
    ([repoPath, cfg]) => cfg?.muted && isPathWithin(workingDirectory, repoPath)
  );
}
```

No new dependency — `isPathWithin` is an existing, already-tested internal helper.
Scope limited to `isMuted`; no settings-shape or IPC changes.

## Tests added (`integration-manager.test.ts`)

- Exact `repoPath === workingDirectory` still mutes.
- Sibling repo sharing a string prefix (`omnidesk` vs `omnidesk-crew`) is **not**
  muted (the over-mute regression this PR fixes).
- Win32-gated (`it.skipIf(process.platform !== 'win32')`): a backslash-keyed,
  differently-cased mute (`C:\repos\Omnidesk`) matches a forward-slash
  workingDirectory (`c:/repos/omnidesk/src`) — the under-mute regression this PR
  fixes. Gated because POSIX case-sensitivity is intentionally preserved by
  `isPathWithin`.
- Existing descendant-mute test (`.../omnidesk/.claude/worktrees/feat-x`) kept
  green, unmodified.

Closes #91

## Verification

- `npx vitest run --config vitest.workspace.ts --project main src/main/integrations/integration-manager.test.ts` — 14/14 passing (was 11, +3 new).
- `npm test` — 90 files / 882 tests passing, 0 failures.
- `npx tsc --noEmit -p tsconfig.json` — clean.
- `npx tsc --noEmit -p tsconfig.main.json` — clean.
- Ran on Windows, so the win32-gated normalization test executed (not skipped) and passed.