### PR TITLE
feat(palette): search sessions across all open repos

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -916,8 +916,9 @@ function App() {
       {showPalette && activeRepo && (
         <Palette
           repo={activeRepo}
+          repos={visibleRepos}
           sessions={sessions}
-          onPickSession={(id) => { handleSelectSession(id); setShowPalette(false); }}
+          onPickSession={(id) => { handleMobileSelectSession(id); setShowPalette(false); }}
           onClose={() => setShowPalette(false)}
           actions={paletteActions}
         />

--- a/src/renderer/components/shell/Palette.test.tsx
+++ b/src/renderer/components/shell/Palette.test.tsx
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { Palette } from './Palette';
+
+const repoA = { id: 'r1', name: 'demo', org: '', path: '/demo', workspacePath: '/demo', lastOpened: 0, color: 'neutral', isGit: true } as any;
+const repoB = { id: 'r2', name: 'api', org: '', path: '/api', workspacePath: '/api', lastOpened: 0, color: 'neutral', isGit: true } as any;
+
+const mk = () => ({
+  repo: repoA,
+  repos: [repoA, repoB],
+  sessions: [
+    { id: 's1', name: 'work', mainRepoPath: '/demo', workingDirectory: '/demo' },
+    { id: 's2', name: 'build', mainRepoPath: '/demo', workingDirectory: '/demo' },
+    { id: 's3', name: 'api-tests', mainRepoPath: '/api', workingDirectory: '/api' },
+  ] as any,
+  onPickSession: vi.fn(),
+  onClose: vi.fn(),
+  actions: [],
+});
+
+describe('Palette', () => {
+  it('shows only the active repo sessions when the query is empty', () => {
+    render(<Palette {...mk()} />);
+    expect(screen.getByText('work')).toBeInTheDocument();
+    expect(screen.getByText('build')).toBeInTheDocument();
+    expect(screen.queryByText('api-tests')).not.toBeInTheDocument();
+    expect(screen.getByText('Sessions in demo')).toBeInTheDocument();
+  });
+
+  it('surfaces a matching session from a non-active repo on a non-empty query', () => {
+    const p = mk();
+    render(<Palette {...p} />);
+    fireEvent.change(screen.getByPlaceholderText(/search sessions/i), { target: { value: 'api-tests' } });
+    expect(screen.getByText('api-tests')).toBeInTheDocument();
+    expect(screen.getByText('api')).toBeInTheDocument(); // non-active repo's group header is just the repo name
+    fireEvent.click(screen.getByText('api-tests'));
+    expect(p.onPickSession).toHaveBeenCalledWith('s3');
+  });
+
+  it('groups the active repo first when a query matches sessions in multiple repos', () => {
+    render(<Palette {...mk()} />);
+    fireEvent.change(screen.getByPlaceholderText(/search sessions/i), { target: { value: '' } });
+    fireEvent.change(screen.getByPlaceholderText(/search sessions/i), { target: { value: 'build' } });
+    // 'build' only matches the active repo's session in this fixture; assert the
+    // active-repo group heading still renders as expected on a non-empty query.
+    expect(screen.getByText('Sessions in demo')).toBeInTheDocument();
+  });
+
+  it('selects a cross-repo match via keyboard (ArrowDown + Enter)', () => {
+    const p = mk();
+    render(<Palette {...p} />);
+    const input = screen.getByPlaceholderText(/search sessions/i);
+    fireEvent.change(input, { target: { value: 'api-tests' } });
+    fireEvent.keyDown(input, { key: 'ArrowDown' });
+    fireEvent.keyDown(input, { key: 'Enter' });
+    expect(p.onPickSession).toHaveBeenCalledWith('s3');
+  });
+
+  it('falls back to only the active repo when repos prop is omitted', () => {
+    const p = mk();
+    (p as any).repos = undefined;
+    render(<Palette {...p} />);
+    fireEvent.change(screen.getByPlaceholderText(/search sessions/i), { target: { value: 'api-tests' } });
+    expect(screen.queryByText('api-tests')).not.toBeInTheDocument();
+  });
+
+  it('closes on Escape', () => {
+    const p = mk();
+    render(<Palette {...p} />);
+    fireEvent.keyDown(screen.getByPlaceholderText(/search sessions/i), { key: 'Escape' });
+    expect(p.onClose).toHaveBeenCalled();
+  });
+});

--- a/src/renderer/components/shell/Palette.tsx
+++ b/src/renderer/components/shell/Palette.tsx
@@ -25,6 +25,15 @@ interface PaletteProps {
   onPickSession: (id: string) => void;
   onClose: () => void;
   actions: PaletteAction[];
+  // All open repos, for cross-repo search on a non-empty query (#148). Optional
+  // and defaults to just `repo` — an empty query always shows only `repo`'s
+  // sessions, unchanged from before this prop existed.
+  repos?: Repo[];
+}
+
+interface SessionGroup {
+  repo: Repo;
+  sessions: TabData[];
 }
 
 export function Palette({
@@ -33,6 +42,7 @@ export function Palette({
   onPickSession,
   onClose,
   actions,
+  repos,
 }: PaletteProps) {
   const [q, setQ] = useState('');
   const [sel, setSel] = useState(0);
@@ -44,18 +54,43 @@ export function Palette({
 
   const results = useMemo(() => {
     const needle = q.toLowerCase();
-    const filteredSessions = needle
-      ? repoSessions.filter(s =>
-          s.name.toLowerCase().includes(needle) ||
-          (s.worktreeBranch?.toLowerCase().includes(needle) ?? false))
-      : repoSessions;
     const filteredActions = needle
       ? actions.filter(a => a.title.toLowerCase().includes(needle))
       : actions;
-    return { actions: filteredActions, sessions: filteredSessions };
-  }, [q, repoSessions, actions]);
 
-  const total = results.actions.length + results.sessions.length;
+    if (!needle) {
+      // Empty query: unchanged behavior — only the active repo's sessions.
+      const groups: SessionGroup[] = repoSessions.length > 0 ? [{ repo, sessions: repoSessions }] : [];
+      return { actions: filteredActions, groups, flatSessions: repoSessions };
+    }
+
+    const matches = (s: TabData) =>
+      s.name.toLowerCase().includes(needle) ||
+      (s.worktreeBranch?.toLowerCase().includes(needle) ?? false);
+
+    // Cross-repo search: group matches by owning repo, active repo's group
+    // first, then the rest in `repos` order. Claim-as-we-go dedups a session
+    // that could otherwise match more than one repo's path convention (see
+    // MobileDrawer's grouping for the same pattern).
+    const searchRepos = repos && repos.length > 0 ? repos : [repo];
+    const orderedRepos = [
+      repo,
+      ...searchRepos.filter(r => r.id !== repo.id),
+    ];
+    const claimed = new Set<string>();
+    const groups: SessionGroup[] = [];
+    for (const r of orderedRepos) {
+      const repoMatches = sessionsForRepo(r, sessions)
+        .filter(s => !claimed.has(s.id) && matches(s));
+      if (repoMatches.length === 0) continue;
+      repoMatches.forEach(s => claimed.add(s.id));
+      groups.push({ repo: r, sessions: repoMatches });
+    }
+    const flatSessions = groups.flatMap(g => g.sessions);
+    return { actions: filteredActions, groups, flatSessions };
+  }, [q, repo, repoSessions, sessions, repos, actions]);
+
+  const total = results.actions.length + results.flatSessions.length;
   useEffect(() => { setSel(0); }, [q]);
 
   const handleKey = (e: React.KeyboardEvent<HTMLInputElement>) => {
@@ -65,7 +100,7 @@ export function Palette({
       if (sel < results.actions.length) {
         results.actions[sel]?.run();
       } else {
-        const s = results.sessions[sel - results.actions.length];
+        const s = results.flatSessions[sel - results.actions.length];
         if (s) onPickSession(s.id);
       }
       e.preventDefault();
@@ -123,58 +158,65 @@ export function Palette({
             </>
           )}
 
-          {results.sessions.length > 0 && (
-            <>
-              <div className="p4-palette-group">Sessions in {repo.name}</div>
-              {results.sessions.map((s, i) => {
-                const idx = results.actions.length + i;
-                const status = mapTabStatus(s);
-                const meta = STATUS_META[status];
-                const color: RepoColor = status === 'errored' ? 'error' :
-                                          status === 'live' ? 'accent' :
-                                          status === 'idle' ? 'neutral' : 'info';
-                return (
-                  <button
-                    key={s.id}
-                    type="button"
-                    className={'p4-palette-row' + (sel === idx ? ' on' : '')}
-                    onClick={() => onPickSession(s.id)}
-                    onMouseEnter={() => setSel(idx)}
-                    style={{
-                      width: '100%', border: 0, background: 'transparent',
-                      color: 'inherit', font: 'inherit', textAlign: 'left',
-                    }}
-                  >
-                    <span style={{
-                      width: 20, height: 20, borderRadius: 5,
-                      background: colorBg(color), color: colorFg(color),
-                      display: 'grid', placeItems: 'center',
-                      fontFamily: 'var(--font-mono)', fontSize: 10, fontWeight: 700,
-                      flexShrink: 0,
-                    }}>{initials(s.name)}</span>
-                    <div style={{ flex: 1, marginLeft: 2 }}>
-                      <div className="txt">{s.name}</div>
-                      <div className="sub">
-                        {agentLetter(s.providerId)}{s.worktreeBranch ? ` · ${s.worktreeBranch}` : ''}
-                      </div>
-                    </div>
-                    <span
-                      className={'p4-chip ' + (meta.chip || '')}
+          {results.groups.map((group, gi) => {
+            // Index offset of this group's first session within the flattened
+            // keyboard-nav list (actions, then each group's sessions in order).
+            const priorSessions = results.groups.slice(0, gi).reduce((n, g) => n + g.sessions.length, 0);
+            return (
+              <div key={group.repo.id || 'active'} className="p4-palette-group-block">
+                <div className="p4-palette-group">
+                  {group.repo.id === repo.id ? `Sessions in ${group.repo.name}` : group.repo.name}
+                </div>
+                {group.sessions.map((s, i) => {
+                  const idx = results.actions.length + priorSessions + i;
+                  const status = mapTabStatus(s);
+                  const meta = STATUS_META[status];
+                  const color: RepoColor = status === 'errored' ? 'error' :
+                                            status === 'live' ? 'accent' :
+                                            status === 'idle' ? 'neutral' : 'info';
+                  return (
+                    <button
+                      key={s.id}
+                      type="button"
+                      className={'p4-palette-row' + (sel === idx ? ' on' : '')}
+                      onClick={() => onPickSession(s.id)}
+                      onMouseEnter={() => setSel(idx)}
                       style={{
-                        animation: meta.pulse ? 'p4-pulse 1.6s var(--ease-in-out) infinite' : undefined,
+                        width: '100%', border: 0, background: 'transparent',
+                        color: 'inherit', font: 'inherit', textAlign: 'left',
                       }}
                     >
                       <span style={{
-                        width: 6, height: 6, borderRadius: '50%',
-                        background: meta.color, display: 'inline-block',
-                      }} />
-                      {meta.label}
-                    </span>
-                  </button>
-                );
-              })}
-            </>
-          )}
+                        width: 20, height: 20, borderRadius: 5,
+                        background: colorBg(color), color: colorFg(color),
+                        display: 'grid', placeItems: 'center',
+                        fontFamily: 'var(--font-mono)', fontSize: 10, fontWeight: 700,
+                        flexShrink: 0,
+                      }}>{initials(s.name)}</span>
+                      <div style={{ flex: 1, marginLeft: 2 }}>
+                        <div className="txt">{s.name}</div>
+                        <div className="sub">
+                          {agentLetter(s.providerId)}{s.worktreeBranch ? ` · ${s.worktreeBranch}` : ''}
+                        </div>
+                      </div>
+                      <span
+                        className={'p4-chip ' + (meta.chip || '')}
+                        style={{
+                          animation: meta.pulse ? 'p4-pulse 1.6s var(--ease-in-out) infinite' : undefined,
+                        }}
+                      >
+                        <span style={{
+                          width: 6, height: 6, borderRadius: '50%',
+                          background: meta.color, display: 'inline-block',
+                        }} />
+                        {meta.label}
+                      </span>
+                    </button>
+                  );
+                })}
+              </div>
+            );
+          })}
 
           {total === 0 && (
             <div style={{


### PR DESCRIPTION
## Summary

Cmd+K (`Palette`) previously only searched sessions in the active repo,
even when a query was typed. This closes #148: a non-empty query now
searches every visible open repo, not just the active one.

## Changes

- `Palette.tsx`: results are now grouped per-repo (`SessionGroup[]`)
  instead of a single flat list. On empty query, behavior is unchanged
  (only the active repo's sessions, single implicit group). On
  non-empty query, every repo passed via the new optional `repos` prop
  is searched; matches are grouped by owning repo with the **active
  repo's group rendered first**, followed by other repos in `repos`
  order. Dedup uses the same "claim-as-you-go" `Set` pattern already
  used in `MobileDrawer.tsx`, since `sessionsForRepo` path-matching can
  otherwise match a session under more than one repo.
  - Keyboard nav (`sel`/`total`/arrow keys/Enter) now walks a flattened
    `flatSessions` list built from the ordered groups, so index math
    still lines up with what's rendered.
  - `repos` is optional and defaults to `[repo]` when omitted, so any
    caller not passing it keeps the old single-repo-only behavior.
- `App.tsx`: the desktop `<Palette>` call site now passes
  `repos={visibleRepos}` and swaps `onPickSession` to call the existing
  `handleMobileSelectSession` (previously `handleSelectSession`).
  `handleMobileSelectSession` already knows how to switch the active
  repo/group before focusing a session belonging elsewhere — this
  satisfies the issue's requirement to reuse existing selection
  semantics rather than adding new logic. The secondary "no active
  repo" empty-state `<Palette>` render is untouched (it has no real
  sessions regardless).
- `Palette.test.tsx`: new file (none existed before). Covers: empty
  query stays scoped to the active repo; a query matching a session in
  a non-active repo surfaces it under that repo's own group heading and
  clicking it calls `onPickSession` with the right id; the same via
  keyboard (arrow + Enter); active-repo group still renders first when
  a query matches; `repos` omitted falls back to active-repo-only
  search; Escape still closes.

## Out of scope

Per the issue: no fuzzy/scored matching, no searching of repos that
aren't currently open/visible. Issue #148 also noted overlap with
sibling issue #142 (adds a "No results" empty state + subtitle search
to the same file, and would have added the first test file). Since
`Palette.test.tsx` doesn't exist elsewhere yet, this PR creates it —
whoever lands second between #142 and this should expect a small
rebase, but there's no behavioral conflict.

## Verification

- `npx tsc --noEmit -p tsconfig.json` — clean
- `npx tsc --noEmit -p tsconfig.main.json` — clean
- `npx vitest run --config vitest.workspace.ts --project renderer src/renderer/components/shell/Palette.test.tsx` — 6/6 passed
- `npm test` (full suite, all projects) — 98 files / 1075 tests passed, no regressions

Closes #148