### PR TITLE
fix(providers): unify permissionModes on the PermissionMode domain

### DIFF
--- a/src/main/providers/codex-provider.test.ts
+++ b/src/main/providers/codex-provider.test.ts
@@ -33,11 +33,23 @@ describe('CodexProvider', () => {
       expect(info.capabilities.readinessDetection).toBe(true);
     });
 
-    it('includes Codex-specific permission modes', () => {
+    it('advertises permission modes in the OmniDesk domain vocabulary, not Codex CLI names', () => {
       const info = provider.getInfo();
-      expect(info.capabilities.permissionModes).toContain('suggest');
-      expect(info.capabilities.permissionModes).toContain('auto-edit');
-      expect(info.capabilities.permissionModes).toContain('full-auto');
+      expect(info.capabilities.permissionModes).toEqual(['standard', 'skip-permissions']);
+      // Guard against re-introducing Codex-native names (e.g. 'suggest', 'auto-edit', 'full-auto')
+      expect(info.capabilities.permissionModes).not.toContain('suggest');
+      expect(info.capabilities.permissionModes).not.toContain('auto-edit');
+      expect(info.capabilities.permissionModes).not.toContain('full-auto');
+    });
+
+    it('every advertised permission mode has a buildCommand() translation', () => {
+      const info = provider.getInfo();
+      for (const mode of info.capabilities.permissionModes) {
+        const cmd = provider.buildCommand({ workingDirectory: '/test', permissionMode: mode });
+        expect(cmd).toContain('--approval-mode');
+        // The raw domain name should never leak through untranslated
+        expect(cmd).not.toContain(`--approval-mode ${mode}`);
+      }
     });
   });
 

--- a/src/main/providers/codex-provider.ts
+++ b/src/main/providers/codex-provider.ts
@@ -3,6 +3,11 @@ import { IProvider, ProviderCommandOptions } from './provider';
 import { ProviderId, ProviderInfo } from '../../shared/types/provider-types';
 import type { StateSignals } from '../../shared/session-state-types';
 
+// Note: ProviderCommandOptions.permissionMode (see ./provider) is still a
+// loose `string`, so this map stays keyed by string too — tightening it to
+// PermissionMode breaks the `PERMISSION_MODE_MAP[options.permissionMode]`
+// lookup in buildCommand() below. Narrowing that option's type is out of
+// scope here; see capabilities.permissionModes for the domain-typed surface.
 /** Map OmniDesk permission mode names to Codex approval modes */
 const PERMISSION_MODE_MAP: Record<string, string> = {
   'standard': 'suggest',
@@ -58,7 +63,9 @@ export class CodexProvider implements IProvider {
         agentTeams: false,
         quota: false,
         readinessDetection: true,
-        permissionModes: ['suggest', 'auto-edit', 'full-auto'],
+        // Domain names (see PermissionMode), not Codex's own CLI vocabulary —
+        // buildCommand() below translates these into Codex approval modes.
+        permissionModes: ['standard', 'skip-permissions'],
       },
       defaultModel: 'codex-mini',
     };

--- a/src/shared/types/provider-types.test.ts
+++ b/src/shared/types/provider-types.test.ts
@@ -76,7 +76,7 @@ describe('provider-types', () => {
           agentTeams: false,
           quota: false,
           readinessDetection: true,
-          permissionModes: ['suggest', 'auto-edit', 'full-auto'],
+          permissionModes: ['standard', 'skip-permissions'],
         },
         defaultModel: 'codex-mini',
       };

--- a/src/shared/types/provider-types.ts
+++ b/src/shared/types/provider-types.ts
@@ -1,3 +1,5 @@
+import type { PermissionMode } from '../ipc-types';
+
 export type ProviderId = 'claude' | 'codex';
 
 export interface ProviderCapabilities {
@@ -5,7 +7,7 @@ export interface ProviderCapabilities {
   agentTeams: boolean;         // Supports agent team workflows
   quota: boolean;              // Has usage quota/billing tracking
   readinessDetection: boolean; // Has CLI ready-state detection
-  permissionModes: string[];   // Available permission modes
+  permissionModes: PermissionMode[]; // Available permission modes, in OmniDesk's own domain vocabulary — not provider-native CLI names
 }
 
 export interface ProviderInfo {


### PR DESCRIPTION
Closes #89

## What this does (plain terms)

Codex's provider info was reporting its permission modes using Codex's own internal names (`suggest`, `auto-edit`, `full-auto`), while every other part of OmniDesk uses two simpler, app-level names: `standard` and `skip-permissions`. That mismatch was just sitting there as loose typing — nothing was actively broken today, but it was a landmine: if any future UI code read `capabilities.permissionModes` to build a picker, it would show Codex's raw CLI jargon instead of OmniDesk's names, and one of those three values (`auto-edit`) isn't even translated anywhere, so it would have silently reached the `codex` CLI as an unmapped flag.

This PR fixes the mismatch and makes the compiler catch it if it ever comes back.

## What changed

- `src/shared/types/provider-types.ts`: `ProviderCapabilities.permissionModes` is now typed `PermissionMode[]` (the shared domain type already used everywhere else in the app) instead of a bare `string[]`. This turns "provider advertises a name outside the domain" into a compile error.
- `src/main/providers/codex-provider.ts`: `getInfo()` now advertises `['standard', 'skip-permissions']`, matching `ClaudeProvider`. No behavior change to `buildCommand()` — `PERMISSION_MODE_MAP` already translated these exact domain keys to Codex's `--approval-mode` flags (`suggest` / `full-auto`); that map is unchanged.
- `src/main/providers/codex-provider.test.ts`: replaced the stale assertion of the old Codex-native list, and added a test that walks every advertised mode through `buildCommand()` to confirm it has a real translation (guards against re-introducing an unmapped mode).
- `src/shared/types/provider-types.test.ts`: one inline test fixture used the old Codex-native array literal as a `ProviderCapabilities` value; updated to the domain names so it still type-checks under the tightened type.

Confirmed via grep that nothing in `src/renderer` reads `capabilities.permissionModes` today, so this has no user-visible effect right now — it's a type-safety and correctness fix ahead of that surface being used.

No new dependencies added.

## Verification

- `npx tsc --noEmit -p tsconfig.json` — clean
- `npx tsc --noEmit -p tsconfig.main.json` — clean
- `npx vitest run --config vitest.workspace.ts` — **91 test files / 904 tests passed**, 0 failures (includes the new/updated tests above)