### PR TITLE
fix(integrations): bound connector fetch calls with a timeout (#135)

### DIFF
--- a/src/main/integrations/connector.ts
+++ b/src/main/integrations/connector.ts
@@ -26,6 +26,18 @@ export interface IConnector<C = unknown> {
 export const MAX_RETRY_AFTER_MS = 120_000;
 
 /**
+ * Bound for every connector `fetch()` call (webhook posts and the Telegram getMe/sendMessage
+ * calls). `fetch()` has no default timeout, so a hung or blackholed endpoint — most likely for
+ * the generic WebhookConnector, which posts to an arbitrary user-configured URL — would never
+ * resolve or reject, leaving the DeliveryQueue's per-connector lane (`sending: boolean`) stuck
+ * `true` forever and silently stalling all future deliveries on that connector. Pass
+ * `signal: AbortSignal.timeout(CONNECTOR_FETCH_TIMEOUT_MS)` so a hang instead surfaces as an
+ * AbortError, which flows through the existing `outcomeFromNetworkError` catch path as a
+ * retryable failure.
+ */
+export const CONNECTOR_FETCH_TIMEOUT_MS = 10_000;
+
+/**
  * Parse a Retry-After header value (RFC 7231: either delta-seconds or an HTTP-date) into a
  * positive, clamped millisecond delay. Returns undefined for missing, non-numeric/non-date,
  * negative, zero, or past values so the caller falls back to its own backoff schedule.

--- a/src/main/integrations/connectors.test.ts
+++ b/src/main/integrations/connectors.test.ts
@@ -6,7 +6,7 @@ import { DiscordConnector } from './connectors/discord-connector';
 import { WebhookConnector } from './connectors/webhook-connector';
 import { ConnectorRegistry } from './connector-registry';
 import { formatSlack } from './message-format';
-import { outcomeFromResponse, MAX_RETRY_AFTER_MS } from './connector';
+import { outcomeFromResponse, MAX_RETRY_AFTER_MS, CONNECTOR_FETCH_TIMEOUT_MS } from './connector';
 import type { OutboundMessage } from '../../shared/integration-types';
 
 const msg: OutboundMessage = {
@@ -87,6 +87,29 @@ describe('TelegramConnector', () => {
     expect(c.isConfigured({ enabled: true, botToken: 't', chatId: '' })).toBe(false);
     expect(c.isConfigured({ enabled: true, botToken: 't', chatId: 'c' })).toBe(true);
   });
+
+  it('bounds sendMessage with an AbortSignal (#135)', async () => {
+    const fetchFn = mockFetch();
+    await new TelegramConnector().deliver({ enabled: true, botToken: 't', chatId: 'c' }, msg);
+    const [, init] = fetchFn.mock.calls[0];
+    expect(init.signal).toBeInstanceOf(AbortSignal);
+  });
+
+  it('bounds the test() getMe call with an AbortSignal (#135)', async () => {
+    const fetchFn = mockFetch();
+    await new TelegramConnector().test({ enabled: true, botToken: 't', chatId: 'c' });
+    const [, init] = fetchFn.mock.calls[0];
+    expect(init.signal).toBeInstanceOf(AbortSignal);
+  });
+
+  it('a hung endpoint that aborts maps to a retryable outcome instead of hanging forever (#135)', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockRejectedValue(new DOMException('The operation was aborted.', 'AbortError'))
+    );
+    const out = await new TelegramConnector().deliver({ enabled: true, botToken: 't', chatId: 'c' }, msg);
+    expect(out).toMatchObject({ ok: false, retryable: true });
+  });
 });
 
 describe('SlackConnector', () => {
@@ -115,6 +138,13 @@ describe('SlackConnector', () => {
     expect(body.text).toContain('&lt;Button&gt;');
     expect(body.text).toContain('A &amp; B');
     expect(body.text).not.toContain('<Button>');
+  });
+
+  it('bounds the webhook POST with an AbortSignal (#135)', async () => {
+    const fetchFn = mockFetch();
+    await new SlackConnector().deliver({ enabled: true, webhookUrl: 'https://hooks.slack.com/x' }, msg);
+    const [, init] = fetchFn.mock.calls[0];
+    expect(init.signal).toBeInstanceOf(AbortSignal);
   });
 });
 
@@ -148,6 +178,13 @@ describe('DiscordConnector', () => {
     expect(body.content.length).toBeLessThanOrEqual(2000);
     expect(body.content).toContain('truncated');
   });
+
+  it('bounds the webhook POST with an AbortSignal (#135)', async () => {
+    const fetchFn = mockFetch(204);
+    await new DiscordConnector().deliver({ enabled: true, webhookUrl: 'https://discord.com/api/webhooks/x' }, msg);
+    const [, init] = fetchFn.mock.calls[0];
+    expect(init.signal).toBeInstanceOf(AbortSignal);
+  });
 });
 
 describe('WebhookConnector', () => {
@@ -171,6 +208,22 @@ describe('WebhookConnector', () => {
 
   it('network failure maps to retryable', async () => {
     vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('ECONNREFUSED')));
+    const out = await new WebhookConnector().deliver({ enabled: true, url: 'https://example.com/hook' }, msg);
+    expect(out).toMatchObject({ ok: false, retryable: true });
+  });
+
+  it('bounds the POST with an AbortSignal so a hung URL cannot stall the connector (#135)', async () => {
+    const fetchFn = mockFetch();
+    await new WebhookConnector().deliver({ enabled: true, url: 'https://example.com/hook' }, msg);
+    const [, init] = fetchFn.mock.calls[0];
+    expect(init.signal).toBeInstanceOf(AbortSignal);
+  });
+
+  it('a hung endpoint that aborts maps to a retryable outcome instead of hanging forever (#135)', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockRejectedValue(new DOMException('The operation was aborted.', 'AbortError'))
+    );
     const out = await new WebhookConnector().deliver({ enabled: true, url: 'https://example.com/hook' }, msg);
     expect(out).toMatchObject({ ok: false, retryable: true });
   });
@@ -219,6 +272,13 @@ describe('outcomeFromResponse — Retry-After parsing (#144)', () => {
   it('HTTP-date form in the past → retryAfterMs undefined', () => {
     const past = new Date(Date.now() - 10_000).toUTCString();
     expect(outcomeFromResponse(res429(past)).retryAfterMs).toBeUndefined();
+  });
+});
+
+describe('CONNECTOR_FETCH_TIMEOUT_MS (#135)', () => {
+  it('is a sane, positive bound well under the queue backoff ceiling', () => {
+    expect(CONNECTOR_FETCH_TIMEOUT_MS).toBeGreaterThan(0);
+    expect(CONNECTOR_FETCH_TIMEOUT_MS).toBeLessThan(MAX_RETRY_AFTER_MS);
   });
 });
 

--- a/src/main/integrations/connectors/discord-connector.ts
+++ b/src/main/integrations/connectors/discord-connector.ts
@@ -1,5 +1,5 @@
 import type { ConnectorTestResult, DiscordConfig, OutboundMessage, SendOutcome } from '../../../shared/integration-types';
-import { IConnector, outcomeFromNetworkError, outcomeFromResponse } from '../connector';
+import { CONNECTOR_FETCH_TIMEOUT_MS, IConnector, outcomeFromNetworkError, outcomeFromResponse } from '../connector';
 import { truncatePlainText } from '../message-format';
 
 // Discord webhook `content` field hard limit — over this the API returns HTTP 400.
@@ -31,6 +31,7 @@ export class DiscordConnector implements IConnector<DiscordConfig> {
           content: truncatePlainText(msg.text, DISCORD_MAX_LENGTH),
           allowed_mentions: { parse: [] },
         }),
+        signal: AbortSignal.timeout(CONNECTOR_FETCH_TIMEOUT_MS),
       });
       return outcomeFromResponse(res);
     } catch (err) {

--- a/src/main/integrations/connectors/slack-connector.ts
+++ b/src/main/integrations/connectors/slack-connector.ts
@@ -1,5 +1,5 @@
 import type { ConnectorTestResult, OutboundMessage, SendOutcome, SlackConfig } from '../../../shared/integration-types';
-import { IConnector, outcomeFromNetworkError, outcomeFromResponse } from '../connector';
+import { CONNECTOR_FETCH_TIMEOUT_MS, IConnector, outcomeFromNetworkError, outcomeFromResponse } from '../connector';
 import { formatSlack } from '../message-format';
 
 export class SlackConnector implements IConnector<SlackConfig> {
@@ -25,6 +25,7 @@ export class SlackConnector implements IConnector<SlackConfig> {
         method: 'POST',
         headers: { 'content-type': 'application/json' },
         body: JSON.stringify({ text: formatSlack(msg.event) }),
+        signal: AbortSignal.timeout(CONNECTOR_FETCH_TIMEOUT_MS),
       });
       return outcomeFromResponse(res);
     } catch (err) {

--- a/src/main/integrations/connectors/telegram-connector.ts
+++ b/src/main/integrations/connectors/telegram-connector.ts
@@ -1,5 +1,5 @@
 import type { ConnectorTestResult, OutboundMessage, SendOutcome, TelegramConfig } from '../../../shared/integration-types';
-import { IConnector, outcomeFromNetworkError, outcomeFromResponse } from '../connector';
+import { CONNECTOR_FETCH_TIMEOUT_MS, IConnector, outcomeFromNetworkError, outcomeFromResponse } from '../connector';
 import { formatTelegramHTML, truncateHtmlByLines } from '../message-format';
 
 // Telegram sendMessage `text` field hard limit — over this the API returns HTTP 400.
@@ -16,7 +16,9 @@ export class TelegramConnector implements IConnector<TelegramConfig> {
   async test(cfg: TelegramConfig): Promise<ConnectorTestResult> {
     if (!this.isConfigured(cfg)) return { ok: false, error: 'Bot token and chat id are required' };
     try {
-      const me = await fetch(`https://api.telegram.org/bot${cfg.botToken}/getMe`);
+      const me = await fetch(`https://api.telegram.org/bot${cfg.botToken}/getMe`, {
+        signal: AbortSignal.timeout(CONNECTOR_FETCH_TIMEOUT_MS),
+      });
       if (!me.ok) return { ok: false, error: `getMe failed (HTTP ${me.status}) — check the bot token` };
       const send = await this.deliver(cfg, {
         text: 'OmniDesk test ping ✓',
@@ -39,6 +41,7 @@ export class TelegramConnector implements IConnector<TelegramConfig> {
           parse_mode: 'HTML',
           disable_web_page_preview: true,
         }),
+        signal: AbortSignal.timeout(CONNECTOR_FETCH_TIMEOUT_MS),
       });
       return outcomeFromResponse(res);
     } catch (err) {

--- a/src/main/integrations/connectors/webhook-connector.ts
+++ b/src/main/integrations/connectors/webhook-connector.ts
@@ -1,6 +1,6 @@
 import { createHmac } from 'crypto';
 import type { ConnectorTestResult, OutboundMessage, SendOutcome, WebhookConfig } from '../../../shared/integration-types';
-import { IConnector, outcomeFromNetworkError, outcomeFromResponse } from '../connector';
+import { CONNECTOR_FETCH_TIMEOUT_MS, IConnector, outcomeFromNetworkError, outcomeFromResponse } from '../connector';
 
 /** Generic webhook: POSTs the raw IntegrationEvent JSON — the escape hatch for
  * custom plumbing (n8n, Zapier, home-grown bots). */
@@ -31,7 +31,12 @@ export class WebhookConnector implements IConnector<WebhookConfig> {
       if (cfg.secret) {
         headers['x-omnidesk-signature'] = `sha256=${createHmac('sha256', cfg.secret).update(body).digest('hex')}`;
       }
-      const res = await fetch(cfg.url, { method: 'POST', headers, body });
+      const res = await fetch(cfg.url, {
+        method: 'POST',
+        headers,
+        body,
+        signal: AbortSignal.timeout(CONNECTOR_FETCH_TIMEOUT_MS),
+      });
       return outcomeFromResponse(res);
     } catch (err) {
       return outcomeFromNetworkError(err);


### PR DESCRIPTION
Closes #135

## Problem
`fetch()` has no default timeout. Every connector's `deliver()`/`test()` calls a bare `fetch()`, so a hung or blackholed endpoint never resolves or rejects. Worst case is `WebhookConnector`, which POSTs to an arbitrary user-configured URL. A stuck fetch leaves the `DeliveryQueue`'s per-connector `sending: boolean` lane stuck `true` forever, silently stalling all future deliveries on that connector.

## Fix
- Added `CONNECTOR_FETCH_TIMEOUT_MS = 10_000` in `src/main/integrations/connector.ts`, a single shared, documented constant (same pattern already used for `MAX_RETRY_AFTER_MS`).
- Passed `signal: AbortSignal.timeout(CONNECTOR_FETCH_TIMEOUT_MS)` to every connector `fetch()` call: Slack, Discord, Webhook, and both Telegram calls (`getMe` in `test()`, `sendMessage` in `deliver()`).
- A timeout now surfaces as an `AbortError`, which already flows through each connector's existing catch path (`outcomeFromNetworkError`, or Telegram's inline catch) as a `retryable: true` failure — no new error-handling branch needed.

## Scope
`src/main/integrations/delivery-queue.ts` is intentionally untouched. The issue calls a queue-level stall guard optional defense-in-depth, not required once every connector fetch is itself bounded — keeping this change minimal and focused on the actual failure point.

## Dependencies
None added. `AbortSignal.timeout()` is a native Node/Web API already used elsewhere in this codebase's runtime.

## Verification
- `npx tsc --noEmit -p tsconfig.main.json` — clean
- `npx tsc --noEmit -p tsconfig.json` — clean
- `npx vitest run --config vitest.workspace.ts --project main src/main/integrations/connectors.test.ts` — 30/30 passed (7 new, incl. one per connector asserting the fetch call receives an `AbortSignal`, plus abort-simulation tests confirming the outcome is `{ ok: false, retryable: true }` instead of hanging)
- Full unit suite: `npx vitest run --config vitest.workspace.ts --project shared --project main` — 58 files / 794 tests passed, no regressions