### PR TITLE
fix(quota): normalize burn-rate trend by elapsed time

### DIFF
--- a/src/main/quota-service.test.ts
+++ b/src/main/quota-service.test.ts
@@ -177,6 +177,40 @@ describe('buildBurnRateResult', () => {
       const result = buildBurnRateResult(0, 0, current, history);
       expect(result.trend).toBe('stable');
     });
+
+    it('reflects the real per-hour burn under non-uniform cadence instead of raw deltas', () => {
+      // Older pair ~3min apart: Δ5h=1.5 → 30%/hr.
+      // Recent pair ~15s apart (e.g. a session switch forced an uncached
+      // refresh): Δ5h=0.2 → 48%/hr — a HIGHER real burn rate.
+      // Raw-delta comparison would see 0.2 < 1.5 - 0.5 and wrongly report
+      // 'decreasing'; time-normalized rates correctly report 'increasing'.
+      const history = [
+        makeSample(10, 40, 4), // 4 min ago
+        makeSample(11.5, 40, 1), // 1 min ago (3 min after the previous sample)
+        makeSample(11.6, 40, 0.25), // 15s ago
+        makeSample(11.8, 40, 0), // now (15s after the previous sample)
+      ];
+      const current = history[3];
+      const result = buildBurnRateResult(0, 0, current, history);
+      expect(result.trend).toBe('increasing');
+    });
+
+    it('falls back to stable when adjacent samples share a timestamp (divide-by-zero guard)', () => {
+      const dupTimestamp = new Date(Date.now() - 5 * 60_000).toISOString();
+      const history = [
+        { timestamp: dupTimestamp, fiveHour: 10, sevenDay: 40 },
+        // Duplicate timestamp → olderDeltaMs is 0. Without a guard this
+        // divides by zero (Infinity), which would otherwise force the
+        // comparison below to report 'decreasing' regardless of the
+        // recent pair's real rate.
+        { timestamp: dupTimestamp, fiveHour: 15, sevenDay: 40 },
+        makeSample(20, 40, 2),
+        makeSample(25, 40, 1),
+      ];
+      const current = history[3];
+      const result = buildBurnRateResult(0, 0, current, history);
+      expect(result.trend).toBe('stable');
+    });
   });
 
   describe('7d projection fallback', () => {

--- a/src/main/quota-service.ts
+++ b/src/main/quota-service.ts
@@ -397,13 +397,34 @@ export function buildBurnRateResult(
     projectedMinutes7d = (remaining7d / estimated7dRate) * 60;
   }
 
-  // Determine trend from recent deltas
+  // Determine trend from time-normalized per-hour rates, not raw sample
+  // deltas — samples are not evenly spaced (a session switch can force an
+  // uncached refresh seconds after the last sample, while idle periods can
+  // leave gaps of many minutes), so comparing raw deltas mislabels the trend
+  // whenever cadence differs between the two pairs.
   let trend: BurnRateData['trend'] = 'stable';
   if (history.length >= 4) {
-    const recentRate = history[history.length - 1].fiveHour - history[history.length - 2].fiveHour;
-    const olderRate = history[history.length - 3].fiveHour - history[history.length - 4].fiveHour;
-    if (recentRate > olderRate + 0.5) trend = 'increasing';
-    else if (recentRate < olderRate - 0.5) trend = 'decreasing';
+    const recentDeltaMs =
+      new Date(history[history.length - 1].timestamp).getTime() -
+      new Date(history[history.length - 2].timestamp).getTime();
+    const olderDeltaMs =
+      new Date(history[history.length - 3].timestamp).getTime() -
+      new Date(history[history.length - 4].timestamp).getTime();
+    // Guard divide-by-zero / out-of-order timestamps — an indeterminate pair
+    // leaves the trend at the 'stable' default rather than risking NaN/Infinity.
+    if (recentDeltaMs > 0 && olderDeltaMs > 0) {
+      const recentRate =
+        (history[history.length - 1].fiveHour - history[history.length - 2].fiveHour) /
+        (recentDeltaMs / (1000 * 60 * 60));
+      const olderRate =
+        (history[history.length - 3].fiveHour - history[history.length - 4].fiveHour) /
+        (olderDeltaMs / (1000 * 60 * 60));
+      // Dead-band in percentage-points/hour (re-tuned from the old 0.5
+      // raw-delta threshold, which was only ever meaningful at the ~10min
+      // sample spacing used in tests: 0.5pp / (10min/60min) = 3pp/hr).
+      if (recentRate > olderRate + 3) trend = 'increasing';
+      else if (recentRate < olderRate - 3) trend = 'decreasing';
+    }
   }
 
   // Label based on projected time to limit (worst of both quotas)


### PR DESCRIPTION
Closes #141

## Problem
`buildBurnRateResult` in `src/main/quota-service.ts` classified the burn-rate trend (increasing/decreasing/stable) by comparing **raw** `fiveHour` percentage-point deltas between the last 4 samples, with no adjustment for elapsed time. Sample cadence isn't uniform — a session switch can force an uncached refresh seconds after the previous sample, while idle periods leave multi-minute gaps — so comparing raw deltas mislabels the trend whenever the recent pair's cadence differs from the older pair's.

Concretely: an older pair 3 minutes apart with Δ5h=1.5 (30%/hr) versus a recent pair 15s apart with Δ5h=0.2 (48%/hr — a *higher* real burn rate) would previously report 'decreasing' (0.2 < 1.5 - 0.5), when the real per-hour rate increased.

## Fix
- Normalize both the recent and older deltas to percentage-points/hour using the samples' timestamps before comparing.
- Guard divide-by-zero / duplicate-timestamp pairs (`recentDeltaMs > 0 && olderDeltaMs > 0`) — an indeterminate pair leaves `trend` at the `'stable'` default instead of risking `Infinity`/`NaN` forcing a spurious classification.
- Re-tuned the dead-band from 0.5 (raw delta) to 3.0 (per-hour rate) — the equivalent threshold at the existing tests' uniform 10-minute sample spacing (0.5pp / (10min/60min) = 3pp/hr), chosen so all pre-existing trend tests pass with their fixtures unchanged.

Only the trend block changed. `getBurnRate`'s 5h/7d rate math (already time-normalized) and the public `BurnRateData` shape are untouched, per the issue's scope.

## Tests
Added to `src/main/quota-service.test.ts`:
- `reflects the real per-hour burn under non-uniform cadence instead of raw deltas` — reproduces the exact scenario above, asserts `trend === 'increasing'` (the buggy code would report `'decreasing'`).
- `falls back to stable when adjacent samples share a timestamp (divide-by-zero guard)` — duplicate-timestamp older pair, asserts the guard prevents a spurious `'decreasing'` classification.

## Verification
- `npx vitest run --config vitest.workspace.ts --project main src/main/quota-service.test.ts` — 27/27 passed
- `npx tsc --noEmit -p tsconfig.json` and `-p tsconfig.main.json` — clean
- `npm test` (full workspace: shared + main + renderer) — 1071/1071 passed across 97 files

No new dependencies.