### PR TITLE
fix(integrations): escape Slack control chars and suppress Discord mentions

### DIFF
--- a/src/main/integrations/connectors.test.ts
+++ b/src/main/integrations/connectors.test.ts
@@ -5,6 +5,7 @@ import { SlackConnector } from './connectors/slack-connector';
 import { DiscordConnector } from './connectors/discord-connector';
 import { WebhookConnector } from './connectors/webhook-connector';
 import { ConnectorRegistry } from './connector-registry';
+import { formatSlack } from './message-format';
 import type { OutboundMessage } from '../../shared/integration-types';
 
 const msg: OutboundMessage = {
@@ -88,23 +89,52 @@ describe('TelegramConnector', () => {
 });
 
 describe('SlackConnector', () => {
-  it('posts {text} to the webhook URL', async () => {
+  it('posts {text} formatted via formatSlack (not the raw msg.text) to the webhook URL', async () => {
     const fetchFn = mockFetch();
     const out = await new SlackConnector().deliver({ enabled: true, webhookUrl: 'https://hooks.slack.com/x' }, msg);
     expect(out.ok).toBe(true);
     const [url, init] = fetchFn.mock.calls[0];
     expect(url).toBe('https://hooks.slack.com/x');
-    expect(JSON.parse(init.body)).toEqual({ text: msg.text });
+    expect(JSON.parse(init.body)).toEqual({ text: formatSlack(msg.event) });
+  });
+
+  it('escapes &, <, > from session name and reason in the posted body', async () => {
+    const fetchFn = mockFetch();
+    const specialMsg: OutboundMessage = {
+      text: 'unused',
+      event: {
+        type: 'attention', at: 1, sessionName: '<Button>', repoName: 'omnidesk',
+        state: 'awaiting-input', reason: 'A & B',
+      },
+    };
+    const out = await new SlackConnector().deliver({ enabled: true, webhookUrl: 'https://hooks.slack.com/x' }, specialMsg);
+    expect(out.ok).toBe(true);
+    const [, init] = fetchFn.mock.calls[0];
+    const body = JSON.parse(init.body);
+    expect(body.text).toContain('&lt;Button&gt;');
+    expect(body.text).toContain('A &amp; B');
+    expect(body.text).not.toContain('<Button>');
   });
 });
 
 describe('DiscordConnector', () => {
-  it('posts {content} to the webhook URL', async () => {
+  it('posts {content, allowed_mentions} to the webhook URL', async () => {
     const fetchFn = mockFetch(204);
     const out = await new DiscordConnector().deliver({ enabled: true, webhookUrl: 'https://discord.com/api/webhooks/x' }, msg);
     expect(out.ok).toBe(true);
     const [, init] = fetchFn.mock.calls[0];
-    expect(JSON.parse(init.body)).toEqual({ content: msg.text });
+    expect(JSON.parse(init.body)).toEqual({ content: msg.text, allowed_mentions: { parse: [] } });
+  });
+
+  it('suppresses mentions even when the text contains @everyone', async () => {
+    const fetchFn = mockFetch(204);
+    const mentionMsg: OutboundMessage = { text: '@everyone check this out', event: msg.event };
+    const out = await new DiscordConnector().deliver({ enabled: true, webhookUrl: 'https://discord.com/api/webhooks/x' }, mentionMsg);
+    expect(out.ok).toBe(true);
+    const [, init] = fetchFn.mock.calls[0];
+    const body = JSON.parse(init.body);
+    expect(body.content).toContain('@everyone');
+    expect(body.allowed_mentions).toEqual({ parse: [] });
   });
 
   it('truncates content over the 2000 char limit', async () => {

--- a/src/main/integrations/connectors/discord-connector.ts
+++ b/src/main/integrations/connectors/discord-connector.ts
@@ -27,7 +27,10 @@ export class DiscordConnector implements IConnector<DiscordConfig> {
       const res = await fetch(cfg.webhookUrl, {
         method: 'POST',
         headers: { 'content-type': 'application/json' },
-        body: JSON.stringify({ content: truncatePlainText(msg.text, DISCORD_MAX_LENGTH) }),
+        body: JSON.stringify({
+          content: truncatePlainText(msg.text, DISCORD_MAX_LENGTH),
+          allowed_mentions: { parse: [] },
+        }),
       });
       return outcomeFromResponse(res);
     } catch (err) {

--- a/src/main/integrations/connectors/slack-connector.ts
+++ b/src/main/integrations/connectors/slack-connector.ts
@@ -1,5 +1,6 @@
 import type { ConnectorTestResult, OutboundMessage, SendOutcome, SlackConfig } from '../../../shared/integration-types';
 import { IConnector, outcomeFromNetworkError, outcomeFromResponse } from '../connector';
+import { formatSlack } from '../message-format';
 
 export class SlackConnector implements IConnector<SlackConfig> {
   readonly id = 'slack' as const;
@@ -23,7 +24,7 @@ export class SlackConnector implements IConnector<SlackConfig> {
       const res = await fetch(cfg.webhookUrl, {
         method: 'POST',
         headers: { 'content-type': 'application/json' },
-        body: JSON.stringify({ text: msg.text }),
+        body: JSON.stringify({ text: formatSlack(msg.event) }),
       });
       return outcomeFromResponse(res);
     } catch (err) {

--- a/src/main/integrations/message-format.test.ts
+++ b/src/main/integrations/message-format.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { formatMessage, formatTelegramHTML, truncatePlainText, truncateHtmlByLines } from './message-format';
+import { formatMessage, formatTelegramHTML, formatSlack, truncatePlainText, truncateHtmlByLines } from './message-format';
 import type { IntegrationEvent } from '../../shared/integration-types';
 
 function evt(partial: Partial<IntegrationEvent>): IntegrationEvent {
@@ -60,6 +60,38 @@ describe('formatTelegramHTML', () => {
   it('bolds the session name', () => {
     const text = formatTelegramHTML(evt({ sessionName: 'sess', state: 'awaiting-input' }));
     expect(text).toContain('<b>sess</b>');
+  });
+});
+
+describe('formatSlack', () => {
+  it('escapes &, <, > in names and reason, with & escaped first', () => {
+    const text = formatSlack(evt({
+      sessionName: '<Button>', repoName: 'a<b&c', reason: 'A & B', state: 'awaiting-input',
+    }));
+    expect(text).toContain('&lt;Button&gt;');
+    expect(text).toContain('a&lt;b&amp;c');
+    expect(text).toContain('A &amp; B');
+    expect(text).not.toMatch(/<Button>/);
+    expect(text).not.toMatch(/&(?!amp;|lt;|gt;)/); // no unescaped bare "&"
+  });
+
+  it('does not bold the session name (no HTML markup for Slack)', () => {
+    const text = formatSlack(evt({ sessionName: 'sess', state: 'awaiting-input' }));
+    expect(text).not.toContain('<b>');
+    expect(text).toContain('sess');
+  });
+
+  it('leaves the deep link raw/unescaped so Slack can auto-link it', () => {
+    const text = formatSlack(evt({
+      sessionName: 's', state: 'awaiting-input',
+      link: 'https://x.trycloudflare.com/?token=t&session=abc',
+    }));
+    expect(text).toContain('https://x.trycloudflare.com/?token=t&session=abc');
+    expect(text).not.toContain('&amp;session=abc');
+  });
+
+  it('digest / pr-created / test escape the summary', () => {
+    expect(formatSlack(evt({ type: 'digest', summary: '<all> & done' }))).toContain('&lt;all&gt; &amp; done');
   });
 });
 

--- a/src/main/integrations/message-format.ts
+++ b/src/main/integrations/message-format.ts
@@ -66,6 +66,22 @@ export function formatTelegramHTML(event: IntegrationEvent): string {
   return lines.join('\n');
 }
 
+export function formatSlack(event: IntegrationEvent): string {
+  if (event.type === 'digest' || event.type === 'pr-created' || event.type === 'test') {
+    return escapeHTML(event.summary ?? '');
+  }
+  const lines: string[] = [];
+  const repo = event.repoName ? `${escapeHTML(event.repoName)} · ` : '';
+  const name = event.sessionName ? escapeHTML(event.sessionName) : '';
+  const head = `${repo}${name}`.trim();
+  lines.push(head ? `${head} — ${escapeHTML(stateLabel(event))}` : escapeHTML(stateLabel(event)));
+  if (event.reason && event.reason !== 'bell') lines.push(escapeHTML(event.reason));
+  // The link is left unescaped: Slack auto-links bare URLs, and escaping
+  // `&` inside a query string would break the link.
+  lines.push(linkLine(event));
+  return lines.join('\n');
+}
+
 const DEFAULT_TRUNCATION_MARKER = '\n… (truncated)';
 
 /**


### PR DESCRIPTION
Closes #137

## Problem
Slack and Discord notifications posted raw, unescaped text:
- Slack's `text` field treats `&`, `<`, `>` as control characters — a session/repo name or reason containing them (e.g. `<Button>`) rendered broken/garbled in Slack instead of literal text.
- Discord webhook payloads had no `allowed_mentions` suppression, so a session/repo name or reason containing `@everyone`, `@here`, or a role/user mention would actually ping the channel.

## Changes
- **`message-format.ts`**: added `formatSlack(event)`, mirroring the existing `formatTelegramHTML` escaping approach (reusing the private `escapeHTML`/`stateLabel`/`linkLine` helpers) but without `<b>` bold markup, since Slack's `text` field has no HTML. The deep-link line is deliberately left **unescaped** — Slack auto-links bare URLs, and escaping `&` in a query string would break the link.
- **`slack-connector.ts`**: `deliver()` now posts `{ text: formatSlack(msg.event) }` instead of the raw `msg.text`.
- **`discord-connector.ts`**: `deliver()` now sends `allowed_mentions: { parse: [] }` alongside `content`, suppressing all mention types regardless of what text ends up in the payload. Markdown escaping (`*_~`) is out of scope per the issue.
- Tests: new `formatSlack` describe block in `message-format.test.ts` (escaping order, no bold markup, link left raw, digest/summary escaping); updated `connectors.test.ts` SlackConnector test to assert the posted body matches `formatSlack(msg.event)` plus a new escaping-through-the-wire test, and a new DiscordConnector test asserting `@everyone` in text does not disable mention suppression.

No new dependencies.

## Verification
- `tsc --noEmit` clean on both `tsconfig.json` and `tsconfig.main.json`
- Targeted run (`vitest --config vitest.workspace.ts --project main` on the two changed test files): 32/32 passed
- Full suite (`npm test`): 97 files / 1055 tests, all passed