### PR TITLE
fix(renderer): feed real ratePerHour5h field into burn-rate pill

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -810,7 +810,7 @@ function App() {
           repo={activeRepo}
           repos={repos}
           sessions={sessions}
-          burnRatePerHour={(burnRate as any)?.dollarsPerHour ?? null}
+          burnRatePerHour={burnRate?.ratePerHour5h ?? null}
           onOpenOtherReposLive={() => setRepoSwitcher({ anchorRect: null })}
           needYouCount={attention.count}
           onOpenCockpit={() => setShowCockpit(true)}

--- a/src/renderer/components/shell/StatusBar.test.tsx
+++ b/src/renderer/components/shell/StatusBar.test.tsx
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { StatusBar } from './StatusBar';
+import type { Repo } from '../../hooks/useRepos';
+
+// Minimal valid Repo fixture — StatusBar only reads id/name/path/branch, but
+// the prop type requires the full shape.
+function makeRepo(partial?: Partial<Repo>): Repo {
+  return {
+    id: 'r1',
+    name: 'omnidesk',
+    org: 'workspace',
+    path: 'C:/repos/omnidesk',
+    workspacePath: 'C:/repos',
+    branch: 'main',
+    lastOpened: 0,
+    color: 'accent',
+    isGit: true,
+    ...partial,
+  };
+}
+
+describe('StatusBar burn-rate pill', () => {
+  it('renders the %/hr pill when burnRatePerHour is a number (e.g. BurnRateData.ratePerHour5h)', () => {
+    render(
+      <StatusBar
+        repo={makeRepo()}
+        repos={[makeRepo()]}
+        sessions={[]}
+        burnRatePerHour={12.34}
+        onOpenOtherReposLive={() => {}}
+      />
+    );
+    expect(screen.getByText('12.3%/hr')).toBeInTheDocument();
+  });
+
+  it('does not render the pill when burnRatePerHour is null', () => {
+    render(
+      <StatusBar
+        repo={makeRepo()}
+        repos={[makeRepo()]}
+        sessions={[]}
+        burnRatePerHour={null}
+        onOpenOtherReposLive={() => {}}
+      />
+    );
+    expect(screen.queryByText(/%\/hr/)).not.toBeInTheDocument();
+  });
+
+  it('does not render the pill when burnRatePerHour is undefined', () => {
+    render(
+      <StatusBar
+        repo={makeRepo()}
+        repos={[makeRepo()]}
+        sessions={[]}
+        onOpenOtherReposLive={() => {}}
+      />
+    );
+    expect(screen.queryByText(/%\/hr/)).not.toBeInTheDocument();
+  });
+});

--- a/src/renderer/components/shell/StatusBar.tsx
+++ b/src/renderer/components/shell/StatusBar.tsx
@@ -9,7 +9,7 @@ interface StatusBarProps {
   repo: Repo | null;
   repos: Repo[];
   sessions: TabData[];
-  /** Burn rate, USD per hour, displayed as N.NN /hr. Provide null if not yet known. */
+  /** Burn rate, percent of the 5h quota consumed per hour, displayed as N.N%/hr. Provide null if not yet known. */
   burnRatePerHour?: number | null;
   onOpenOtherReposLive: () => void;
   /** Count of agents (across all repos) currently needing attention. */
@@ -113,7 +113,7 @@ export function StatusBar({
         {typeof burnRatePerHour === 'number' && (
           <span className="pill">
             <P4Icon name="flame" size={10} style={{ color: 'var(--warning)' }} />
-            {burnRatePerHour.toFixed(2)} /hr
+            {burnRatePerHour.toFixed(1)}%/hr
           </span>
         )}
       </div>


### PR DESCRIPTION
## Summary

The status-bar burn-rate ("flame") pill never rendered. `App.tsx` built its
`burnRatePerHour` prop like this:

```tsx
burnRatePerHour={(burnRate as any)?.dollarsPerHour ?? null}
```

`BurnRateData` (src/shared/ipc-types.ts) has no `dollarsPerHour` field — the
`as any` cast silenced the type error but the access always resolved to
`undefined`, so the prop was always `null` and `StatusBar`'s guard
(`typeof burnRatePerHour === 'number'`) never passed.

## Fix

- `App.tsx`: read the real field, `burnRate?.ratePerHour5h ?? null`, and drop
  the `any` cast — `burnRate` is already typed `BurnRateData | null` via
  `useQuota`, so this is now a plain, type-checked field access.
- `StatusBar.tsx`: the pill text (`{v.toFixed(2)} /hr`) and its doc comment
  both implied a dollar amount. `ratePerHour5h` is "percent of the 5h quota
  consumed per hour", so relabelled the pill to `{v.toFixed(1)}%/hr` and
  corrected the doc comment to match.
- Added `StatusBar.test.tsx`: renders the pill and asserts the `%/hr` text
  when `burnRatePerHour` is a number, and asserts it's absent for `null` and
  `undefined`.

## Testing

Renderer test project (full run, not just the new file):

```
 Test Files  39 passed (39)
      Tests  274 passed (274)
```

`npx tsc --noEmit -p tsconfig.json` — no output (clean).

No new dependencies added.

Closes #96