### PR TITLE
fix(integrations): release AttentionPolicy state when a session ends

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -256,6 +256,9 @@ function createWindow(): void {
     },
   });
   sessionManager.addStateListener((evt, meta) => integrationManager?.handleStateChange(evt, meta));
+  // Release the AttentionPolicy record when a session ends (exit or delete)
+  // so per-session state doesn't accumulate for the life of the app.
+  sessionManager.onSessionEnd((sessionId) => integrationManager?.handleSessionRemoved(sessionId));
 
   // Setup IPC handlers with pool reference
   setupIPCHandlers(

--- a/src/main/integrations/integration-manager.test.ts
+++ b/src/main/integrations/integration-manager.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { IntegrationManager, IntegrationManagerDeps } from './integration-manager';
+import { AttentionPolicy } from './attention-policy';
 import { ConnectorRegistry } from './connector-registry';
 import type { IConnector } from './connector';
 import {
@@ -268,6 +269,32 @@ describe('IntegrationManager', () => {
     const { registry } = fakeRegistry();
     const m = new IntegrationManager(makeDeps(settingsWith({})), { registry });
     await expect(m.testConnector('slack', { enabled: true, webhookUrl: 'https://x' })).resolves.toEqual({ ok: true });
+    m.dispose();
+  });
+
+  it('handleSessionRemoved forgets the policy record so a repeated state re-arms', async () => {
+    const { registry, delivered } = fakeRegistry();
+    const m = new IntegrationManager(makeDeps(settingsWith({})), { registry });
+    m.handleStateChange(evt({ at: 1000 }), meta({}));
+    m.handleStateChange(evt({ at: 2000 }), meta({})); // same state, still within debounce -> silent
+    await vi.runAllTimersAsync();
+    expect(delivered.length).toBe(1);
+
+    m.handleSessionRemoved('s1');
+    m.handleStateChange(evt({ at: 3000 }), meta({})); // record released -> fires again despite short gap
+    await vi.runAllTimersAsync();
+    expect(delivered.length).toBe(2);
+    m.dispose();
+  });
+
+  it('handleSessionRemoved never throws even if the underlying policy forget() fails', () => {
+    const { registry } = fakeRegistry();
+    const m = new IntegrationManager(makeDeps(settingsWith({})), { registry });
+    const spy = vi.spyOn(AttentionPolicy.prototype, 'forget').mockImplementation(() => {
+      throw new Error('boom');
+    });
+    expect(() => m.handleSessionRemoved('s1')).not.toThrow();
+    spy.mockRestore();
     m.dispose();
   });
 });

--- a/src/main/integrations/integration-manager.ts
+++ b/src/main/integrations/integration-manager.ts
@@ -86,6 +86,20 @@ export class IntegrationManager {
     }
   }
 
+  /** SessionManager end-of-life hook (`onSessionEnd`): releases the
+   *  AttentionPolicy record for a session once it's gone, so the policy's
+   *  map doesn't retain state for sessions that can never emit another
+   *  transition. Idempotent (Map.delete) and safe to call from both the
+   *  exit and delete fire sites. Must never throw (same contract as
+   *  handleStateChange on the state-tap path). */
+  handleSessionRemoved(sessionId: string): void {
+    try {
+      this.policy.forget(sessionId);
+    } catch (err) {
+      console.error('IntegrationManager.handleSessionRemoved failed:', err);
+    }
+  }
+
   notifyPRCreated(meta: SessionMetadata, prUrl: string): void {
     const settings = this.deps.getSettings();
     if (!settings.shipit.notifyOnPR) return;


### PR DESCRIPTION
Closes #139

## Problem
`AttentionPolicy` keeps a per-session record in a `Map` to drive edge/debounce
notification arming. The class already had a `forget(sessionId)` method
(`Map.delete`), but nothing in production ever called it — only the unit test
for `AttentionPolicy` itself exercised it. Every session that exited or was
deleted left its record behind for the life of the app, so `IntegrationManager`
accumulated stale per-session state indefinitely for long-running fleets.

## Fix
- `IntegrationManager`: added `handleSessionRemoved(sessionId)`, which calls
  `this.policy.forget(sessionId)` inside a try/catch — mirroring the
  must-never-throw contract already used by `handleStateChange`, since this
  also sits on a callback path.
- `src/main/index.ts`: wired `sessionManager.onSessionEnd(...)` (the existing
  lifecycle hook that already fires on both session exit and session delete)
  to call `integrationManager.handleSessionRemoved(sessionId)`.
- `forget()` is a plain `Map.delete`, so calling it from both `onSessionEnd`
  fire sites is idempotent and safe — no existence check needed.
- Read `this.policy` fresh at call time, so if `settingsChanged()` has swapped
  in a new `AttentionPolicy` instance (debounce setting changed), the forget
  still targets whichever policy instance is currently active.

## Tests
Added two tests to `integration-manager.test.ts`:
- `handleSessionRemoved forgets the policy record so a repeated state re-arms`
  — proves the record is actually released by observing that a same-state
  event fires again immediately after `handleSessionRemoved`, instead of
  staying silent for the debounce window.
- `handleSessionRemoved never throws even if the underlying policy forget()
  fails` — spies `AttentionPolicy.prototype.forget` to throw, asserts the
  wrapper swallows it.

No new dependencies.

## Verification
- `npx tsc --noEmit -p tsconfig.json` — clean
- `npx tsc --noEmit -p tsconfig.main.json` — clean
- `npx vitest run --config vitest.workspace.ts --project main src/main/integrations/integration-manager.test.ts` — 17/17 passed (including the 2 new tests)
- `npm test` (full suite) — 97 files / 1060 tests passed, no regressions