### PR TITLE
fix(integrations): clamp and validate Retry-After parsing (#144)

### DIFF
--- a/src/main/integrations/connector.ts
+++ b/src/main/integrations/connector.ts
@@ -15,16 +15,43 @@ export interface IConnector<C = unknown> {
   deliver(cfg: C, msg: OutboundMessage): Promise<SendOutcome>;
 }
 
+/**
+ * Ceiling for a parsed Retry-After delay. A hostile/misconfigured endpoint (the generic
+ * WebhookConnector posts to an arbitrary user-configured URL) can return an out-of-range
+ * Retry-After; without a cap that value flows straight into `setTimeout`, which silently
+ * clamps anything above ~24.85 days (2^31 - 1 ms) down to ~1ms — causing an unbroken
+ * reschedule loop that pins a core. 2 minutes is comfortably above the queue's own
+ * backoff ceiling (32s) while staying far below the setTimeout limit.
+ */
+export const MAX_RETRY_AFTER_MS = 120_000;
+
+/**
+ * Parse a Retry-After header value (RFC 7231: either delta-seconds or an HTTP-date) into a
+ * positive, clamped millisecond delay. Returns undefined for missing, non-numeric/non-date,
+ * negative, zero, or past values so the caller falls back to its own backoff schedule.
+ */
+function parseRetryAfterMs(retryAfter: string | null | undefined): number | undefined {
+  if (!retryAfter) return undefined;
+  const seconds = Number(retryAfter);
+  if (Number.isFinite(seconds)) {
+    return seconds > 0 ? Math.min(seconds * 1000, MAX_RETRY_AFTER_MS) : undefined;
+  }
+  const dateMs = Date.parse(retryAfter);
+  if (Number.isFinite(dateMs)) {
+    const deltaMs = dateMs - Date.now();
+    return deltaMs > 0 ? Math.min(deltaMs, MAX_RETRY_AFTER_MS) : undefined;
+  }
+  return undefined;
+}
+
 /** Map an HTTP response to a SendOutcome. Never leaks tokens/URLs into errors. */
 export function outcomeFromResponse(res: { status: number; headers?: { get(name: string): string | null } }): SendOutcome {
   if (res.status >= 200 && res.status < 300) return { ok: true };
   if (res.status === 429) {
-    const retryAfter = res.headers?.get('retry-after');
-    const seconds = retryAfter ? Number(retryAfter) : NaN;
     return {
       ok: false,
       retryable: true,
-      retryAfterMs: Number.isFinite(seconds) ? seconds * 1000 : undefined,
+      retryAfterMs: parseRetryAfterMs(res.headers?.get('retry-after')),
       error: 'rate limited (429)',
     };
   }

--- a/src/main/integrations/connectors.test.ts
+++ b/src/main/integrations/connectors.test.ts
@@ -6,6 +6,7 @@ import { DiscordConnector } from './connectors/discord-connector';
 import { WebhookConnector } from './connectors/webhook-connector';
 import { ConnectorRegistry } from './connector-registry';
 import { formatSlack } from './message-format';
+import { outcomeFromResponse, MAX_RETRY_AFTER_MS } from './connector';
 import type { OutboundMessage } from '../../shared/integration-types';
 
 const msg: OutboundMessage = {
@@ -172,6 +173,52 @@ describe('WebhookConnector', () => {
     vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('ECONNREFUSED')));
     const out = await new WebhookConnector().deliver({ enabled: true, url: 'https://example.com/hook' }, msg);
     expect(out).toMatchObject({ ok: false, retryable: true });
+  });
+});
+
+describe('outcomeFromResponse — Retry-After parsing (#144)', () => {
+  function res429(retryAfter: string | null) {
+    return { status: 429, headers: { get: (n: string) => (n.toLowerCase() === 'retry-after' ? retryAfter : null) } };
+  }
+
+  it('missing header → retryAfterMs undefined (falls back to queue backoff)', () => {
+    expect(outcomeFromResponse(res429(null))).toMatchObject({ ok: false, retryable: true, retryAfterMs: undefined });
+  });
+
+  it('non-numeric, non-date header → retryAfterMs undefined', () => {
+    expect(outcomeFromResponse(res429('not-a-number-or-date')).retryAfterMs).toBeUndefined();
+  });
+
+  it('negative or zero seconds → retryAfterMs undefined', () => {
+    expect(outcomeFromResponse(res429('-5')).retryAfterMs).toBeUndefined();
+    expect(outcomeFromResponse(res429('0')).retryAfterMs).toBeUndefined();
+  });
+
+  it('sane mid-range seconds pass through unclamped', () => {
+    expect(outcomeFromResponse(res429('30')).retryAfterMs).toBe(30_000);
+  });
+
+  it('out-of-range seconds (~317 years) clamp to MAX_RETRY_AFTER_MS, never overflow setTimeout', () => {
+    const out = outcomeFromResponse(res429('9999999999'));
+    expect(out.retryAfterMs).toBe(MAX_RETRY_AFTER_MS);
+    expect(out.retryAfterMs!).toBeLessThan(2 ** 31 - 1);
+  });
+
+  it('HTTP-date form in the near future yields a positive, clamped delay', () => {
+    const future = new Date(Date.now() + 10_000).toUTCString();
+    const out = outcomeFromResponse(res429(future));
+    expect(out.retryAfterMs).toBeGreaterThan(0);
+    expect(out.retryAfterMs!).toBeLessThanOrEqual(MAX_RETRY_AFTER_MS);
+  });
+
+  it('HTTP-date form far in the future clamps to MAX_RETRY_AFTER_MS', () => {
+    const farFuture = new Date(Date.now() + 365 * 24 * 60 * 60 * 1000).toUTCString();
+    expect(outcomeFromResponse(res429(farFuture)).retryAfterMs).toBe(MAX_RETRY_AFTER_MS);
+  });
+
+  it('HTTP-date form in the past → retryAfterMs undefined', () => {
+    const past = new Date(Date.now() - 10_000).toUTCString();
+    expect(outcomeFromResponse(res429(past)).retryAfterMs).toBeUndefined();
   });
 });
 

--- a/src/main/integrations/delivery-queue.test.ts
+++ b/src/main/integrations/delivery-queue.test.ts
@@ -114,6 +114,30 @@ describe('DeliveryQueue', () => {
     q.dispose();
   });
 
+  it('clamps an out-of-range retryAfterMs instead of scheduling a runaway reschedule loop (#144)', async () => {
+    let attempts = 0;
+    const outcomes: SendOutcome[] = [
+      { ok: false, retryable: true, retryAfterMs: 9_999_999_999_000, error: '429' }, // ~317 years, unclamped would overflow setTimeout
+      { ok: true },
+    ];
+    const q = new DeliveryQueue({
+      send: async () => { attempts++; return outcomes.shift()!; },
+    });
+    q.enqueue('webhook', msg('x'));
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(attempts).toBe(1);
+
+    // Well below the clamp ceiling (120_000ms): must not have retried yet — proves the queue
+    // isn't honoring the raw out-of-range value (which Node would silently floor to ~1ms).
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(attempts).toBe(1);
+
+    // Past the clamp ceiling: the retry fires exactly once, on schedule — not a busy-spin.
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(attempts).toBe(2);
+    q.dispose();
+  });
+
   it('a throwing send() is treated as a retryable failure, never escapes enqueue', async () => {
     let attempts = 0;
     const q = new DeliveryQueue({

--- a/src/main/integrations/delivery-queue.ts
+++ b/src/main/integrations/delivery-queue.ts
@@ -31,6 +31,15 @@ export interface DeliveryQueueOptions {
 
 const BACKOFF_MS = [2_000, 8_000, 32_000];
 
+/**
+ * Defensive independent ceiling on any scheduled retry delay. connector.ts already clamps
+ * retryAfterMs at the parse boundary, but this queue must not trust that a SendOutcome always
+ * came from there — an out-of-range delay feeding straight into setTimeout is silently clamped
+ * by Node to ~1ms above ~24.85 days (2^31 - 1 ms), which turns into an unbroken reschedule loop
+ * on this lane. Kept equal to connector.ts's MAX_RETRY_AFTER_MS so behavior is consistent.
+ */
+const MAX_RETRY_DELAY_MS = 120_000;
+
 export class DeliveryQueue {
   private readonly opts: Required<Pick<DeliveryQueueOptions, 'ratePerMinute' | 'maxQueue' | 'maxRetries'>> &
     Pick<DeliveryQueueOptions, 'send' | 'onStatus'>;
@@ -129,7 +138,7 @@ export class DeliveryQueue {
       this.opts.onStatus?.({ connectorId: id, ok: true, at: Date.now() });
     } else if (outcome.retryable && item.attempts < this.opts.maxRetries) {
       const backoff = BACKOFF_MS[Math.min(item.attempts, BACKOFF_MS.length - 1)];
-      const delay = outcome.retryAfterMs ?? backoff;
+      const delay = Math.min(outcome.retryAfterMs ?? backoff, MAX_RETRY_DELAY_MS);
       lane.queue.unshift({ ...item, attempts: item.attempts + 1, notBefore: Date.now() + delay });
     } else {
       this.opts.onStatus?.({ connectorId: id, ok: false, error: outcome.error, at: Date.now() });


### PR DESCRIPTION
## Summary

Closes #144.

`outcomeFromResponse` parsed the `Retry-After` 429 response header with a
naive `Number(retryAfter) * 1000` and passed the result straight through to
`DeliveryQueue`'s `setTimeout`-based retry scheduler with no upper bound.

Two defects fixed:

1. **Reliability — runaway reschedule loop.** An out-of-range numeric
   `Retry-After` (e.g. `9999999999` ≈ 317 years) survived `Number.isFinite`
   and produced a multi-decade `retryAfterMs`. Node's `setTimeout` silently
   clamps any delay above `2^31 - 1` ms (~24.85 days) down to ~1ms, so the
   queue would fire almost immediately, find the item still not eligible
   (`notBefore` is still decades away), recompute the same huge delay, and
   reschedule — an unbroken ~1ms busy loop pinning a CPU core. Since
   `WebhookConnector` posts to an arbitrary user-configured URL, a
   misconfigured or hostile endpoint could trigger this on the user's
   machine.
2. **Correctness — HTTP-date form dropped.** RFC 7231 allows `Retry-After`
   as either delta-seconds or an HTTP-date. `Number("Wed, 21 Oct ...")` is
   `NaN`, so the date form was silently discarded in favor of the default
   backoff.

### Fix

- `connector.ts`: new `parseRetryAfterMs()` handles both delta-seconds and
  HTTP-date forms, rejects non-positive/invalid values (returns
  `undefined`, falling back to the queue's own backoff), and clamps to a
  new `MAX_RETRY_AFTER_MS = 120_000` (well above the queue's own backoff
  ceiling, far below Node's setTimeout limit).
- `delivery-queue.ts`: clamps `retryAfterMs` again at the consumer boundary
  (defense in depth) so the queue can't be driven into the same loop by any
  other `SendOutcome` producer, not just this connector.

### Tests added

- `connectors.test.ts`: `outcomeFromResponse` — Retry-After parsing (#144)
  — missing header, non-numeric/non-date, negative/zero, sane mid-range
  (regression guard), huge numeric (clamps, stays under 2^31-1), HTTP-date
  near-future, HTTP-date far-future (clamps), HTTP-date in the past.
- `delivery-queue.test.ts`: proves an out-of-range `retryAfterMs` is
  clamped to the ceiling rather than causing a runaway 1ms reschedule loop
  (asserts the retry does *not* fire before the clamp ceiling elapses, and
  fires exactly once after).

No new dependencies.

## Verification

- `npx tsc --noEmit` (both `tsconfig.json` and `tsconfig.main.json`): clean.
- Targeted: `npx vitest run --config vitest.workspace.ts --project main src/main/integrations/connectors.test.ts src/main/integrations/delivery-queue.test.ts` → 2 files, 31 tests passed.
- Full suite: `npm test` → 97 files, 1067 tests passed, no regressions.