### PR TITLE
fix(main): avoid mid-UTF-8 truncation in readFileContent; add tests

### DIFF
--- a/src/main/file-dragdrop-handler.test.ts
+++ b/src/main/file-dragdrop-handler.test.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { getFileInfo, readFileContent } from './file-dragdrop-handler';
+
+describe('file-dragdrop-handler', () => {
+  let tmpDir: string;
+
+  afterEach(() => {
+    if (tmpDir) fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function tempFile(name: string, data: string | Buffer): string {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'file-dragdrop-'));
+    const filePath = path.join(tmpDir, name);
+    fs.writeFileSync(filePath, data);
+    return filePath;
+  }
+
+  function tempDir(): string {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'file-dragdrop-'));
+    return tmpDir;
+  }
+
+  describe('getFileInfo', () => {
+    it('returns populated FileInfo for a valid local file', async () => {
+      const filePath = tempFile('notes.txt', 'hello world\n');
+      const [info] = await getFileInfo([filePath]);
+
+      expect(info).toBeDefined();
+      expect(info.name).toBe('notes.txt');
+      expect(info.extension).toBe('.txt');
+      expect(info.sizeBytes).toBe(Buffer.byteLength('hello world\n'));
+      expect(info.category).toBe('document');
+      expect(info.isBinary).toBe(false);
+      expect(info.mimeType).toBe('text/plain');
+    });
+
+    it('skips (does not throw for) a non-local path', async () => {
+      const results = await getFileInfo(['https://example.com/a.txt']);
+      expect(results).toEqual([]);
+    });
+
+    it('skips (does not throw for) a missing path', async () => {
+      const dir = tempDir();
+      const missing = path.join(dir, 'does-not-exist.txt');
+      const results = await getFileInfo([missing]);
+      expect(results).toEqual([]);
+    });
+
+    it('skips (does not throw for) a directory', async () => {
+      const dir = tempDir();
+      const results = await getFileInfo([dir]);
+      expect(results).toEqual([]);
+    });
+
+    it('processes multiple paths independently, skipping invalid ones', async () => {
+      const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'file-dragdrop-'));
+      tmpDir = dir;
+      const goodFile = path.join(dir, 'good.md');
+      fs.writeFileSync(goodFile, '# heading');
+      const missing = path.join(dir, 'missing.md');
+
+      const results = await getFileInfo([missing, goodFile, 'https://example.com/x']);
+
+      expect(results).toHaveLength(1);
+      expect(results[0].name).toBe('good.md');
+    });
+  });
+
+  describe('readFileContent', () => {
+    it('throws for a non-local path', async () => {
+      await expect(readFileContent('https://example.com/a.txt', 1024)).rejects.toThrow(
+        'Cannot read non-local files'
+      );
+    });
+
+    it('throws for a missing file', async () => {
+      const dir = tempDir();
+      const missing = path.join(dir, 'does-not-exist.txt');
+      await expect(readFileContent(missing, 1024)).rejects.toThrow('File does not exist');
+    });
+
+    it('throws for a directory', async () => {
+      const dir = tempDir();
+      await expect(readFileContent(dir, 1024)).rejects.toThrow('Path is not a file');
+    });
+
+    it('throws for a binary file', async () => {
+      const filePath = tempFile('binary.bin', Buffer.from([0x68, 0x69, 0x00, 0x21]));
+      await expect(readFileContent(filePath, 1024)).rejects.toThrow(
+        'Cannot read binary file content'
+      );
+    });
+
+    it('returns full content with truncated=false when the file fits within the limit', async () => {
+      const filePath = tempFile('small.txt', 'hello');
+      const result = await readFileContent(filePath, 1024);
+      expect(result.truncated).toBe(false);
+      expect(result.content).toBe('hello');
+    });
+
+    it('truncates a pure-ASCII file at the exact byte boundary, unaffected', async () => {
+      const filePath = tempFile('ascii.txt', 'a'.repeat(20));
+      // maxSizeBytes = 10 * 1024 would be huge; use a fractional KB so the
+      // byte boundary is exactly 10 (10/1024 KB * 1024 = 10 bytes).
+      const result = await readFileContent(filePath, 10 / 1024);
+      expect(result.truncated).toBe(true);
+      expect(result.content).toBe('a'.repeat(10));
+    });
+
+    it('does not emit a trailing U+FFFD when the cut lands 1 byte into a multi-byte UTF-8 sequence', async () => {
+      // '€' is E2 82 AC (3 bytes). Cutting after 11 bytes lands 1 byte into it.
+      const content = 'x'.repeat(10) + '€' + 'y'.repeat(10);
+      const filePath = tempFile('euro-cut-1.txt', content);
+      const result = await readFileContent(filePath, 11 / 1024);
+
+      expect(result.truncated).toBe(true);
+      expect(result.content).toBe('x'.repeat(10));
+      expect(result.content).not.toContain('�');
+    });
+
+    it('does not emit a trailing U+FFFD when the cut lands 2 bytes into a multi-byte UTF-8 sequence', async () => {
+      const content = 'x'.repeat(10) + '€' + 'y'.repeat(10);
+      const filePath = tempFile('euro-cut-2.txt', content);
+      const result = await readFileContent(filePath, 12 / 1024);
+
+      expect(result.truncated).toBe(true);
+      expect(result.content).toBe('x'.repeat(10));
+      expect(result.content).not.toContain('�');
+    });
+
+    it('keeps the full multi-byte character when the cut lands exactly on a sequence boundary', async () => {
+      const content = 'x'.repeat(10) + '€' + 'y'.repeat(10);
+      const filePath = tempFile('euro-cut-3.txt', content);
+      // 10 ASCII bytes + all 3 bytes of '€' = 13 bytes, a clean boundary.
+      const result = await readFileContent(filePath, 13 / 1024);
+
+      expect(result.truncated).toBe(true);
+      expect(result.content).toBe('x'.repeat(10) + '€');
+      expect(result.content).not.toContain('�');
+    });
+
+    it('strips null bytes from returned content', async () => {
+      // isBinaryFile only inspects the first 8KB, so put the null byte past
+      // that window in an otherwise-printable, non-truncated file.
+      const content = 'a'.repeat(8300) + '\0' + 'end';
+      const filePath = tempFile('with-null.txt', content);
+
+      const result = await readFileContent(filePath, 1024 * 1024);
+      expect(result.truncated).toBe(false);
+      expect(result.content).not.toContain('\0');
+      expect(result.content).toBe('a'.repeat(8300) + 'end');
+    });
+  });
+});

--- a/src/main/file-dragdrop-handler.ts
+++ b/src/main/file-dragdrop-handler.ts
@@ -63,6 +63,59 @@ export async function getFileInfo(filePaths: string[]): Promise<FileInfo[]> {
 }
 
 /**
+ * Given a buffer and the number of valid bytes read into it, return the
+ * length (<= bytesRead) that ends on a complete UTF-8 code point.
+ *
+ * When a truncation cut lands in the middle of a multi-byte UTF-8 sequence
+ * (accented letters, CJK, emoji, box-drawing, etc.), decoding the dangling
+ * lead byte(s) produces a spurious trailing U+FFFD replacement character.
+ * This walks back over any trailing continuation bytes (0x80-0xBF) to find
+ * the sequence's leader byte, and if that sequence isn't fully present in
+ * `bytesRead`, trims back to just before it. A UTF-8 sequence is at most 4
+ * bytes, so at most 3 trailing continuation bytes are ever scanned.
+ */
+function trimIncompleteTrailingUtf8Sequence(buffer: Buffer, bytesRead: number): number {
+  if (bytesRead === 0) {
+    return 0;
+  }
+
+  let leaderIndex = bytesRead - 1;
+  let continuationBytes = 0;
+  while (
+    leaderIndex >= 0 &&
+    continuationBytes < 3 &&
+    (buffer[leaderIndex] & 0xc0) === 0x80
+  ) {
+    continuationBytes++;
+    leaderIndex--;
+  }
+
+  if (leaderIndex < 0) {
+    // Nothing but continuation bytes in the scanned window; no safe boundary found.
+    return 0;
+  }
+
+  const leader = buffer[leaderIndex];
+  let sequenceLength: number;
+  if ((leader & 0x80) === 0x00) {
+    sequenceLength = 1; // ASCII
+  } else if ((leader & 0xe0) === 0xc0) {
+    sequenceLength = 2;
+  } else if ((leader & 0xf0) === 0xe0) {
+    sequenceLength = 3;
+  } else if ((leader & 0xf8) === 0xf0) {
+    sequenceLength = 4;
+  } else {
+    // Not a valid leader byte (e.g. a run of continuation bytes with no
+    // leader, or an invalid encoding) - drop it along with its continuations.
+    return leaderIndex;
+  }
+
+  const bytesAvailable = bytesRead - leaderIndex;
+  return bytesAvailable >= sequenceLength ? bytesRead : leaderIndex;
+}
+
+/**
  * Read file content with size limit
  */
 export async function readFileContent(
@@ -104,7 +157,8 @@ export async function readFileContent(
       const fd = fs.openSync(sanitizedPath, 'r');
       const bytesRead = fs.readSync(fd, buffer, 0, maxSizeBytes, 0);
       fs.closeSync(fd);
-      content = buffer.toString('utf-8', 0, bytesRead);
+      const safeLength = trimIncompleteTrailingUtf8Sequence(buffer, bytesRead);
+      content = buffer.toString('utf-8', 0, safeLength);
     } else {
       content = fs.readFileSync(sanitizedPath, 'utf-8');
     }


### PR DESCRIPTION
## What

`readFileContent()` in `src/main/file-dragdrop-handler.ts` truncated oversized
drag-dropped files at a raw byte offset (`maxSizeBytes`) and decoded the whole
buffer as UTF-8. If that cut landed in the middle of a multi-byte UTF-8
sequence (accented letters, CJK, emoji, box-drawing, etc.), the dangling
lead byte(s) decoded to a trailing `U+FFFD` (`�`). This wasn't just cosmetic:
the truncated content is pasted into the terminal / sent to the agent
(`Terminal.tsx` -> `xtermRef.current.paste(text)`), so a stray `�` could reach
the model on any truncated non-ASCII file.

Separately, `file-dragdrop-handler.ts` had zero tests despite being the
enforcement point for `isLocalFile`/`sanitizeFilePath` gating, binary
rejection, and null-byte stripping.

Closes #109

## How

- Added `trimIncompleteTrailingUtf8Sequence(buffer, bytesRead)`: walks back
  from the end of the read buffer over trailing continuation bytes
  (`0x80`-`0xBF`) to find the sequence's leader byte, then trims the cut back
  to just before that sequence if it isn't fully present within `bytesRead`.
  A UTF-8 sequence is at most 4 bytes, so at most 3 continuation bytes are
  ever scanned — O(1), no allocation.
- `readFileContent` now decodes only the safe length returned by that helper
  instead of the raw `bytesRead`.
- Added `src/main/file-dragdrop-handler.test.ts` (new file, 15 tests):
  `getFileInfo` happy/invalid-path cases, and `readFileContent` covering
  non-local/missing/directory/binary rejection, exact-fit content, ASCII
  truncation at an exact byte boundary (regression guard — should be
  unaffected), three UTF-8-boundary cases (cut 1 byte into a 3-byte sequence,
  cut 2 bytes in, cut exactly on the sequence boundary), and null-byte
  stripping.

No new dependencies.

## Verification

- Targeted: `vitest run --config vitest.workspace.ts --project main src/main/file-dragdrop-handler.test.ts` — 15/15 passed.
- Full suite: `npm test` — 94 files / 964 tests passed, 0 failures.
- `tsc --noEmit` clean on both `tsconfig.json` and `tsconfig.main.json`.