### PR TITLE
fix(integrations): exclude exited sessions from idle digest count

### DIFF
--- a/src/main/integrations/integration-manager.test.ts
+++ b/src/main/integrations/integration-manager.test.ts
@@ -160,6 +160,24 @@ describe('IntegrationManager', () => {
     m.dispose();
   });
 
+  it('sendDigestNow does not count exited sessions as idle', async () => {
+    const { registry, delivered } = fakeRegistry();
+    const sessions = [
+      meta({ id: 'a', name: 'one', activityState: 'working' }),
+      meta({ id: 'b', name: 'two', activityState: 'exited' }),
+      meta({ id: 'c', name: 'three', activityState: 'exited' }),
+      meta({ id: 'd', name: 'four', activityState: 'exited' }),
+    ];
+    const m = new IntegrationManager(makeDeps(settingsWith({}), { sessions }), { registry });
+    await m.sendDigestNow();
+    await vi.runAllTimersAsync();
+    expect(delivered.length).toBe(1);
+    const text = delivered[0].msg.text;
+    expect(text).toContain('1 working');
+    expect(text).toContain('0 idle');
+    m.dispose();
+  });
+
   it('scheduled digest skips when the whole fleet is idle', async () => {
     const { registry, delivered } = fakeRegistry();
     const sessions = [meta({ id: 'a', activityState: 'idle' }), meta({ id: 'b', activityState: 'exited' })];

--- a/src/main/integrations/integration-manager.ts
+++ b/src/main/integrations/integration-manager.ts
@@ -177,7 +177,7 @@ export class IntegrationManager {
       if (state === 'working' || state === 'initializing') counts.working++;
       else if (state === 'awaiting-input' || state === 'awaiting-approval' || state === 'done') counts.needYou++;
       else if (state === 'errored') counts.errored++;
-      else counts.idle++;
+      else if (state !== 'exited') counts.idle++;
       if (state !== 'idle' && state !== 'exited') {
         lines.push(`${path.basename(s.workingDirectory)} · ${s.name} — ${state}`);
       }


### PR DESCRIPTION
## Summary

`buildDigestEvent()` in `integration-manager.ts` counts session states into
`working` / `needYou` / `idle` / `errored` buckets for the fleet digest. The
counting loop's catch-all `else` branch folded `exited` sessions into
`counts.idle`, but two other places in the same file already treat `exited`
as excluded from everything:

- `fleetActive()` — used to decide whether the scheduled digest fires at all
- the per-session summary line filter (`state !== 'idle' && state !== 'exited'`)

Net effect: a fleet made up entirely of exited sessions produced a digest
saying "N idle" (wrong — those sessions are gone) even though the digest
scheduler itself considers that fleet inactive and would skip sending on a
timer tick. Manual `sendDigestNow()` calls didn't get that skip, so the
inconsistent count was visible.

## Fix

One-line change: the idle branch now excludes `exited`, same guard already
used by `fleetActive()` and the per-line filter.

```diff
- else counts.idle++;
+ else if (state !== 'exited') counts.idle++;
```

Exited sessions now land in no bucket, consistent with the rest of the file.
All other states (`working`, `needYou`, `errored`, genuinely idle) are
unaffected.

## Testing

Added a regression test, `sendDigestNow does not count exited sessions as
idle`, asserting a fleet with 1 working + 3 exited sessions reports `0 idle`
(previously would have reported `3 idle`).

Full main-project suite, run from the omnidesk-agent clone:

```
npx vitest run --config vitest.workspace.ts --project main
 Test Files  43 passed (43)
      Tests  511 passed (511)
```

(511 vs. the pre-change 510 confirms the new test executed and passed.)

Type-check, both projects clean (no output):

```
npx tsc --noEmit -p tsconfig.json
npx tsc --noEmit -p tsconfig.main.json
```

No new dependencies added.

Closes #93