### PR TITLE
fix(shell): gate NewSessionSheet agent toggle behind real provider availability

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -22,6 +22,7 @@ import { useSessionManager } from './hooks/useSessionManager';
 import { useRepos } from './hooks/useRepos';
 import { useQuota } from './hooks/useQuota';
 import { useAgentViewAvailability } from './hooks/useAgentViewAvailability';
+import { useProvider } from './hooks/useProvider';
 import { useSessionPreviews } from './hooks/useSessionPreviews';
 import { useTouchMode } from './hooks/useTouchMode';
 import { MobileKeyBar } from './components/shell/mobile/MobileKeyBar';
@@ -105,6 +106,14 @@ function App() {
   // Gate the "agents" launch mode based on the live availability probe.
   const agentView = useAgentViewAvailability();
   const agentsAvailable = agentView.availability?.status === 'available';
+
+  // Providers whose CLI is actually installed, for gating the new-session
+  // Agent toggle (empty while the probe is in flight — see NewSessionSheet).
+  const { availableProviders: availableProviderInfos } = useProvider();
+  const availableProviderIds = useMemo(
+    () => availableProviderInfos.map(p => p.id),
+    [availableProviderInfos]
+  );
 
   // Per-session recent-output snapshots, fed into Grid tiles + Inspector last-activity.
   const previews = useSessionPreviews();
@@ -883,6 +892,7 @@ function App() {
             sessions={sessions}
             activeRepoId={activeRepoId}
             agentsAvailable={agentsAvailable}
+            availableProviders={availableProviderIds}
             prefill={newSessionPrefill ?? undefined}
             onClose={() => { setShowNewSession(false); setNewSessionPrefill(null); }}
             onCreate={handleCreateSession}

--- a/src/renderer/components/shell/NewSessionSheet.test.tsx
+++ b/src/renderer/components/shell/NewSessionSheet.test.tsx
@@ -20,3 +20,54 @@ describe('NewSessionSheet — Terminal type', () => {
     expect(form.workingDirectory).toBe('/repos/demo');
   });
 });
+
+describe('NewSessionSheet — provider availability gating (#122)', () => {
+  it('disables the Codex toggle when only Claude is available', () => {
+    render(
+      <NewSessionSheet
+        repos={[repo]}
+        sessions={[]}
+        activeRepoId="r1"
+        availableProviders={['claude']}
+        onClose={() => {}}
+        onCreate={vi.fn()}
+      />
+    );
+    expect(screen.getByRole('button', { name: /codex/i })).toBeDisabled();
+    expect(screen.getByRole('button', { name: /claude/i })).not.toBeDisabled();
+  });
+
+  it('defaults the agent selection to Codex when only Codex is available', async () => {
+    const onCreate = vi.fn().mockResolvedValue(undefined);
+    render(
+      <NewSessionSheet
+        repos={[repo]}
+        sessions={[]}
+        activeRepoId="r1"
+        availableProviders={['codex']}
+        onClose={() => {}}
+        onCreate={onCreate}
+      />
+    );
+    expect(screen.getByRole('button', { name: /claude/i })).toBeDisabled();
+    fireEvent.click(screen.getByRole('button', { name: /start session/i }));
+    await Promise.resolve();
+    expect(onCreate).toHaveBeenCalledTimes(1);
+    expect(onCreate.mock.calls[0][0].agent).toBe('codex');
+  });
+
+  it('renders both providers enabled when availability is unknown (empty list)', () => {
+    render(
+      <NewSessionSheet
+        repos={[repo]}
+        sessions={[]}
+        activeRepoId="r1"
+        availableProviders={[]}
+        onClose={() => {}}
+        onCreate={vi.fn()}
+      />
+    );
+    expect(screen.getByRole('button', { name: /claude/i })).not.toBeDisabled();
+    expect(screen.getByRole('button', { name: /codex/i })).not.toBeDisabled();
+  });
+});

--- a/src/renderer/components/shell/NewSessionSheet.tsx
+++ b/src/renderer/components/shell/NewSessionSheet.tsx
@@ -52,6 +52,11 @@ interface NewSessionSheetProps {
   activeRepoId: string | null;
   /** Whether `claude agents` is available right now (probe result from useAgentViewAvailability). */
   agentsAvailable?: boolean;
+  /** Providers whose CLI is actually installed (from useProvider().availableProviders,
+   *  mapped to ids). Empty means "unknown / still loading" — both options stay shown
+   *  and selectable, matching NewSessionDialog's fallback, so the sheet never renders
+   *  an empty toggle while the probe is in flight. */
+  availableProviders?: ProviderId[];
   /** Optional pre-filled values (work intake). */
   prefill?: NewSessionPrefill;
   onClose: () => void;
@@ -66,6 +71,7 @@ export function NewSessionSheet({
   sessions,
   activeRepoId,
   agentsAvailable = true,
+  availableProviders = [],
   prefill,
   onClose,
   onCreate,
@@ -101,6 +107,20 @@ export function NewSessionSheet({
   useEffect(() => {
     if (agent !== 'claude' && launchMode !== 'default') setLaunchMode('default');
   }, [agent, launchMode]);
+
+  // Default to an actually-installed provider once availability is known.
+  // Empty availableProviders means "still probing" — leave the default (claude)
+  // in place rather than guessing. Fires once per mount so it never clobbers
+  // a manual pick made while the probe was in flight.
+  const appliedProviderDefaultRef = useRef(false);
+  useEffect(() => {
+    if (appliedProviderDefaultRef.current) return;
+    if (availableProviders.length === 0) return;
+    appliedProviderDefaultRef.current = true;
+    if (!availableProviders.includes('claude')) {
+      setAgent(availableProviders[0]);
+    }
+  }, [availableProviders]);
 
   // Sessions in the active repo that currently have their own worktree —
   // candidates for "Share" mode. We exclude sessions running in the main
@@ -505,24 +525,37 @@ export function NewSessionSheet({
             <div className="p4-form-row" style={{ marginBottom: 0 }}>
               <label>Agent</label>
               <div style={{ display: 'flex', gap: 4, background: 'var(--surface-mid)', padding: 2, borderRadius: 6 }}>
-                {(['claude', 'codex'] as ProviderId[]).map(a => (
-                  <button
-                    key={a}
-                    type="button"
-                    onClick={() => setAgent(a)}
-                    className="p4-btn"
-                    style={{
-                      flex: 1, justifyContent: 'center',
-                      background: agent === a ? 'var(--surface-high)' : 'transparent',
-                      border: 0,
-                      color: agent === a
-                        ? a === 'claude' ? 'var(--accent)' : 'var(--accent-2)'
-                        : 'var(--text-secondary)',
-                    }}
-                  >
-                    {a === 'claude' ? 'Claude' : 'Codex'}
-                  </button>
-                ))}
+                {(['claude', 'codex'] as ProviderId[]).map(a => {
+                  // Empty availableProviders means "still probing" — show both,
+                  // selectable, matching the empty-state fallback above.
+                  const known = availableProviders.length > 0;
+                  const unavailable = known && !availableProviders.includes(a);
+                  const label = a === 'claude' ? 'Claude' : 'Codex';
+                  return (
+                    <button
+                      key={a}
+                      type="button"
+                      disabled={unavailable}
+                      title={unavailable ? `${label} CLI not installed` : undefined}
+                      onClick={() => setAgent(a)}
+                      className="p4-btn"
+                      style={{
+                        flex: 1, justifyContent: 'center',
+                        background: agent === a ? 'var(--surface-high)' : 'transparent',
+                        border: 0,
+                        color: unavailable
+                          ? 'var(--text-quaternary)'
+                          : agent === a
+                            ? a === 'claude' ? 'var(--accent)' : 'var(--accent-2)'
+                            : 'var(--text-secondary)',
+                        opacity: unavailable ? 0.5 : 1,
+                        cursor: unavailable ? 'not-allowed' : 'pointer',
+                      }}
+                    >
+                      {label}{unavailable ? <span style={{ fontSize: 9, marginLeft: 4 }}>(not installed)</span> : null}
+                    </button>
+                  );
+                })}
               </div>
             </div>
 

--- a/src/renderer/hooks/useProvider.ts
+++ b/src/renderer/hooks/useProvider.ts
@@ -7,9 +7,11 @@ export function useProvider() {
   const capabilitiesCache = useRef<Map<ProviderId, ProviderCapabilities>>(new Map());
 
   useEffect(() => {
-    // Load providers on mount
-    window.electronAPI.listProviders().then(setProviders);
-    window.electronAPI.getAvailableProviders().then(setAvailableProviders);
+    // Load providers on mount. Guard against a resolved value of undefined
+    // (e.g. an unconfigured IPC mock in tests) so consumers can always rely
+    // on these being arrays.
+    window.electronAPI.listProviders().then(res => setProviders(res ?? []));
+    window.electronAPI.getAvailableProviders().then(res => setAvailableProviders(res ?? []));
   }, []);
 
   const getCapabilities = useCallback(async (providerId: ProviderId): Promise<ProviderCapabilities> => {


### PR DESCRIPTION
Closes #122

## Problem
`NewSessionSheet` (the mounted shell UI, `App.tsx:858`) always rendered both Claude and Codex in its Agent toggle, regardless of whether the CLI was actually installed. Selecting an uninstalled provider produced a dead session — the PTY shell fails with a cryptic `'codex' is not recognized` / `command not found` instead of the option being disabled or hidden. The legacy `NewSessionDialog` already gated correctly via `useProvider()`; that gating was dropped when the P4 shell replaced it.

## Change
- `useProvider.ts`: guard `listProviders()`/`getAvailableProviders()` resolution against `undefined` (e.g. an unconfigured IPC mock in tests) so consumers can rely on plain arrays.
- `App.tsx`: derive `availableProviders: ProviderId[]` from `useProvider()` and pass it into `NewSessionSheet`, mirroring the existing `agentsAvailable` prop.
- `NewSessionSheet.tsx`:
  - Agent toggle now driven by `availableProviders` instead of the literal `['claude','codex']`.
  - Unavailable options render disabled with a "(not installed)" hint and a title tooltip.
  - Defaults to the first available provider once the probe resolves (fires once per mount, so it never clobbers a manual pick made while the probe was in flight).
  - Empty `availableProviders` means "still probing" — both options stay enabled/selectable, matching `NewSessionDialog`'s fallback, so the sheet never flashes an empty toggle before the probe resolves.

## Tests
Added 3 tests to `NewSessionSheet.test.tsx` covering the three states: Codex disabled when only Claude is available, default-to-Codex when only Codex is available, and both enabled while availability is unknown.

## Verification
- `tsc --noEmit` clean on `tsconfig.json` and `tsconfig.main.json`
- Targeted file: `NewSessionSheet.test.tsx` 4/4 passed
- Full suite: `npm test` — 97 files / 1052 tests passed

No new dependencies added.