### PR TITLE
docs(readme): add voice-dictation hotkey to Keyboard Shortcuts table

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,7 @@ Built packages will be in the `release/` directory.
 | `Ctrl/Cmd+1` | Focus View |
 | `Ctrl/Cmd+2` | Grid View |
 | `Ctrl/Cmd+.` | Toggle Right Inspector |
+| `Ctrl+Shift+Space` | Toggle voice dictation (start/stop; default, configurable in Voice settings) |
 | `Escape` | Close Palette / Sheets |
 | `Ctrl+C` | Session Termination Dialog |
 | `Ctrl/Shift/Alt/Cmd+Enter` | Insert newline (without submitting) |


### PR DESCRIPTION
Closes #88

## What
Adds a row for the voice-dictation hotkey (`Ctrl+Shift+Space`) to the README's "Keyboard Shortcuts" reference table. It was already documented in prose (`README.md:96`) and implemented as a global hotkey (`VoiceControls.tsx`, default set in `settings-persistence.ts:65`), but missing from the single-glance shortcuts table.

## Why
Docs-completeness fix from #88: the voice-dictation feature is the one interactive feature with its own dedicated global hotkey that wasn't in the reference table.

## Change
- `README.md`: one new table row — `Ctrl+Shift+Space | Toggle voice dictation (start/stop; default, configurable in Voice settings)` — placed after "Toggle Right Inspector", before "Escape". No other rows changed.

## Verification
Docs-only change (no code/behavior touched), so no build/test run was needed to validate it — confirmed via `git diff` that only the intended single line was added and no other content shifted.