### PR TITLE
fix(remote): prune stale entries from RemoteAuth rate-limit map

### DIFF
--- a/src/main/remote/remote-auth.test.ts
+++ b/src/main/remote/remote-auth.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { RemoteAuth } from './remote-auth';
 
 describe('RemoteAuth', () => {
@@ -55,5 +55,31 @@ describe('RemoteAuth', () => {
     for (let i = 0; i < 10; i++) expect(a.rateLimited('1.2.3.4')).toBe(false);
     expect(a.rateLimited('1.2.3.4')).toBe(true);
     expect(a.rateLimited('9.9.9.9')).toBe(false);
+  });
+
+  it('prunes stale attempts once the window elapses, keeping the map bounded', () => {
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(0);
+      const a = new RemoteAuth();
+
+      // Flood with many distinct IPs (as a spoofed X-Forwarded-For header
+      // could do) — each gets one entry in the attempts map.
+      const ipCount = 50;
+      for (let i = 0; i < ipCount; i++) {
+        a.rateLimited(`10.0.0.${i}`);
+      }
+      expect(a.size()).toBe(ipCount);
+
+      // Advance past WINDOW_MS (60s). The next call should sweep out every
+      // entry whose window has elapsed before recording the new one.
+      vi.setSystemTime(61_000);
+      expect(a.rateLimited('10.0.0.999')).toBe(false);
+
+      // Only the fresh entry should remain — the map didn't grow unbounded.
+      expect(a.size()).toBe(1);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/src/main/remote/remote-auth.ts
+++ b/src/main/remote/remote-auth.ts
@@ -12,6 +12,9 @@ export class RemoteAuth {
   private readonly attempts = new Map<string, { count: number; first: number }>();
   private readonly WINDOW_MS = 60_000;
   private readonly MAX_ATTEMPTS = 10;
+  // Throttle the sweep so the common-path call stays O(1): a full pass over
+  // `attempts` only runs once per WINDOW_MS, not on every call.
+  private lastPruneAt = 0;
 
   constructor(token?: string) {
     this.token = token ?? RemoteAuth.generateToken();
@@ -62,6 +65,7 @@ export class RemoteAuth {
 
   rateLimited(ip: string): boolean {
     const now = Date.now();
+    this.pruneStaleAttempts(now);
     const rec = this.attempts.get(ip);
     if (!rec || now - rec.first > this.WINDOW_MS) {
       this.attempts.set(ip, { count: 1, first: now });
@@ -69,5 +73,28 @@ export class RemoteAuth {
     }
     rec.count += 1;
     return rec.count > this.MAX_ATTEMPTS;
+  }
+
+  /**
+   * Number of IPs currently tracked in the rate-limit window. Exposed for
+   * tests/monitoring; not used by the rate-limit decision itself.
+   */
+  size(): number {
+    return this.attempts.size;
+  }
+
+  // `attempts` is fed one entry per distinct caller (remote-access-server.ts
+  // trusts a client-supplied header for the IP), so an entry for an IP that
+  // never calls again would otherwise sit in the Map forever. Sweep out
+  // anything whose window has elapsed, but only as often as WINDOW_MS so a
+  // steady stream of requests doesn't pay an O(n) scan on every call.
+  private pruneStaleAttempts(now: number): void {
+    if (now - this.lastPruneAt < this.WINDOW_MS) return;
+    this.lastPruneAt = now;
+    for (const [ip, rec] of this.attempts) {
+      if (now - rec.first > this.WINDOW_MS) {
+        this.attempts.delete(ip);
+      }
+    }
   }
 }


### PR DESCRIPTION
## What this does (plain terms)

OmniDesk's remote-access feature keeps a short-term "how many login attempts has this visitor made" list, keyed by the visitor's IP address, so it can block someone hammering the login with wrong credentials. The bug: that list never cleaned itself up. Someone could send requests pretending to be thousands of different IPs and the list would just keep growing forever, slowly eating memory. This PR makes the list clean out old, no-longer-relevant entries automatically, so it can't grow without bound.

Closes #104

## Implementation

- `RemoteAuth.rateLimited()` now calls a new `pruneStaleAttempts(now)` before recording the current attempt. It removes any tracked IP whose window (`WINDOW_MS` = 60s) has already elapsed.
- To keep the common-path call cheap, the sweep is throttled: the full scan over the `attempts` Map only runs once per `WINDOW_MS`, via a `lastPruneAt` timestamp, not on every single call. So a steady stream of requests still pays O(1) per call on average, while the Map stays bounded.
- Added `size()` (test/monitoring accessor only — not used in the rate-limit decision itself) so the bound is directly observable from tests.
- No change to `MAX_ATTEMPTS` / `WINDOW_MS` semantics for an actively-attempting IP — an IP mid-window is unaffected by the sweep.
- Chose time-based pruning over an LRU/size-threshold cap since the issue explicitly allowed either, and this one is simpler and matches the existing window-based rate-limit model already in the file. Whether to trust the client-supplied IP header at all is explicitly out of scope per the issue (separate hardening issue).
- No new dependencies.

## Testing

- `npx tsc --noEmit -p tsconfig.json` — clean.
- `npx tsc --noEmit -p tsconfig.main.json` — clean.
- `npm test` (full suite, `vitest.workspace.ts`, all three projects) — 90/90 files, 880/880 tests passing.
- New test in `remote-auth.test.ts` (`prunes stale attempts once the window elapses, keeping the map bounded`): seeds 50 distinct IPs at `t=0` and confirms `size()` is 50, advances simulated time past `WINDOW_MS` via `vi.useFakeTimers()`/`vi.setSystemTime()`, triggers one more call, and confirms `size()` drops to 1 (stale entries pruned).
- Existing rate-limit test (`rate limits after the max attempts within the window`) verified unchanged and still passing.