### PR TITLE
fix(github-service): detect real default branch in ship-it preview

### DIFF
--- a/src/main/integrations/github-service.test.ts
+++ b/src/main/integrations/github-service.test.ts
@@ -124,6 +124,57 @@ describe('GitHubService.getShipItPreview', () => {
       existingPrUrl: 'https://github.com/a/b/pull/3',
     });
   });
+
+  it('uses origin/HEAD to detect a non-main/master default branch', async () => {
+    routeExec((bin, args) => {
+      const found = ghFound(bin, args);
+      if (found) return found;
+      if (bin === 'git' && args[0] === 'rev-parse' && args.includes('--abbrev-ref')) return { stdout: 'feat/x\n' };
+      if (bin === 'git' && args[0] === 'symbolic-ref') return { stdout: 'origin/develop\n' };
+      if (bin === 'git' && args[0] === 'rev-parse' && args.includes('origin/develop')) return { exitCode: 0 };
+      if (bin === 'git' && args[0] === 'diff') return { stdout: ' 1 file changed, 4 insertions(+)\n' };
+      if (bin === 'git' && args[0] === 'log') return { stdout: 'aaa111 chore: setup\n' };
+      if (args[0] === 'pr' && args[1] === 'view') return { exitCode: 1 };
+      return undefined;
+    });
+    const preview = await new GitHubService().getShipItPreview('C:\\repo');
+    expect(preview).toEqual({
+      branch: 'feat/x',
+      baseBranch: 'develop',
+      filesChanged: 1,
+      insertions: 4,
+      deletions: 0,
+      commits: ['aaa111 chore: setup'],
+      existingPrUrl: undefined,
+    });
+  });
+
+  it('throws when no base branch can be resolved', async () => {
+    routeExec((bin, args) => {
+      const found = ghFound(bin, args);
+      if (found) return found;
+      if (bin === 'git' && args[0] === 'rev-parse' && args.includes('--abbrev-ref')) return { stdout: 'feat/x\n' };
+      if (bin === 'git' && args[0] === 'symbolic-ref') return { exitCode: 1 };
+      if (bin === 'git' && args[0] === 'rev-parse' && args.includes('origin/main')) return { exitCode: 1 };
+      if (bin === 'git' && args[0] === 'rev-parse' && args.includes('origin/master')) return { exitCode: 1 };
+      return undefined;
+    });
+    await expect(new GitHubService().getShipItPreview('C:\\repo'))
+      .rejects.toThrow('Could not determine the base branch to compare against');
+  });
+
+  it('throws when diff/log commands fail against a resolved base', async () => {
+    routeExec((bin, args) => {
+      const found = ghFound(bin, args);
+      if (found) return found;
+      if (bin === 'git' && args[0] === 'rev-parse' && args.includes('--abbrev-ref')) return { stdout: 'feat/x\n' };
+      if (bin === 'git' && args[0] === 'rev-parse' && args.includes('origin/main')) return { exitCode: 0 };
+      if (bin === 'git' && args[0] === 'diff') return { exitCode: 1, stderr: 'fatal: bad revision\n' };
+      return undefined;
+    });
+    await expect(new GitHubService().getShipItPreview('C:\\repo'))
+      .rejects.toThrow('Could not determine the base branch to compare against');
+  });
 });
 
 describe('GitHubService.createPR', () => {

--- a/src/main/integrations/github-service.ts
+++ b/src/main/integrations/github-service.ts
@@ -72,6 +72,26 @@ export class GitHubService {
     return this.ghBinary;
   }
 
+  /**
+   * Best-effort detection of the repo's real default branch, for repos whose
+   * default is neither `main` nor `master` (e.g. `develop`, `trunk`).
+   * `origin/HEAD` is the canonical, offline answer (set at clone time), so it
+   * is tried first; the main/master probes remain as a fallback for shallow
+   * or never-fetched clones where `origin/HEAD` isn't set.
+   */
+  private async detectDefaultBranch(dir: string): Promise<string | undefined> {
+    const symbolicRef = await this.exec('git', ['symbolic-ref', '--short', 'refs/remotes/origin/HEAD'], dir);
+    if (symbolicRef.exitCode === 0) {
+      const stripped = symbolicRef.stdout.trim().replace(/^origin\//, '');
+      if (stripped) return stripped;
+    }
+    const hasMain = await this.exec('git', ['rev-parse', '--verify', '--quiet', 'origin/main'], dir);
+    if (hasMain.exitCode === 0) return 'main';
+    const hasMaster = await this.exec('git', ['rev-parse', '--verify', '--quiet', 'origin/master'], dir);
+    if (hasMaster.exitCode === 0) return 'master';
+    return undefined;
+  }
+
   async preflight(dir: string): Promise<GitHubPreflight> {
     const gh = await this.findGh();
     if (!gh) {
@@ -113,16 +133,19 @@ export class GitHubService {
       if (branchRes.exitCode !== 0) throw new Error('Not a git repository');
       const branch = branchRes.stdout.trim();
 
-      let base = baseBranch;
-      if (!base) {
-        const hasMain = await this.exec('git', ['rev-parse', '--verify', '--quiet', 'origin/main'], dir);
-        base = hasMain.exitCode === 0 ? 'main' : 'master';
+      let base = baseBranch || (await this.detectDefaultBranch(dir));
+      if (base) {
+        const baseExists = await this.exec('git', ['rev-parse', '--verify', '--quiet', `origin/${base}`], dir);
+        if (baseExists.exitCode !== 0) base = undefined;
       }
+      if (!base) throw new Error('Could not determine the base branch to compare against');
 
       const stat = await this.exec('git', ['diff', '--shortstat', `origin/${base}...HEAD`], dir);
+      if (stat.exitCode !== 0) throw new Error('Could not determine the base branch to compare against');
       const { filesChanged, insertions, deletions } = parseShortstat(stat.stdout);
 
       const logRes = await this.exec('git', ['log', '--oneline', `origin/${base}..HEAD`], dir);
+      if (logRes.exitCode !== 0) throw new Error('Could not determine the base branch to compare against');
       const commits = logRes.stdout.split(/\r?\n/).map((l) => l.trim()).filter(Boolean);
 
       const gh = await this.findGh();


### PR DESCRIPTION
## Summary

Closes #81.

`getShipItPreview` assumed the repo's base branch was always `main` or `master`, and it never checked the exit codes on the `git diff --shortstat` / `git log --oneline` calls. Result: on a repo whose default branch is something else (`develop`, `trunk`, etc.), or if those commands failed for any reason, the preview silently returned `filesChanged: 0, insertions: 0, deletions: 0, commits: []` instead of surfacing a problem — misleading the user into thinking there was nothing to ship.

## Change

- Added `detectDefaultBranch(dir)`: tries the canonical, offline `origin/HEAD` symbolic-ref first (`git symbolic-ref --short refs/remotes/origin/HEAD`, set at clone time), then falls back to probing `origin/main`, then `origin/master`.
- `getShipItPreview` now uses this helper when no `baseBranch` override is given, and verifies the resolved ref actually exists via `git rev-parse --verify --quiet origin/<base>` before comparing against it.
- If no base branch can be resolved, or if the `diff`/`log` calls exit non-zero, it now throws `Could not determine the base branch to compare against` instead of returning zeroed-out stats.

No new dependencies.

## Test plan

- Added two new tests to `github-service.test.ts`:
  - `origin/HEAD` pointing at a non-main/master branch (`develop`) is correctly detected and used for the diff/log comparison.
  - When all base-branch detection paths fail, `getShipItPreview` rejects with the descriptive error.
- Added a third defensive test: a resolved base branch whose `diff` call still fails also rejects with the same descriptive error (was previously silently swallowed).
- `npx tsc --noEmit -p tsconfig.json` — clean.
- `npx tsc --noEmit -p tsconfig.main.json` — clean.
- `npx vitest run --config vitest.workspace.ts src/main/integrations/github-service.test.ts` — 12/12 passed.
- Full suite (`npm test`): 90 files / 882 tests passed.