### PR TITLE
fix(git): reject paths that escape workDir in GitManager.fileContent

### DIFF
--- a/src/main/git-manager.test.ts
+++ b/src/main/git-manager.test.ts
@@ -10,14 +10,19 @@ vi.mock('child_process', () => ({
 vi.mock('fs', () => ({
   existsSync: vi.fn(() => false),
   watch: vi.fn(() => ({ close: vi.fn(), on: vi.fn() })),
+  promises: {
+    readFile: vi.fn(),
+  },
 }));
 
 import { execFile } from 'child_process';
 import * as fs from 'fs';
+import * as path from 'path';
 
 const mockExecFile = execFile as unknown as ReturnType<typeof vi.fn>;
 const mockExistsSync = fs.existsSync as unknown as ReturnType<typeof vi.fn>;
 const mockWatch = fs.watch as unknown as ReturnType<typeof vi.fn>;
+const mockReadFile = fs.promises.readFile as unknown as ReturnType<typeof vi.fn>;
 
 /** Fake FSWatcher: a real EventEmitter (so `.on('error', ...)` actually works) plus a close() spy. */
 function fakeWatcher(): EventEmitter & { close: ReturnType<typeof vi.fn> } {
@@ -398,6 +403,48 @@ describe('GitManager', () => {
       mockGitResponse('', '', 0);
       const result = await manager.unstageAll('/test');
       expect(result.success).toBe(true);
+    });
+  });
+
+  describe('fileContent', () => {
+    it('reads a relative path inside workDir and formats it as an add-diff', async () => {
+      mockReadFile.mockResolvedValueOnce('line1\nline2\n');
+      const result = await manager.fileContent('/test/repo', 'src/foo.ts');
+
+      expect(mockReadFile).toHaveBeenCalledWith(
+        path.resolve('/test/repo', 'src/foo.ts'),
+        'utf-8',
+      );
+      expect(result.filePath).toBe('src/foo.ts');
+      expect(result.diff).toContain('+line1');
+      expect(result.diff).toContain('+line2');
+      expect(result.isTruncated).toBe(false);
+    });
+
+    it('rejects a ../ traversal path that escapes workDir', async () => {
+      await expect(
+        manager.fileContent('/test/repo', '../../etc/passwd'),
+      ).rejects.toThrow(/escapes workDir/);
+      expect(mockReadFile).not.toHaveBeenCalled();
+    });
+
+    it('rejects an absolute path outside workDir', async () => {
+      const outside = process.platform === 'win32' ? 'C:\\Windows\\win.ini' : '/etc/passwd';
+      await expect(
+        manager.fileContent('/test/repo', outside),
+      ).rejects.toThrow(/escapes workDir/);
+      expect(mockReadFile).not.toHaveBeenCalled();
+    });
+
+    it('allows a path that traverses out and back in, staying within workDir', async () => {
+      mockReadFile.mockResolvedValueOnce('content\n');
+      const result = await manager.fileContent('/test/repo', 'sub/../file.txt');
+
+      expect(mockReadFile).toHaveBeenCalledWith(
+        path.resolve('/test/repo', 'sub/../file.txt'),
+        'utf-8',
+      );
+      expect(result.diff).toContain('+content');
     });
   });
 

--- a/src/main/git-manager.ts
+++ b/src/main/git-manager.ts
@@ -3,6 +3,7 @@ import { execFile } from 'child_process';
 import * as fs from 'fs';
 import * as path from 'path';
 import { IPCEmitter } from './ipc-emitter';
+import { isPathWithin } from './path-access';
 import type {
   GitStatus,
   GitFileStatus,
@@ -780,6 +781,9 @@ export class GitManager {
 
   async fileContent(workDir: string, filePath: string): Promise<GitDiffResult> {
     const fullPath = path.resolve(workDir, filePath);
+    if (!isPathWithin(fullPath, path.resolve(workDir))) {
+      throw new Error(`fileContent: path escapes workDir: ${filePath}`);
+    }
     try {
       const content = await fs.promises.readFile(fullPath, 'utf-8');
       const totalSize = Buffer.byteLength(content, 'utf-8');


### PR DESCRIPTION
## Summary

`GitManager.fileContent(workDir, filePath)` computed `path.resolve(workDir, filePath)` and passed the result straight to `fs.promises.readFile`, with no check that the resolved path actually stays inside `workDir`. Two ways to escape it:

- A `filePath` containing `../` sequences (e.g. `../../../../etc/passwd`) resolves outside `workDir`.
- An **absolute** `filePath` makes `path.resolve` ignore `workDir` entirely and just use the absolute path as-is.

This method is invoked from the `gitFileContent` IPC handler, which forwards `workDir`/`filePath` unchanged — and that handler is reachable over the remote WS bridge (`ws-router.ts` dispatches any `{method, args}` frame straight to the registry with no per-method allowlist). So this wasn't just a local bug: anyone holding a valid remote auth token could read arbitrary files off disk via this path.

## Fix

Added the same containment check the codebase already uses elsewhere (`ipc-handlers.ts`, `integration-manager.ts`): `isPathWithin()` from `src/main/path-access.ts`. `fileContent` now resolves the path and throws before ever touching the filesystem if the resolved path isn't inside the resolved `workDir`:

```ts
const fullPath = path.resolve(workDir, filePath);
if (!isPathWithin(fullPath, path.resolve(workDir))) {
  throw new Error(`fileContent: path escapes workDir: ${filePath}`);
}
```

No new dependency — reuses the existing `path-access.ts` helper that other handlers already rely on for the same purpose.

## Testing

`fileContent` had zero test coverage before this change. Added a `describe('fileContent', ...)` block in `git-manager.test.ts` covering:
- happy path: relative path inside `workDir` reads and formats correctly
- `../` traversal path is rejected (throws, `readFile` never called)
- absolute path outside `workDir` is rejected (throws, `readFile` never called)
- a path that traverses out and back in (`sub/../file.txt`) still resolves inside `workDir` and is allowed

Also extended the existing `vi.mock('fs', ...)` factory in the test file to stub `fs.promises.readFile` (it previously only stubbed `existsSync`/`watch`, so nothing exercised the read path before).

Verified:
- `npx tsc --noEmit` — clean
- `npx vitest run --config vitest.workspace.ts --project shared --project main` — 53 files / 656 tests passed, no regressions

Closes #113