### PR TITLE
test(shared): add claude-detector.ts coverage; delegate to generic fns

### DIFF
--- a/src/shared/claude-detector.test.ts
+++ b/src/shared/claude-detector.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect } from 'vitest';
+import {
+  CLAUDE_READY_PATTERNS,
+  isClaudeReady,
+  findClaudeOutputStart,
+  isProviderReady,
+  findProviderOutputStart,
+} from './claude-detector';
+
+describe('isClaudeReady', () => {
+  it('returns true when output contains a single known pattern', () => {
+    expect(isClaudeReady('... Tips for getting started ...')).toBe(true);
+  });
+
+  it('returns true for each individual pattern in CLAUDE_READY_PATTERNS', () => {
+    for (const pattern of CLAUDE_READY_PATTERNS) {
+      expect(isClaudeReady(`prefix ${pattern} suffix`)).toBe(true);
+    }
+  });
+
+  it('returns false for output with no matching pattern', () => {
+    expect(isClaudeReady('just a normal shell prompt $ ')).toBe(false);
+  });
+
+  it('returns false for the empty string', () => {
+    expect(isClaudeReady('')).toBe(false);
+  });
+});
+
+describe('findClaudeOutputStart', () => {
+  it('returns the earliest index when multiple patterns appear out of list order', () => {
+    // In CLAUDE_READY_PATTERNS, 'Claude Code' comes before 'Opus', but here 'Opus'
+    // appears earlier in the buffer — the earliest buffer index must win regardless
+    // of pattern-list order.
+    const buffer = 'noise Opus noise Claude Code noise';
+    const opusIndex = buffer.indexOf('Opus');
+    expect(findClaudeOutputStart(buffer)).toBe(opusIndex);
+  });
+
+  it('returns -1 when no pattern is present', () => {
+    expect(findClaudeOutputStart('nothing relevant here')).toBe(-1);
+  });
+
+  it('returns -1 for the empty string', () => {
+    expect(findClaudeOutputStart('')).toBe(-1);
+  });
+
+  it('finds a pattern that appears at index 0', () => {
+    expect(findClaudeOutputStart('Sonnet is ready')).toBe(0);
+  });
+});
+
+describe('isProviderReady', () => {
+  it('returns true when output matches a caller-supplied pattern', () => {
+    expect(isProviderReady('hello world', ['world'])).toBe(true);
+  });
+
+  it('returns false when output matches none of the caller-supplied patterns', () => {
+    expect(isProviderReady('hello world', ['foo', 'bar'])).toBe(false);
+  });
+
+  it('returns false for an empty pattern array', () => {
+    expect(isProviderReady('anything', [])).toBe(false);
+  });
+});
+
+describe('findProviderOutputStart', () => {
+  it('returns the earliest index across caller-supplied patterns regardless of list order', () => {
+    const buffer = 'noise first noise second noise';
+    const firstIndex = buffer.indexOf('first');
+    // 'second' is listed before 'first' in the patterns array, but 'first' appears
+    // earlier in the buffer, so it must win.
+    expect(findProviderOutputStart(buffer, ['second', 'first'])).toBe(firstIndex);
+  });
+
+  it('returns -1 when none of the caller-supplied patterns are found', () => {
+    expect(findProviderOutputStart('buffer text', ['nope', 'nada'])).toBe(-1);
+  });
+
+  it('returns -1 for an empty pattern array', () => {
+    expect(findProviderOutputStart('buffer text', [])).toBe(-1);
+  });
+});
+
+describe('delegation: Claude-specific functions stay in sync with the generic ones', () => {
+  it('isClaudeReady matches isProviderReady(output, CLAUDE_READY_PATTERNS) for arbitrary inputs', () => {
+    const samples = [
+      '',
+      'no match here',
+      'Welcome back to the tool',
+      'Sonnet and Haiku both appear',
+      'trailing Recent activity text',
+    ];
+    for (const sample of samples) {
+      expect(isClaudeReady(sample)).toBe(
+        isProviderReady(sample, [...CLAUDE_READY_PATTERNS])
+      );
+    }
+  });
+
+  it('findClaudeOutputStart matches findProviderOutputStart(buffer, CLAUDE_READY_PATTERNS) for arbitrary inputs', () => {
+    const samples = [
+      '',
+      'no match here',
+      'Haiku appears before Claude Code in this buffer',
+      'Claude Code then Opus then Sonnet',
+    ];
+    for (const sample of samples) {
+      expect(findClaudeOutputStart(sample)).toBe(
+        findProviderOutputStart(sample, [...CLAUDE_READY_PATTERNS])
+      );
+    }
+  });
+});

--- a/src/shared/claude-detector.ts
+++ b/src/shared/claude-detector.ts
@@ -2,7 +2,7 @@
  * Centralized Claude-ready detection.
  *
  * Detects whether Claude Code's welcome screen has appeared in terminal output.
- * Used by: Terminal.tsx (renderer), MultiTerminal (renderer), HistoryManager (main).
+ * Used by: Terminal.tsx (renderer), history-manager.ts (main), claude-provider.ts (main).
  *
  * Keep this as the SINGLE SOURCE OF TRUTH for detection patterns.
  * When Claude Code updates its welcome screen, update ONLY this file.
@@ -21,24 +21,19 @@ export const CLAUDE_READY_PATTERNS = [
 
 /**
  * Check if a string contains any Claude-ready pattern.
+ * Delegates to the generic `isProviderReady` so the two cannot drift.
  */
 export function isClaudeReady(output: string): boolean {
-  return CLAUDE_READY_PATTERNS.some(pattern => output.includes(pattern));
+  return isProviderReady(output, CLAUDE_READY_PATTERNS as unknown as string[]);
 }
 
 /**
  * Find the earliest index in the buffer where Claude's output begins.
  * Returns the index of the first matching pattern, or -1 if none found.
+ * Delegates to the generic `findProviderOutputStart` so the two cannot drift.
  */
 export function findClaudeOutputStart(buffer: string): number {
-  let earliest = -1;
-  for (const pattern of CLAUDE_READY_PATTERNS) {
-    const index = buffer.indexOf(pattern);
-    if (index !== -1 && (earliest === -1 || index < earliest)) {
-      earliest = index;
-    }
-  }
-  return earliest;
+  return findProviderOutputStart(buffer, CLAUDE_READY_PATTERNS as unknown as string[]);
 }
 
 /**


### PR DESCRIPTION
Closes #76

## Summary

`src/shared/claude-detector.ts` is documented as the single source of truth for Claude-ready detection but had zero tests. This PR adds coverage and fixes two secondary issues flagged in #76:

- **Tests added** (`src/shared/claude-detector.test.ts`, 16 tests, no mocks needed — pure module): `isClaudeReady`, `findClaudeOutputStart` (including the "earliest match across out-of-order patterns" case), `isProviderReady`, `findProviderOutputStart`, and delegation-equivalence checks across a table of sample inputs.
- **Delegation fix**: `isClaudeReady`/`findClaudeOutputStart` now call `isProviderReady`/`findProviderOutputStart` with `CLAUDE_READY_PATTERNS` instead of duplicating the scan loop. Behavior-preserving — the tests lock in identical output for both paths so they can no longer silently drift (the same failure mode noted in #69 for `stripAnsi`).
- **Doc fix**: header comment no longer references the non-existent `MultiTerminal` component; now lists the real consumers (`Terminal.tsx`, `history-manager.ts`, `claude-provider.ts`).

No production behavior change outside the delegation refactor, which is covered by the equivalence tests.

## Verification

- `npx vitest run --config vitest.workspace.ts src/shared/claude-detector.test.ts` → 16/16 passed
- `npx tsc --noEmit -p tsconfig.json` → clean
- `npx tsc --noEmit -p tsconfig.main.json` → clean
- `npm test` (full suite) → 95 files / 1009 tests passed