### PR TITLE
fix(terminal): keep UTF-16 surrogate pairs intact across write() chunk boundaries

### DIFF
--- a/src/main/cli-manager.test.ts
+++ b/src/main/cli-manager.test.ts
@@ -204,3 +204,77 @@ describe('CLIManager deferred provider launch', () => {
     }
   });
 });
+
+describe('CLIManager write() chunking (surrogate-pair safe)', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('writes payloads at or under 1024 chars in a single ptyProcess.write call', async () => {
+    const mgr = new CLIManager({ workingDirectory: '/tmp', permissionMode: 'standard' });
+    await mgr.spawn();
+
+    const payload = 'hello world'.repeat(50); // 550 chars, well under the 1024 chunk size
+    mgr.write(payload);
+
+    expect(getWrite().mock.calls.length).toBe(1);
+    expect(getWrite().mock.calls[0][0]).toBe(payload);
+  });
+
+  it('splits a large ASCII write into <=1024-char chunks that reassemble to the original', async () => {
+    vi.useFakeTimers();
+    try {
+      const mgr = new CLIManager({ workingDirectory: '/tmp', permissionMode: 'standard' });
+      const spawnPromise = mgr.spawn();
+      // createPtyProcess waits ~150ms for shell readiness.
+      await vi.advanceTimersByTimeAsync(200);
+      await spawnPromise;
+
+      const payload = 'x'.repeat(2500); // spans 3 chunks at WRITE_CHUNK_SIZE = 1024
+      mgr.write(payload);
+      // Flush the chained setTimeout(writeNextChunk, WRITE_CHUNK_DELAY) calls.
+      await vi.advanceTimersByTimeAsync(50);
+
+      const calls = getWrite().mock.calls.map((c: string[]) => c[0]);
+      expect(calls.length).toBeGreaterThan(1);
+      expect(calls.join('')).toBe(payload);
+      for (const chunk of calls) {
+        expect(chunk.length).toBeLessThanOrEqual(1024);
+      }
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('reassembles a large write with an astral emoji straddling the 1024-char chunk boundary', async () => {
+    vi.useFakeTimers();
+    try {
+      const mgr = new CLIManager({ workingDirectory: '/tmp', permissionMode: 'standard' });
+      const spawnPromise = mgr.spawn();
+      await vi.advanceTimersByTimeAsync(200);
+      await spawnPromise;
+
+      // 😀 (U+1F600) is a surrogate pair: high surrogate U+D83D + low surrogate
+      // U+DE00. Placed right after 1023 filler chars, the naive chunk boundary
+      // (offset 0 + WRITE_CHUNK_SIZE 1024) would land between the two halves —
+      // exactly the corruption case the fix guards against.
+      const emoji = '\u{1F600}';
+      const payload = 'a'.repeat(1023) + emoji + 'b'.repeat(200);
+      mgr.write(payload);
+      await vi.advanceTimersByTimeAsync(50);
+
+      const calls = getWrite().mock.calls.map((c: string[]) => c[0]);
+      expect(calls.length).toBeGreaterThan(1);
+      expect(calls.join('')).toBe(payload);
+
+      // No chunk may end with a lone high surrogate or start with a lone low
+      // surrogate — that's what causes node-pty's UTF-8 encoder to emit U+FFFD.
+      for (const chunk of calls) {
+        const lastCode = chunk.charCodeAt(chunk.length - 1);
+        expect(lastCode >= 0xd800 && lastCode <= 0xdbff).toBe(false);
+        const firstCode = chunk.charCodeAt(0);
+        expect(firstCode >= 0xdc00 && firstCode <= 0xdfff).toBe(false);
+      }
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/src/main/cli-manager.ts
+++ b/src/main/cli-manager.ts
@@ -596,7 +596,22 @@ export class CLIManager {
     let offset = 0;
     const writeNextChunk = () => {
       if (!this.ptyProcess || !this._isRunning) return;
-      const end = Math.min(offset + this.WRITE_CHUNK_SIZE, data.length);
+      let end = Math.min(offset + this.WRITE_CHUNK_SIZE, data.length);
+      // JS strings are UTF-16; an astral character (emoji, some CJK, etc.) is
+      // a surrogate pair of two code units. If the boundary falls between
+      // them, this chunk ends with a lone high surrogate and the next one
+      // starts with a lone low surrogate — node-pty encodes each write to
+      // UTF-8 independently, so a lone surrogate is replaced with U+FFFD
+      // ("�") and the character is corrupted. Pull the boundary back one
+      // code unit so the pair stays together in the next chunk instead.
+      // WRITE_CHUNK_SIZE is a soft max (varies by at most one code unit);
+      // that's harmless for its pipe-buffer-draining purpose.
+      if (end < data.length && end > offset) {
+        const code = data.charCodeAt(end - 1);
+        if (code >= 0xd800 && code <= 0xdbff) {
+          end -= 1;
+        }
+      }
       this.ptyProcess.write(data.substring(offset, end));
       offset = end;
       if (offset < data.length) {


### PR DESCRIPTION
## What changed (plain language)
When you paste a large chunk of text into the terminal, omnidesk sends it to the CLI in ~1024-character pieces (with small delays) so the connection doesn't get overwhelmed. The bug: some characters — emoji, certain CJK characters, math symbols — are actually stored internally as *two* linked halves. If a 1024-character cut point happened to fall between those two halves, the two pieces got sent separately and the terminal couldn't reconstruct the character, showing a broken `<27>` glyph instead and corrupting the paste.

The fix checks, right before cutting a chunk, whether the cut would split one of these two-halves characters. If so, it backs the cut point up by one character so the pair stays together in the next chunk. Chunks are very rarely off by one character as a result — completely harmless, since the chunking is only there to pace the writes, not to hit an exact size.

## Files touched
- `src/main/cli-manager.ts` — the chunk-boundary fix in `write()`'s `writeNextChunk` loop.
- `src/main/cli-manager.test.ts` — 3 new tests.

## No new dependencies added.

## How I verified it
- `npx tsc --noEmit -p tsconfig.main.json` — clean
- `npx tsc --noEmit -p tsconfig.json` — clean
- `npx vitest run --config vitest.workspace.ts` — full suite green: 92 test files / 932 tests, 0 failures
- New tests specifically cover:
  - payloads `<=1024` chars still go out as a single `ptyProcess.write` call (existing behavior unchanged)
  - a large ASCII payload is split into chunks whose concatenation equals the original
  - a payload with an emoji (surrogate pair) placed exactly on the naive 1024-char boundary reassembles to the original, with no chunk ending on a lone high surrogate or starting on a lone low surrogate

Closes #110

## Acceptance criteria (from the issue)
- [x] No chunk emitted by `write()` ends with a lone high surrogate or begins with a lone low surrogate
- [x] Concatenating all `ptyProcess.write` arguments equals the original input for any payload, verified by a test with an astral character positioned on the 1024 boundary
- [x] Existing behavior preserved for <=1024 payloads (single immediate write) and ASCII pastes
- [x] New tests in `cli-manager.test.ts` cover the three cases and pass