### PR TITLE
fix(postinstall): gate source-code banner to skip CI and local dev installs

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "main": "dist/main/index.js",
   "scripts": {
-    "postinstall": "node -e \"console.log('\\n⚠️  OmniDesk is a desktop application.\\n\\nYou\\'ve installed the SOURCE CODE. To get the INSTALLABLE APP:\\n→ https://github.com/carloluisito/omnidesk/releases\\n\\nTo build from source: npm run package\\n')\"",
+    "postinstall": "node scripts/postinstall.mjs",
     "dev": "vite",
     "build": "tsc && vite build",
     "build:electron": "tsc -p tsconfig.main.json",

--- a/scripts/postinstall.mjs
+++ b/scripts/postinstall.mjs
@@ -1,0 +1,16 @@
+// Prints a heads-up banner for end users who run `npm install
+// @carloluisito/omnidesk` (or `npm i -g ...`) thinking it's an installable
+// app rather than the source tree.
+//
+// This must NOT fire for:
+//   - CI (`npm ci` in workflows) — `CI` is set by GitHub Actions and every
+//     other major CI provider.
+//   - Local dev / contributors running `npm install` at the repo root —
+//     npm sets INIT_CWD to the directory the install was invoked from, which
+//     equals process.cwd() (this package's own directory) in that case.
+if (process.env.CI) process.exit(0);
+if (process.env.INIT_CWD && process.env.INIT_CWD === process.cwd()) process.exit(0);
+
+console.log(
+  `\n⚠️  OmniDesk is a desktop application.\n\nYou've installed the SOURCE CODE. To get the INSTALLABLE APP:\n→ https://github.com/carloluisito/omnidesk/releases\n\nTo build from source: npm run package\n`
+);


### PR DESCRIPTION
Closes #66

## Summary

The `postinstall` script unconditionally printed the "you installed the SOURCE CODE" banner. That's correct for the end-user case (`npm install @carloluisito/omnidesk`), but it also fired for:
- Every `npm ci` in CI (`ci.yml`, `release.yml` x2)
- Every local `npm install` at the repo root by contributors — the exact source-code case the banner warns against

Moved the inline `node -e` one-liner (already at readability limit) to `scripts/postinstall.mjs` and added two guards using env vars npm/CI already set, no new dependency:
- `process.env.CI` — set by GitHub Actions and other major CI providers
- `process.env.INIT_CWD === process.cwd()` — true when `npm install` is invoked from the package's own directory (local dev/contributor case)

`package.json`'s `postinstall` now points at the script instead of the inline string.

## Verification

- Ran the script directly under each scenario from the issue's acceptance criteria:
  - `INIT_CWD` == `process.cwd()`, no `CI` → silent (exit 0)
  - `CI=1` set, `INIT_CWD` different → silent (exit 0)
  - `INIT_CWD` different, no `CI` → banner printed (end-user behavior unchanged)
- Ran real `npm install --no-audit --no-fund` at the repo root and grepped stdout for "SOURCE CODE" → 0 occurrences (banner absent, as required)
- Ran `CI=1 npm install --no-audit --no-fund` at the repo root → 0 occurrences
- `npx tsc --noEmit` clean on `tsconfig.json` and `tsconfig.main.json`
- `npm test` — 96 files / 1031 tests passed

No dependency added — uses only npm/CI env vars already available at postinstall time.