### PR TITLE
fix(git-manager): attach missing error handler on .git/index watcher

### DIFF
--- a/src/main/git-manager.test.ts
+++ b/src/main/git-manager.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { EventEmitter } from 'events';
 import { GitManager } from './git-manager';
 
 // Mock child_process and fs
@@ -12,8 +13,18 @@ vi.mock('fs', () => ({
 }));
 
 import { execFile } from 'child_process';
+import * as fs from 'fs';
 
 const mockExecFile = execFile as unknown as ReturnType<typeof vi.fn>;
+const mockExistsSync = fs.existsSync as unknown as ReturnType<typeof vi.fn>;
+const mockWatch = fs.watch as unknown as ReturnType<typeof vi.fn>;
+
+/** Fake FSWatcher: a real EventEmitter (so `.on('error', ...)` actually works) plus a close() spy. */
+function fakeWatcher(): EventEmitter & { close: ReturnType<typeof vi.fn> } {
+  const w = new EventEmitter() as EventEmitter & { close: ReturnType<typeof vi.fn> };
+  w.close = vi.fn();
+  return w;
+}
 
 function mockGitResponse(stdout: string, stderr = '', exitCode = 0) {
   mockExecFile.mockImplementationOnce(
@@ -394,6 +405,58 @@ describe('GitManager', () => {
     it('stopWatching returns true even with no watcher', () => {
       const result = manager.stopWatching('/test');
       expect(result).toBe(true);
+    });
+
+    describe('watcher error handling (regression for #99)', () => {
+      let watchers: Array<EventEmitter & { close: ReturnType<typeof vi.fn> }>;
+
+      beforeEach(() => {
+        watchers = [];
+        mockExistsSync.mockReturnValue(true); // gitDir and indexPath both "exist"
+        mockWatch.mockImplementation(() => {
+          const w = fakeWatcher();
+          watchers.push(w);
+          return w;
+        });
+      });
+
+      it('registers an error listener on both the dir watcher and the index watcher', () => {
+        const ok = manager.startWatching('/repo');
+        expect(ok).toBe(true);
+        expect(watchers.length).toBe(2); // [0] = .git dir watcher, [1] = .git/index watcher
+        expect(watchers[0].listenerCount('error')).toBeGreaterThan(0);
+        expect(watchers[1].listenerCount('error')).toBeGreaterThan(0);
+      });
+
+      it('dir watcher "error" is caught, logged, and stops watching without throwing', () => {
+        const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+        manager.startWatching('/repo');
+        const [dirWatcher, indexWatcher] = watchers;
+
+        expect(() => dirWatcher.emit('error', new Error('boom'))).not.toThrow();
+
+        expect(warnSpy).toHaveBeenCalledWith('[GitManager] Watch error for', '/repo', expect.any(Error));
+        expect(dirWatcher.close).toHaveBeenCalled();
+        expect(indexWatcher.close).toHaveBeenCalled(); // stopWatching closes both entries
+
+        warnSpy.mockRestore();
+      });
+
+      it('index watcher "error" is caught, logged, and stops watching without throwing (the #99 crash path)', () => {
+        const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+        manager.startWatching('/repo');
+        const [dirWatcher, indexWatcher] = watchers;
+
+        // Before the fix, this emit had no listener and Node would throw it as an
+        // uncaught exception, crashing the Electron main process.
+        expect(() => indexWatcher.emit('error', new Error('boom'))).not.toThrow();
+
+        expect(warnSpy).toHaveBeenCalledWith('[GitManager] Index watch error for', '/repo', expect.any(Error));
+        expect(dirWatcher.close).toHaveBeenCalled();
+        expect(indexWatcher.close).toHaveBeenCalled();
+
+        warnSpy.mockRestore();
+      });
     });
   });
 

--- a/src/main/git-manager.ts
+++ b/src/main/git-manager.ts
@@ -1162,6 +1162,10 @@ export class GitManager {
           const indexWatcher = fs.watch(indexPath, () => {
             this.debouncedRefresh(workDir);
           });
+          indexWatcher.on('error', (err) => {
+            console.warn('[GitManager] Index watch error for', workDir, err);
+            this.stopWatching(workDir);
+          });
           // Store with a modified key
           this.watchers.set(workDir + ':index', indexWatcher);
         } catch {


### PR DESCRIPTION
## What
`GitManager.startWatching` creates two `fs.watch` watchers per repo: one on
the `.git` directory and one on `.git/index`. The dir watcher has an
`'error'` listener (log + `stopWatching`), but the index watcher did not.

Node's `EventEmitter`/`fs.watch` throws an unhandled `'error'` event as an
uncaught exception when there's no listener attached. In Electron's main
process that's fatal — it crashes the whole app. Anything that can trigger
an fs-watch error on the index file (file replaced during a rebase/checkout,
platform watch limits, EMFILE, etc.) could take the app down.

## Fix
Mirror the existing dir-watcher handling on the index watcher: log a warning
and call `stopWatching(workDir)` so both watchers are torn down cleanly
instead of letting the error propagate unhandled.

```ts
const indexWatcher = fs.watch(indexPath, () => {
  this.debouncedRefresh(workDir);
});
indexWatcher.on('error', (err) => {
  console.warn('[GitManager] Index watch error for', workDir, err);
  this.stopWatching(workDir);
});
```

## Tests
Added `describe('watcher error handling (regression for #99)', ...)` in
`src/main/git-manager.test.ts`, using a real `EventEmitter` as the fake
`FSWatcher` so `.on('error', ...)`/`.emit('error', ...)` exercise the actual
production handler rather than a stub:
- both the dir watcher and index watcher register an `'error'` listener
- the existing dir-watcher error path still logs, closes both watchers, and
  does not throw
- the previously-unhandled index-watcher error path (the actual #99 crash)
  now also logs, closes both watchers, and does not throw

## Verification
- `npx vitest run --config vitest.workspace.ts --project main src/main/git-manager.test.ts` → 46/46 passed (43 pre-existing + 3 new)
- `npx vitest run --config vitest.workspace.ts --project main` → 513/513 passed across all 43 files, no regressions
- `npx tsc -p tsconfig.main.json --noEmit` → clean, no errors

No new dependencies added.

Closes #99