### PR TITLE
fix(cli-manager): avoid cmd.exe %VAR% expansion when relocating pooled Windows shells

### DIFF
--- a/src/main/cli-manager.test.ts
+++ b/src/main/cli-manager.test.ts
@@ -146,6 +146,90 @@ describe('CLIManager Windows ConPTY rendering workarounds', () => {
   });
 });
 
+describe('CLIManager Windows relocation (cmd.exe %VAR% expansion)', () => {
+  const realPlatform = Object.getOwnPropertyDescriptor(process, 'platform')!;
+  const setPlatform = (value: string) =>
+    Object.defineProperty(process, 'platform', { value, configurable: true });
+
+  beforeEach(() => vi.clearAllMocks());
+  afterEach(() => Object.defineProperty(process, 'platform', realPlatform));
+
+  function spawnCount(): number {
+    const spawnMock = pty.spawn as unknown as ReturnType<typeof vi.fn>;
+    return spawnMock.mock.calls.length;
+  }
+  function spawnOptionsAt(index: number): Record<string, unknown> {
+    const spawnMock = pty.spawn as unknown as ReturnType<typeof vi.fn>;
+    return spawnMock.mock.calls[index][2];
+  }
+  function ptyInstanceAt(index: number) {
+    const spawnMock = pty.spawn as unknown as ReturnType<typeof vi.fn>;
+    return spawnMock.mock.results[index].value;
+  }
+
+  it('relocates a pooled win32 shell via interactive cd for a plain path', async () => {
+    setPlatform('win32');
+    const mgr = new CLIManager({ workingDirectory: '/tmp', permissionMode: 'standard' });
+    await mgr.spawnShell();
+    await mgr.initializeSession('C:\\Users\\carlo\\project', 'standard');
+
+    expect(spawnCount()).toBe(1); // no respawn needed
+    expect(writtenText()).toContain('cd /d "C:\\Users\\carlo\\project"');
+  });
+
+  it('relocates a pooled win32 shell via interactive cd for a path with spaces', async () => {
+    setPlatform('win32');
+    const mgr = new CLIManager({ workingDirectory: '/tmp', permissionMode: 'standard' });
+    await mgr.spawnShell();
+    await mgr.initializeSession('C:\\Users\\carlo\\My Project', 'standard');
+
+    expect(spawnCount()).toBe(1);
+    expect(writtenText()).toContain('cd /d "C:\\Users\\carlo\\My Project"');
+  });
+
+  it('respawns instead of writing an interactive cd when the target path contains %VAR%', async () => {
+    setPlatform('win32');
+    const mgr = new CLIManager({ workingDirectory: '/tmp', permissionMode: 'standard' });
+    await mgr.spawnShell();
+    const firstPty = ptyInstanceAt(0);
+
+    const target = 'C:\\Users\\carlo\\%TEMP%\\project';
+    await mgr.initializeSession(target, 'standard');
+
+    // The old pooled pty was killed rather than sent an interactive cd that
+    // cmd.exe would silently expand...
+    expect(firstPty.kill).toHaveBeenCalled();
+    // ...and a fresh pty was spawned directly at the target cwd instead
+    // (node-pty hands cwd straight to the OS, bypassing cmd's parser).
+    expect(spawnCount()).toBe(2);
+    expect(spawnOptionsAt(1).cwd).toBe(target);
+    // No interactive command should ever carry the unexpanded %TEMP% token.
+    expect(writtenText()).not.toContain('%TEMP%');
+    expect(mgr.isInitialized).toBe(true);
+  });
+
+  it('ignores a stale exit event from the killed pooled pty after a %VAR% respawn', async () => {
+    setPlatform('win32');
+    const mgr = new CLIManager({ workingDirectory: '/tmp', permissionMode: 'standard' });
+    await mgr.spawnShell();
+    const firstPty = ptyInstanceAt(0);
+    const staleOnExit = firstPty.onExit.mock.calls[0][0];
+
+    const onExitCb = vi.fn();
+    mgr.onExit(onExitCb);
+
+    await mgr.initializeSession('C:\\Users\\carlo\\%TEMP%\\project', 'standard');
+
+    // The killed pooled pty's exit event can still arrive asynchronously —
+    // it must be a no-op against the manager's current (new) session state.
+    staleOnExit({ exitCode: 1 });
+
+    expect(onExitCb).not.toHaveBeenCalled();
+    expect(mgr.isRunning).toBe(true);
+    expect(mgr.isInitialized).toBe(true);
+  });
+});
+
 describe('CLIManager deferred provider launch', () => {
   beforeEach(() => vi.clearAllMocks());
 

--- a/src/main/cli-manager.ts
+++ b/src/main/cli-manager.ts
@@ -264,8 +264,20 @@ export class CLIManager {
       this.options.launchMode = launchMode;
     }
 
-    // Change to the target directory (shell was spawned at process.cwd())
-    if (process.platform === 'win32') {
+    // Change to the target directory (shell was spawned at process.cwd()).
+    // cmd.exe expands %VAR% tokens on the interactive command line even
+    // inside double quotes, with no interactive escape sequence available —
+    // so a workingDirectory containing e.g. "%TEMP%" would silently land the
+    // shell somewhere other than the intended path. Rather than risk that,
+    // respawn the pooled pty directly at the target cwd (node-pty hands cwd
+    // straight to the OS, bypassing cmd's parser entirely).
+    if (process.platform === 'win32' && workingDirectory.includes('%')) {
+      if (this.ptyProcess) {
+        this.ptyProcess.kill();
+        this.ptyProcess = null;
+      }
+      await this.createPtyProcess();
+    } else if (process.platform === 'win32') {
       this.write(`cd /d "${workingDirectory}"\r`);
     } else {
       const escapedDir = workingDirectory.replace(/'/g, "'\\''");
@@ -403,11 +415,22 @@ export class CLIManager {
     // past the probe, which arrives in the very first chunk.
     this.da1ScanChunksLeft = process.platform === 'win32' ? 16 : 0;
 
-    this.ptyProcess.onData((data: string) => {
+    // Capture this spawn's process by reference. createPtyProcess() can be
+    // called again on the same CLIManager instance (e.g. the win32 %VAR%
+    // relocation respawn in initializeSession), which kills the old
+    // ptyProcess and replaces this.ptyProcess with a new one. The old
+    // process's onData/onExit can still fire asynchronously after that —
+    // guard both handlers so a stale event from a superseded pty is a
+    // no-op instead of corrupting the current session's state.
+    const proc = this.ptyProcess;
+
+    proc.onData((data: string) => {
+      if (this.ptyProcess !== proc) return;
       this.bufferOutput(this.interceptConptyDa1(data));
     });
 
-    this.ptyProcess.onExit(({ exitCode }) => {
+    proc.onExit(({ exitCode }) => {
+      if (this.ptyProcess !== proc) return;
       this._isRunning = false;
       this._isInitialized = false;
       this.flushOutput();


### PR DESCRIPTION
Closes #119

## What this does (plain terms)
On Windows, when the app reuses a pre-warmed background shell and moves it into your project's folder, it does so by typing a `cd` command into that shell. If your folder path happens to contain something like `%TEMP%` (a Windows environment-variable token), `cmd.exe` would silently expand that token to something else instead of using your actual folder name — landing the session in the wrong directory without any error. This fix detects that case and, instead of typing a `cd` command, starts a brand-new shell process directly in the correct folder (bypassing the part of `cmd.exe` that does the risky expansion). Everyday paths without a `%` character are unaffected and behave exactly as before.

## Technical summary
- `src/main/cli-manager.ts`:
  - `initializeSession()`: on `win32`, if `workingDirectory` contains a literal `%`, kill the pooled `ptyProcess` and call `createPtyProcess()` to respawn fresh at the target `cwd` (node-pty passes `cwd` straight to the OS, never through cmd's interactive parser). Otherwise, behavior is unchanged: `cd /d "<path>"` on win32, `cd '<escaped-path>'` on POSIX.
  - `createPtyProcess()`: since the same `CLIManager` instance can now spawn a pty more than once (the relocation respawn above), the previous pty's `onData`/`onExit` callbacks could still fire asynchronously after being superseded. Added a reference-identity guard (`this.ptyProcess !== proc`) so a stale event from a killed pty is a no-op instead of corrupting the live session's state.
- `src/main/cli-manager.test.ts`: added 4 tests covering plain-path relocation (interactive `cd`, single spawn), path-with-spaces relocation (correctly quoted, single spawn), `%VAR%`-path relocation (old pty killed, second spawn at the exact target `cwd`, no interactive command ever contains the raw `%TEMP%` token), and the stale-exit-event guard (manually firing the killed pty's `onExit` after a respawn must not affect the manager's current state).

## Verification
- `npx tsc --noEmit -p tsconfig.json` — clean.
- `npx tsc --noEmit -p tsconfig.main.json` — clean.
- `npx vitest run --config vitest.workspace.ts --project shared --project main` — **54 test files, 672 tests passed, 0 failures** (includes the 4 new tests; no regressions elsewhere, e.g. `session-manager.test.ts` mocks `initializeSession` entirely and is unaffected).

No new dependencies added.