### PR TITLE
fix(main): gate createSession.workingDirectory behind isPathAllowed

### DIFF
--- a/src/main/ipc-handlers.createSession.test.ts
+++ b/src/main/ipc-handlers.createSession.test.ts
@@ -1,0 +1,135 @@
+/**
+ * Boundary tests for the createSession IPC handler — verifies the REAL
+ * setupIPCHandlers registration (not a re-implementation). createSession is
+ * reachable over the unauthenticated-by-path remote WS bridge, so it must
+ * gate the effective working directory behind the same isPathAllowed
+ * allowlist as writeFile/listSubdirectories/listGitRepos, rather than
+ * blindly handing an arbitrary path to sessionManager.createSession.
+ *
+ * See issue #115.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { _resetApprovedRoots, approvePickedRoot } from './path-access';
+
+const handleSpy = vi.fn();
+const onSpy = vi.fn();
+
+vi.mock('./ipc-registry', () => ({
+  IPCRegistry: class {
+    handle = handleSpy;
+    on = onSpy;
+  },
+}));
+
+import { setupIPCHandlers } from './ipc-handlers';
+
+type Handler = (...args: unknown[]) => Promise<unknown>;
+
+function getHandler(name: string): Handler {
+  const call = handleSpy.mock.calls.find((c) => c[0] === name);
+  if (!call) throw new Error(`handler not registered: ${name}`);
+  return call[1] as Handler;
+}
+
+describe('createSession IPC handler — path allowlist', () => {
+  // test/setup-main.ts mocks electron's app.getPath('home') to '/mock/home'.
+  const sessionManager = {
+    setMainWindow: vi.fn(),
+    createSession: vi.fn(async (req: unknown) => ({ id: 'sess-1', ...(req as object) })),
+  };
+  const settingsManager = {
+    getWorkspaces: vi.fn(() => [{ path: '/mock/workspace' }]),
+  };
+  const checkpointManager = { setMainWindow: vi.fn() };
+
+  beforeEach(() => {
+    handleSpy.mockClear();
+    sessionManager.createSession.mockClear();
+    _resetApprovedRoots();
+    setupIPCHandlers(
+      {} as never, // mainWindow
+      sessionManager as never,
+      settingsManager as never,
+      {} as never, // historyManager
+      checkpointManager as never,
+      {} as never, // sessionPool
+      {} as never, // gitManager
+      {} as never, // providerRegistry
+      {} as never, // remoteAuth
+      {} as never, // sttManager
+      {} as never, // integrationManager
+      {} as never, // githubService
+    );
+  });
+
+  it('rejects a workingDirectory outside home/workspaces/approved roots', async () => {
+    await expect(
+      getHandler('createSession')({}, {
+        workingDirectory: 'C:\\Windows\\System32',
+        permissionMode: 'standard',
+      }),
+    ).rejects.toThrow('Working directory not allowed');
+    expect(sessionManager.createSession).not.toHaveBeenCalled();
+  });
+
+  it('accepts a workingDirectory under the home directory', async () => {
+    await getHandler('createSession')({}, {
+      workingDirectory: '/mock/home/projects/foo',
+      permissionMode: 'standard',
+    });
+    expect(sessionManager.createSession).toHaveBeenCalledTimes(1);
+  });
+
+  it('accepts a workingDirectory under a registered workspace', async () => {
+    await getHandler('createSession')({}, {
+      workingDirectory: '/mock/workspace/sub-project',
+      permissionMode: 'standard',
+    });
+    expect(sessionManager.createSession).toHaveBeenCalledTimes(1);
+  });
+
+  it('accepts a workingDirectory under a user-approved picked root', async () => {
+    approvePickedRoot('/some/picked/root');
+    await getHandler('createSession')({}, {
+      workingDirectory: '/some/picked/root/nested',
+      permissionMode: 'standard',
+    });
+    expect(sessionManager.createSession).toHaveBeenCalledTimes(1);
+  });
+
+  it('defaults to the home directory and succeeds when workingDirectory is empty', async () => {
+    await getHandler('createSession')({}, {
+      workingDirectory: '',
+      permissionMode: 'standard',
+    });
+    expect(sessionManager.createSession).toHaveBeenCalledTimes(1);
+  });
+
+  it('validates worktree.mainRepoPath rather than the eventual worktree path', async () => {
+    await getHandler('createSession')({}, {
+      workingDirectory: '/mock/home/repo',
+      permissionMode: 'standard',
+      worktree: {
+        mainRepoPath: '/mock/home/repo',
+        branch: 'feature',
+        isNewBranch: true,
+      },
+    });
+    expect(sessionManager.createSession).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects a worktree request whose mainRepoPath is outside the allowlist', async () => {
+    await expect(
+      getHandler('createSession')({}, {
+        workingDirectory: '/mock/home/repo',
+        permissionMode: 'standard',
+        worktree: {
+          mainRepoPath: 'C:\\Windows\\System32',
+          branch: 'feature',
+          isNewBranch: true,
+        },
+      }),
+    ).rejects.toThrow('Working directory not allowed');
+    expect(sessionManager.createSession).not.toHaveBeenCalled();
+  });
+});

--- a/src/main/ipc-handlers.ts
+++ b/src/main/ipc-handlers.ts
@@ -70,6 +70,18 @@ export function setupIPCHandlers(
 
   registry.handle('createSession', async (_e, request) => {
     try {
+      // Validate the entry-point directory before any worktree/process is
+      // created. For worktree sessions this is mainRepoPath — the eventual
+      // worktree path is derived by git and legitimately may sit outside
+      // home/workspaces (e.g. a sibling checkout), so it isn't the right
+      // thing to gate on; the repo the worktree is created from is.
+      const pathToCheck =
+        request.worktree?.mainRepoPath || request.workingDirectory || app.getPath('home');
+      const resolved = path.resolve(pathToCheck);
+      if (!isPathAllowed(resolved)) {
+        console.warn('[createSession] Blocked working directory outside home/workspaces:', resolved);
+        throw new Error('Working directory not allowed');
+      }
       const result = await sessionManager.createSession(request);
       return result;
     }

--- a/src/main/path-access.ts
+++ b/src/main/path-access.ts
@@ -32,7 +32,10 @@ function isApprovedRoot(resolved: string): boolean {
 }
 
 export function isPathAllowed(resolved: string, homeDir: string, workspacePaths: string[]): boolean {
-  if (isPathWithin(resolved, homeDir)) return true;
+  // homeDir must be resolved the same way workspacePaths are below, otherwise
+  // a resolved (drive-lettered on win32) child path can fail to match an
+  // unresolved homeDir that lacks a drive letter, causing false rejections.
+  if (isPathWithin(resolved, path.resolve(homeDir))) return true;
   for (const ws of workspacePaths) {
     if (isPathWithin(resolved, path.resolve(ws))) return true;
   }


### PR DESCRIPTION
Closes #115

## Problem
`createSession` is registered as a normal IPC handler and reachable over the
remote WS bridge, which dispatches any registered method with no per-method
allowlist. Unlike its siblings (`writeFile`, `listSubdirectories`,
`listGitRepos`), it accepted an arbitrary `workingDirectory` without running
it through the `isPathAllowed` containment check, so a remote caller could
open a shell/session rooted anywhere on disk.

## Fix
In `src/main/ipc-handlers.ts`, the `createSession` handler now resolves and
validates the entry-point path before calling `sessionManager.createSession`:
- `request.worktree?.mainRepoPath` when a worktree is requested (the eventual
  worktree path is derived by git and may legitimately live outside
  home/workspaces — the repo it's created from is the thing that must be
  contained)
- otherwise `request.workingDirectory`, falling back to the home directory
  when empty

An unresolvable/disallowed path throws `Working directory not allowed` before
any session or worktree is created.

## Bonus fix found while testing
Writing boundary tests against the real `setupIPCHandlers` registration (same
pattern as `ipc-handlers.integrations.test.ts`) surfaced a pre-existing bug in
`src/main/path-access.ts`: `isPathAllowed` compared a resolved child path
against a **raw, unresolved** `homeDir`, while workspace paths were resolved
via `path.resolve()` before comparison. On Windows, `path.resolve()` adds a
drive letter to POSIX-style absolute paths but `path.normalize()` (used
internally for comparison) does not, so a legitimately-nested path under home
was incorrectly rejected. Fixed by resolving `homeDir` the same way workspace
paths already are — one line, no behavior change for already-passing cases.

## Testing
- New `src/main/ipc-handlers.createSession.test.ts` (7 tests) exercises the
  real handler registration: rejects paths outside home/workspaces/approved
  roots, accepts paths under home/workspace/an approved picked root, defaults
  to home when `workingDirectory` is empty, and validates
  `worktree.mainRepoPath` rather than the not-yet-computed worktree path.
- `npx tsc --noEmit` clean on both `tsconfig.json` and `tsconfig.main.json`.
- Full suite: `npx vitest run --config vitest.workspace.ts` — 93 test files,
  944 tests, all passing (including the pre-existing `path-access.test.ts`,
  confirming no regression from the `homeDir` resolve fix).

No new dependencies.