### PR TITLE
fix(integrations): truncate Discord/Telegram messages to API limits

### DIFF
--- a/src/main/integrations/connectors.test.ts
+++ b/src/main/integrations/connectors.test.ts
@@ -40,6 +40,29 @@ describe('TelegramConnector', () => {
     expect(body.text).toContain('<b>sess</b>');
   });
 
+  it('truncates text over the 4096 char limit without breaking HTML tags/entities', async () => {
+    const fetchFn = mockFetch();
+    const longMsg: OutboundMessage = {
+      text: 'x',
+      event: {
+        type: 'attention',
+        at: 1,
+        sessionName: 'a<b>&c'.repeat(200), // forces escaping + long single "head" line
+        repoName: 'omnidesk',
+        state: 'awaiting-input',
+        reason: Array.from({ length: 300 }, (_, i) => `line ${i}`).join('\n'),
+      },
+    };
+    const out = await new TelegramConnector().deliver({ enabled: true, botToken: 't', chatId: 'c' }, longMsg);
+    expect(out.ok).toBe(true);
+    const [, init] = fetchFn.mock.calls[0];
+    const body = JSON.parse(init.body);
+    expect(body.text.length).toBeLessThanOrEqual(4096);
+    // No unclosed <b> tag and no split-in-half HTML entity.
+    expect((body.text.match(/<b>/g) ?? []).length).toBe((body.text.match(/<\/b>/g) ?? []).length);
+    expect(body.text).not.toMatch(/&(amp|lt|gt);?$/); // dangling partial entity at the cut
+  });
+
   it('maps 429 with Retry-After to a retryable outcome', async () => {
     mockFetch(429, { 'retry-after': '7' });
     const out = await new TelegramConnector().deliver({ enabled: true, botToken: 't', chatId: 'c' }, msg);
@@ -82,6 +105,17 @@ describe('DiscordConnector', () => {
     expect(out.ok).toBe(true);
     const [, init] = fetchFn.mock.calls[0];
     expect(JSON.parse(init.body)).toEqual({ content: msg.text });
+  });
+
+  it('truncates content over the 2000 char limit', async () => {
+    const fetchFn = mockFetch(204);
+    const longMsg: OutboundMessage = { text: 'y'.repeat(2500), event: msg.event };
+    const out = await new DiscordConnector().deliver({ enabled: true, webhookUrl: 'https://discord.com/api/webhooks/x' }, longMsg);
+    expect(out.ok).toBe(true);
+    const [, init] = fetchFn.mock.calls[0];
+    const body = JSON.parse(init.body);
+    expect(body.content.length).toBeLessThanOrEqual(2000);
+    expect(body.content).toContain('truncated');
   });
 });
 

--- a/src/main/integrations/connectors/discord-connector.ts
+++ b/src/main/integrations/connectors/discord-connector.ts
@@ -1,5 +1,9 @@
 import type { ConnectorTestResult, DiscordConfig, OutboundMessage, SendOutcome } from '../../../shared/integration-types';
 import { IConnector, outcomeFromNetworkError, outcomeFromResponse } from '../connector';
+import { truncatePlainText } from '../message-format';
+
+// Discord webhook `content` field hard limit — over this the API returns HTTP 400.
+const DISCORD_MAX_LENGTH = 2000;
 
 export class DiscordConnector implements IConnector<DiscordConfig> {
   readonly id = 'discord' as const;
@@ -23,7 +27,7 @@ export class DiscordConnector implements IConnector<DiscordConfig> {
       const res = await fetch(cfg.webhookUrl, {
         method: 'POST',
         headers: { 'content-type': 'application/json' },
-        body: JSON.stringify({ content: msg.text }),
+        body: JSON.stringify({ content: truncatePlainText(msg.text, DISCORD_MAX_LENGTH) }),
       });
       return outcomeFromResponse(res);
     } catch (err) {

--- a/src/main/integrations/connectors/telegram-connector.ts
+++ b/src/main/integrations/connectors/telegram-connector.ts
@@ -1,6 +1,9 @@
 import type { ConnectorTestResult, OutboundMessage, SendOutcome, TelegramConfig } from '../../../shared/integration-types';
 import { IConnector, outcomeFromNetworkError, outcomeFromResponse } from '../connector';
-import { formatTelegramHTML } from '../message-format';
+import { formatTelegramHTML, truncateHtmlByLines } from '../message-format';
+
+// Telegram sendMessage `text` field hard limit — over this the API returns HTTP 400.
+const TELEGRAM_MAX_LENGTH = 4096;
 
 export class TelegramConnector implements IConnector<TelegramConfig> {
   readonly id = 'telegram' as const;
@@ -32,7 +35,7 @@ export class TelegramConnector implements IConnector<TelegramConfig> {
         headers: { 'content-type': 'application/json' },
         body: JSON.stringify({
           chat_id: cfg.chatId,
-          text: formatTelegramHTML(msg.event),
+          text: truncateHtmlByLines(formatTelegramHTML(msg.event), TELEGRAM_MAX_LENGTH),
           parse_mode: 'HTML',
           disable_web_page_preview: true,
         }),

--- a/src/main/integrations/message-format.test.ts
+++ b/src/main/integrations/message-format.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { formatMessage, formatTelegramHTML } from './message-format';
+import { formatMessage, formatTelegramHTML, truncatePlainText, truncateHtmlByLines } from './message-format';
 import type { IntegrationEvent } from '../../shared/integration-types';
 
 function evt(partial: Partial<IntegrationEvent>): IntegrationEvent {
@@ -60,5 +60,53 @@ describe('formatTelegramHTML', () => {
   it('bolds the session name', () => {
     const text = formatTelegramHTML(evt({ sessionName: 'sess', state: 'awaiting-input' }));
     expect(text).toContain('<b>sess</b>');
+  });
+});
+
+describe('truncatePlainText', () => {
+  it('returns the text unchanged when under the limit', () => {
+    expect(truncatePlainText('short', 100)).toBe('short');
+  });
+
+  it('truncates to at most maxLength and appends the marker', () => {
+    const result = truncatePlainText('x'.repeat(2500), 2000);
+    expect(result.length).toBeLessThanOrEqual(2000);
+    expect(result.endsWith('(truncated)')).toBe(true);
+  });
+
+  it('never exceeds maxLength even when the marker itself is long', () => {
+    const result = truncatePlainText('x'.repeat(50), 10, '\n… (truncated)');
+    expect(result.length).toBeLessThanOrEqual(10);
+  });
+});
+
+describe('truncateHtmlByLines', () => {
+  it('returns the text unchanged when under the limit', () => {
+    const text = 'head\nbody\nfoot';
+    expect(truncateHtmlByLines(text, 100)).toBe(text);
+  });
+
+  it('drops whole trailing lines and never splits an HTML entity or tag', () => {
+    const lines = ['<b>head</b>', ...Array.from({ length: 500 }, (_, i) => `line ${i} &amp; more`)];
+    const text = lines.join('\n');
+    const result = truncateHtmlByLines(text, 200);
+    expect(result.length).toBeLessThanOrEqual(200);
+    // Every kept line (all but the appended marker) must be one of the original whole lines.
+    const marker = '\n… (truncated)';
+    const withoutMarker = result.endsWith(marker) ? result.slice(0, -marker.length) : result;
+    const keptLines = withoutMarker.split('\n');
+    for (const line of keptLines) {
+      expect(lines).toContain(line);
+    }
+    expect(result).not.toMatch(/&(?!amp;)/); // no dangling/partial "&" entity
+  });
+
+  it('falls back to a stripped, hard-sliced plain-text cut when the first line alone exceeds maxLength', () => {
+    const hugeLine = `<b>${'z'.repeat(300)}</b>`;
+    const result = truncateHtmlByLines(hugeLine, 100);
+    expect(result.length).toBeLessThanOrEqual(100);
+    // Tags must be stripped in this fallback — no unclosed <b> left dangling.
+    expect(result).not.toContain('<b>');
+    expect(result).not.toContain('</b>');
   });
 });

--- a/src/main/integrations/message-format.ts
+++ b/src/main/integrations/message-format.ts
@@ -65,3 +65,56 @@ export function formatTelegramHTML(event: IntegrationEvent): string {
   lines.push(event.link ? escapeHTML(event.link) : escapeHTML(OFFLINE_LINE));
   return lines.join('\n');
 }
+
+const DEFAULT_TRUNCATION_MARKER = '\n… (truncated)';
+
+/**
+ * Truncates plain text to at most `maxLength` characters, keeping the head
+ * and dropping from the tail. Appends `marker` when truncation occurs, and
+ * the returned string is always `<= maxLength` characters. Safe for bodies
+ * with no markup to preserve (Discord's `content`).
+ */
+export function truncatePlainText(
+  text: string,
+  maxLength: number,
+  marker: string = DEFAULT_TRUNCATION_MARKER
+): string {
+  if (text.length <= maxLength) return text;
+  const budget = Math.max(0, maxLength - marker.length);
+  return text.slice(0, budget) + marker.slice(0, maxLength - budget);
+}
+
+/**
+ * Truncates an HTML-formatted string to at most `maxLength` characters by
+ * dropping whole trailing lines — never cutting inside a line. This keeps
+ * HTML entities and tags intact because `formatTelegramHTML` always keeps
+ * them self-contained within a single line (e.g. a full `<b>…</b>` span, or
+ * a fully-escaped `&amp;`), so a `\n` boundary is always a safe cut point.
+ *
+ * In the pathological case where the very first line alone exceeds
+ * `maxLength`, tags are stripped before a hard character slice so the result
+ * can never leave an unclosed tag (which Telegram's HTML parse mode would
+ * reject outright). The length guarantee (`<= maxLength`) always holds.
+ */
+export function truncateHtmlByLines(
+  text: string,
+  maxLength: number,
+  marker: string = DEFAULT_TRUNCATION_MARKER
+): string {
+  if (text.length <= maxLength) return text;
+  const budget = maxLength - marker.length;
+  const lines = text.split('\n');
+  const kept: string[] = [];
+  let used = 0;
+  for (const line of lines) {
+    const addLen = line.length + (kept.length > 0 ? 1 : 0); // +1 for the joining '\n'
+    if (used + addLen > budget) break;
+    kept.push(line);
+    used += addLen;
+  }
+  if (kept.length > 0) return kept.join('\n') + marker;
+  // Even the head line alone doesn't fit: strip tags to avoid an unclosed
+  // tag, then hard-slice as plain text.
+  const stripped = lines[0].replace(/<\/?[a-z]+>/gi, '');
+  return truncatePlainText(stripped, maxLength, marker);
+}


### PR DESCRIPTION
Closes #80

## Problem
Discord's webhook `content` field (2000 char limit) and Telegram's
`sendMessage` `text` field (4096 char limit) both reject over-limit
payloads with HTTP 400. `outcomeFromResponse` treats 4xx as
non-retryable, so an over-limit digest (e.g. a busy fleet with many
active sessions) was silently dropped — no delivery, no retry, no
visible error. Root cause is the missing length guard combined with
400 being (correctly) non-retryable; truncation at the source is the
fix, not a retry-classification change.

## Change
- `message-format.ts`: added two pure helpers.
  - `truncatePlainText(text, maxLength, marker?)` — character-based
    truncation, used for Discord's plain `content`.
  - `truncateHtmlByLines(text, maxLength, marker?)` — drops whole
    trailing lines rather than cutting mid-line. Safe because
    `formatTelegramHTML` always keeps a tag (`<b>…</b>`) or an escaped
    entity (`&amp;`) fully contained within a single line, so a `\n`
    boundary is always a safe cut point. Falls back to stripping tags
    and hard-slicing plain text for the pathological case where the
    very first line alone exceeds the limit, so an unclosed `<b>` can
    never reach Telegram (which would otherwise reject the whole
    message under `parse_mode: HTML`).
- `discord-connector.ts`: `content` now goes through
  `truncatePlainText(msg.text, 2000)`.
- `telegram-connector.ts`: `text` now goes through
  `truncateHtmlByLines(formatTelegramHTML(msg.event), 4096)`.

No new dependencies.

## Tests
- `message-format.test.ts`: new `describe` blocks for
  `truncatePlainText` and `truncateHtmlByLines`, including the
  line-boundary-preservation case and the pathological
  single-oversized-line fallback (asserts stripped tags, no unclosed
  `<b>`).
- `connectors.test.ts`: new cases — Discord content >2000 chars is
  truncated to ≤2000 with the marker; Telegram text >4096 chars is
  truncated to ≤4096 with balanced `<b>`/`</b>` tags and no dangling
  HTML entity. Existing under-limit assertions (unchanged payload)
  still pass — no regression.

## Verification
- Targeted: `npx vitest run --config vitest.workspace.ts
  src/main/integrations/message-format.test.ts
  src/main/integrations/connectors.test.ts` → 2 files, 26 tests, all
  passing.
- Full suite: `npm test` → 90 files / 887 tests, all passing (887 =
  882 baseline + 5 new).
- `tsc --noEmit -p tsconfig.json` and `tsc --noEmit -p
  tsconfig.main.json` → both clean.