### PR TITLE
fix(session-manager): guard restartSession status='running' behind status==='starting'

### DIFF
--- a/src/main/session-manager.test.ts
+++ b/src/main/session-manager.test.ts
@@ -486,6 +486,29 @@ describe('SessionManager.restartSession — spawn failure gating (F1)', () => {
     expect(manager.getSession(meta.id)?.status).toBe('error');
     expect(manager.getSession(meta.id)?.error).toContain('respawn failed');
   });
+
+  it('does not overwrite an onExit-driven crash status with running when the PTY dies during the restart spawn (#124)', async () => {
+    const meta = await manager.createSession({ ...baseRequest });
+    vi.clearAllMocks();
+
+    // Capture the onExit callback wired for the NEW CLIManager created inside
+    // restartSession (mirrors the F2 createSession crash test).
+    let capturedExit: ((code: number) => void) | undefined;
+    vi.mocked(CLIManager.prototype.onExit).mockImplementationOnce((cb: (code: number) => void) => {
+      capturedExit = cb;
+    });
+    // Fire the crash from inside spawn(), before the spawn promise resolves —
+    // the exact race restartSession must guard against.
+    vi.mocked(CLIManager.prototype.spawn).mockImplementationOnce(async () => {
+      capturedExit?.(1);
+    });
+
+    const ok = await manager.restartSession(meta.id);
+
+    expect(ok).toBe(true);
+    expect(manager.getSession(meta.id)?.status).toBe('error');
+    expect(manager.getSession(meta.id)?.exitCode).toBe(1);
+  });
 });
 
 describe('SessionManager.createSession — early map insertion (F2)', () => {

--- a/src/main/session-manager.ts
+++ b/src/main/session-manager.ts
@@ -828,7 +828,12 @@ export class SessionManager {
       } else {
         await cliManager.spawn();
       }
-      session.metadata.status = 'running';
+      // Only claim 'running' once the PTY actually spawned. onExit may have
+      // already moved us to 'exited'/'error' (crash-on-launch during restart);
+      // don't overwrite that with a false 'running'. Mirrors createSession.
+      if (session.metadata.status === 'starting') {
+        session.metadata.status = 'running';
+      }
     } catch (err) {
       session.metadata.status = 'error';
       session.metadata.error = err instanceof Error ? err.message : String(err);


### PR DESCRIPTION
Closes #124

## What/why
`restartSession` wires the replacement `CLIManager` (assigns `session.cliManager` and calls `wireCliManager`, which registers `onExit`) *before* it awaits `spawn()`/`spawnShellSession()`. If the PTY crashes on launch during that await, `onExit` fires first and correctly moves the session to `error`/`exited` — but the code right after the await then did an unconditional `session.metadata.status = 'running'`, silently overwriting that crash status with a false "running".

`createSession` already had the same guard for its analogous race; `restartSession` didn't. This closes that gap by only claiming `'running'` when the status is still `'starting'` (i.e. nothing else has already moved it):

```ts
if (session.metadata.status === 'starting') {
  session.metadata.status = 'running';
}
```

No dependency changes — one guard clause plus a comment, mirroring the existing `createSession` guard.

## How I verified it
- Added a regression test in `src/main/session-manager.test.ts` (`SessionManager.restartSession — spawn failure gating (F1)`) that captures the `onExit` callback wired for the new `CLIManager` during restart, fires it mid-`spawn()` with a non-zero exit code (simulating crash-on-launch), and asserts the final status is `error` with `exitCode: 1` — not overwritten to `running`. Modeled on the existing `createSession — early map insertion (F2)` crash test as suggested in the issue.
- `npx tsc --noEmit` on both `tsconfig.json` and `tsconfig.main.json`: clean.
- `npx vitest run --config vitest.workspace.ts --project main src/main/session-manager.test.ts`: 54/54 passing (including the existing F1 spawn-rejection test and the stale-manager/crash-status tests, unaffected).
- Full suite: `npx vitest run --config vitest.workspace.ts`: 92 files / 938 tests, all passing.