### PR TITLE
fix(previews): collapse \r progress-bar frames in useSessionPreviews

### DIFF
--- a/src/renderer/hooks/useSessionPreviews.test.ts
+++ b/src/renderer/hooks/useSessionPreviews.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useSessionPreviews } from './useSessionPreviews';
+
+/** Minimal fake onOutput registrar mimicking the real IPC subscription shape. */
+function makeEmitter() {
+  let cb: ((sessionId: string, data: string) => void) | null = null;
+  return {
+    onOutput: (callback: (sessionId: string, data: string) => void) => {
+      cb = callback;
+      return () => {
+        cb = null;
+      };
+    },
+    emit: (sessionId: string, data: string) => cb?.(sessionId, data),
+  };
+}
+
+describe('useSessionPreviews', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('collapses a \\r-driven progress bar to its last frame', () => {
+    const { result } = renderHook(() => useSessionPreviews());
+    const emitter = makeEmitter();
+    act(() => {
+      result.current.attach(emitter.onOutput);
+    });
+
+    act(() => {
+      emitter.emit('s1', 'Progress 1%\rProgress 50%\rProgress 100%\n');
+    });
+    act(() => {
+      vi.advanceTimersByTime(200);
+    });
+
+    expect(result.current.outputSnapshots.s1).toEqual(['Progress 100%']);
+  });
+
+  it('collapses a progress bar whose frames arrive across separate writes', () => {
+    const { result } = renderHook(() => useSessionPreviews());
+    const emitter = makeEmitter();
+    act(() => {
+      result.current.attach(emitter.onOutput);
+    });
+
+    act(() => {
+      emitter.emit('s1', 'Progress 1%\r');
+      emitter.emit('s1', 'Progress 50%\r');
+      emitter.emit('s1', 'Progress 100%\n');
+    });
+    act(() => {
+      vi.advanceTimersByTime(200);
+    });
+
+    expect(result.current.outputSnapshots.s1).toEqual(['Progress 100%']);
+  });
+
+  it('caps the carried partial line so a redraw-only stream cannot grow unbounded', () => {
+    const { result } = renderHook(() => useSessionPreviews());
+    const emitter = makeEmitter();
+    act(() => {
+      result.current.attach(emitter.onOutput);
+    });
+
+    // No \n at all - a spinner that keeps redrawing without ever terminating
+    // the line. Send several writes, none of which flush a completed line,
+    // and confirm the internal carry doesn't grow proportionally with the
+    // amount of data seen: flush a final \n and check the surfaced line is
+    // bounded by the cap rather than the full accumulated history.
+    act(() => {
+      for (let i = 0; i < 50; i++) {
+        emitter.emit('s1', `frame-${i}-`.repeat(200)); // long junk with no \r or \n
+      }
+      emitter.emit('s1', '\n');
+    });
+    act(() => {
+      vi.advanceTimersByTime(200);
+    });
+
+    const lines = result.current.outputSnapshots.s1;
+    expect(lines).toHaveLength(1);
+    expect(lines[0].length).toBeLessThanOrEqual(4096);
+  });
+
+  it('leaves normal multi-line \\n output unchanged and keeps only the last MAX_LINES', () => {
+    const { result } = renderHook(() => useSessionPreviews());
+    const emitter = makeEmitter();
+    act(() => {
+      result.current.attach(emitter.onOutput);
+    });
+
+    act(() => {
+      const lines = Array.from({ length: 10 }, (_, i) => `line ${i}`).join('\n') + '\n';
+      emitter.emit('s1', lines);
+    });
+    act(() => {
+      vi.advanceTimersByTime(200);
+    });
+
+    expect(result.current.outputSnapshots.s1).toEqual([
+      'line 2', 'line 3', 'line 4', 'line 5', 'line 6', 'line 7', 'line 8', 'line 9',
+    ]);
+  });
+
+  it('throttles state updates to a single flush per 200ms window and updates lastActivityAt', () => {
+    const { result } = renderHook(() => useSessionPreviews());
+    const emitter = makeEmitter();
+    act(() => {
+      result.current.attach(emitter.onOutput);
+    });
+
+    act(() => {
+      emitter.emit('s1', 'a\n');
+    });
+    // Not flushed yet - throttle window hasn't elapsed.
+    expect(result.current.outputSnapshots.s1).toBeUndefined();
+
+    act(() => {
+      emitter.emit('s1', 'b\n');
+      vi.advanceTimersByTime(200);
+    });
+
+    expect(result.current.outputSnapshots.s1).toEqual(['a', 'b']);
+    expect(result.current.lastActivityAt.s1).toBeGreaterThan(0);
+  });
+});

--- a/src/renderer/hooks/useSessionPreviews.ts
+++ b/src/renderer/hooks/useSessionPreviews.ts
@@ -1,10 +1,27 @@
 // useSessionPreviews — capture the last N lines of stdout per session
 // for the Grid tiles. Strips ANSI escape sequences. Tracks last-activity
 // timestamp per session as a side effect.
+//
+// Carriage-return handling: a lone \r (not part of a \r\n line ending) means
+// "move cursor to column 0 and overwrite" — the classic progress-bar redraw.
+// We normalize \r\n to \n (real line endings) up front, then collapse any
+// remaining \r within a line down to the text after the last \r, so a
+// progress bar that redraws in place collapses to its final frame instead of
+// leaking every intermediate frame as its own preview line.
 import { useEffect, useRef, useState, useCallback } from 'react';
-import { stripAnsi } from '../../shared/ansi-strip';
+import { stripAnsiCodes } from '../../shared/ansi-strip';
 
 const MAX_LINES = 8;
+// Defense-in-depth cap on the carried (not-yet-newline-terminated) partial
+// line, in case a session emits an unbounded stream of \r-redraws with no
+// \n and no \r (e.g. a hung spinner with no terminator).
+const CARRY_LIMIT = 4096;
+
+/** Keep only the text after the last \r in a line — the final overwrite. */
+function collapseCR(segment: string): string {
+  const idx = segment.lastIndexOf('\r');
+  return idx === -1 ? segment : segment.slice(idx + 1);
+}
 
 export interface SessionPreviewsApi {
   outputSnapshots: Record<string, string[]>;
@@ -55,10 +72,13 @@ export function useSessionPreviews(): SessionPreviewsApi {
 
   const ingest = useCallback((sessionId: string, data: string) => {
     const carry = carryRef.current.get(sessionId) ?? '';
-    const combined = carry + stripAnsi(data);
+    const combined = (carry + stripAnsiCodes(data)).replace(/\r\n/g, '\n');
     const segments = combined.split('\n');
     const next = segments.slice(0, -1);
-    const remainder = segments[segments.length - 1] ?? '';
+    let remainder = collapseCR(segments[segments.length - 1] ?? '');
+    if (remainder.length > CARRY_LIMIT) {
+      remainder = remainder.slice(remainder.length - CARRY_LIMIT);
+    }
     carryRef.current.set(sessionId, remainder);
 
     if (next.length === 0) {
@@ -69,7 +89,7 @@ export function useSessionPreviews(): SessionPreviewsApi {
 
     const buf = linesRef.current.get(sessionId) ?? [];
     for (const line of next) {
-      buf.push(line.trimEnd());
+      buf.push(collapseCR(line).trimEnd());
       if (buf.length > MAX_LINES) buf.shift();
     }
     linesRef.current.set(sessionId, buf);

--- a/src/shared/ansi-strip.test.ts
+++ b/src/shared/ansi-strip.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { stripAnsi } from './ansi-strip';
+import { stripAnsi, stripAnsiCodes } from './ansi-strip';
 
 describe('stripAnsi', () => {
   it('strips CSI color/SGR codes', () => {
@@ -36,5 +36,16 @@ describe('stripAnsi', () => {
 
   it('handles empty input', () => {
     expect(stripAnsi('')).toBe('');
+  });
+});
+
+describe('stripAnsiCodes', () => {
+  it('strips CSI/OSC sequences but leaves \\r and \\n untouched', () => {
+    const raw = '\x1b[31mline1\r\x1b[0mline2\r\nline3';
+    expect(stripAnsiCodes(raw)).toBe('line1\rline2\r\nline3');
+  });
+
+  it('passes plain text through unchanged', () => {
+    expect(stripAnsiCodes('hello world')).toBe('hello world');
   });
 });

--- a/src/shared/ansi-strip.ts
+++ b/src/shared/ansi-strip.ts
@@ -15,14 +15,26 @@ const ANSI_PATTERN = /[\u001b\u009b][[()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9
 const OSC_PATTERN = /\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)/g;
 
 /**
+ * Strips only ANSI CSI/OSC escape sequences, leaving \r and \n untouched.
+ * Callers that need to reason about carriage-return overwrite semantics
+ * (e.g. collapsing \r-driven progress-bar redraws) should use this instead
+ * of stripAnsi, which normalizes all line endings to \n.
+ * @param input - Raw terminal output with ANSI codes
+ * @returns Text with ANSI codes removed, \r/\n left as-is
+ */
+export function stripAnsiCodes(input: string): string {
+  return input
+    .replace(OSC_PATTERN, '') // Remove OSC sequences first
+    .replace(ANSI_PATTERN, ''); // Remove CSI sequences
+}
+
+/**
  * Strips ANSI escape codes from terminal output
  * @param input - Raw terminal output with ANSI codes
  * @returns Clean text with ANSI codes removed
  */
 export function stripAnsi(input: string): string {
-  return input
-    .replace(OSC_PATTERN, '') // Remove OSC sequences first
-    .replace(ANSI_PATTERN, '') // Remove CSI sequences
+  return stripAnsiCodes(input)
     .replace(/\r\n/g, '\n') // Normalize Windows line endings
     .replace(/\r/g, '\n'); // Convert remaining carriage returns
 }


### PR DESCRIPTION
Closes #154

## Problem
Session preview tiles render the last few lines of a session's stdout. When
a session prints a `\r`-driven progress bar (redraw-in-place), each
intermediate frame was being surfaced as its own preview line instead of
being collapsed to the final frame — producing a garbled tile full of
`Progress 1%` / `Progress 50%` / `Progress 100%` lines instead of just the
last one. This reproduces whether the frames arrive in a single write or
are split across multiple writes.

Note on the issue title ("unbounded carry growth"): PR #74 already
normalizes a lone `\r` → `\n` inside `stripAnsi()`, so pure unbounded growth
via `stripAnsi` is no longer reachable on `main`. The still-real bug is the
garbled-tile symptom described above, which is what this PR fixes. I also
kept the defense-in-depth carry cap since a redraw-only stream with no `\n`
and no `\r` (e.g. a spinner) can still accumulate without a terminator.

## Change
- Added `stripAnsiCodes()` to `src/shared/ansi-strip.ts` — strips only
  CSI/OSC escape sequences, leaving `\r`/`\n` untouched (existing
  `stripAnsi()` is unchanged and delegates to it, so all current callers
  keep byte-identical behavior).
- `useSessionPreviews.ts` now uses `stripAnsiCodes` and collapses each
  `\r`-delimited segment down to the text after its last `\r` before
  pushing it into the line buffer, so a redrawing progress bar collapses to
  its final frame. `\r\n` is normalized to `\n` first so real CRLF line
  endings aren't affected.
- Carried (not-yet-newline-terminated) partial line is capped at 4096
  chars as defense-in-depth against an unterminated redraw-only stream.
- Added `src/renderer/hooks/useSessionPreviews.test.ts` (new file) covering:
  single-chunk `\r` collapse, `\r` collapse across separate writes, the
  4096-char carry cap, unchanged normal multi-line `\n` output with
  `MAX_LINES=8` trimming, and the 200ms throttled flush + `lastActivityAt`
  update.
- Added two tests to `src/shared/ansi-strip.test.ts` for the new
  `stripAnsiCodes` export (CSI/OSC stripped, `\r`/`\n` left alone; plain
  text passthrough).

## Verification
- `npx tsc --noEmit` — clean, no errors.
- Targeted: `npx vitest run --config vitest.workspace.ts src/renderer/hooks/useSessionPreviews.test.ts src/shared/ansi-strip.test.ts` — 15/15 passed.
- Full suite: `npx vitest run --config vitest.workspace.ts` — 99 files / 1107 tests passed. (Some pre-existing, unrelated stderr noise from `App.test.tsx` / `pcm-recorder.test.ts` own error-handling assertions, not caused by this change.)

## Dependencies
None added.