### PR TITLE
fix(quota): guard useQuota against out-of-order fetch responses

### DIFF
--- a/src/renderer/hooks/useQuota.test.ts
+++ b/src/renderer/hooks/useQuota.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { getElectronAPI, resetElectronAPI } from '../../../test/helpers/electron-api-mock';
+import { useQuota } from './useQuota';
+import type { ClaudeUsageQuota, BurnRateData } from '../../shared/ipc-types';
+
+function makeQuota(overrides: Partial<ClaudeUsageQuota> = {}): ClaudeUsageQuota {
+  return {
+    five_hour: { utilization: 0.1, resets_at: '2026-01-01T00:00:00.000Z' },
+    seven_day: { utilization: 0.2, resets_at: '2026-01-07T00:00:00.000Z' },
+    lastUpdated: '2026-01-01T00:00:00.000Z',
+    ...overrides,
+  } as ClaudeUsageQuota;
+}
+
+function makeBurnRate(overrides: Partial<BurnRateData> = {}): BurnRateData {
+  return {
+    ratePerHour5h: 0.01,
+    ratePerHour7d: 0.001,
+    trend: 'stable',
+    projectedTimeToLimit5h: null,
+    projectedTimeToLimit7d: null,
+    label: 'on-track',
+    dataPoints: 1,
+    ...overrides,
+  } as BurnRateData;
+}
+
+/** Deferred promise helper so a test can control exactly when a fetch resolves. */
+function deferred<T>() {
+  let resolve!: (v: T) => void;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
+
+describe('useQuota', () => {
+  beforeEach(() => {
+    resetElectronAPI();
+  });
+
+  it('populates quota and burnRate from the initial fetch', async () => {
+    const api = getElectronAPI();
+    const quotaA = makeQuota({ five_hour: { utilization: 0.42, resets_at: '2026-01-01T00:00:00.000Z' } });
+    const burnA = makeBurnRate({ ratePerHour5h: 0.03 });
+    api.getQuota = vi.fn().mockResolvedValue(quotaA);
+    api.getBurnRate = vi.fn().mockResolvedValue(burnA);
+
+    const { result } = renderHook(() => useQuota(null));
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.quota).toEqual(quotaA);
+    expect(result.current.burnRate).toEqual(burnA);
+    expect(result.current.error).toBeNull();
+    expect(api.getQuota).toHaveBeenCalledTimes(1);
+  });
+
+  it('re-fetches via refreshQuota when the active session changes', async () => {
+    const api = getElectronAPI();
+    api.getQuota = vi.fn().mockResolvedValue(makeQuota());
+    api.refreshQuota = vi.fn().mockResolvedValue(
+      makeQuota({ five_hour: { utilization: 0.99, resets_at: '2026-01-01T00:00:00.000Z' } })
+    );
+    api.getBurnRate = vi.fn().mockResolvedValue(makeBurnRate());
+
+    const { result, rerender } = renderHook(({ sessionId }) => useQuota(sessionId), {
+      initialProps: { sessionId: 'session-a' as string | null },
+    });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(api.refreshQuota).not.toHaveBeenCalled();
+
+    rerender({ sessionId: 'session-b' });
+
+    await waitFor(() => expect(api.refreshQuota).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(result.current.quota?.five_hour.utilization).toBe(0.99));
+  });
+
+  it('drops an out-of-order response: a slower earlier fetch cannot overwrite a newer one', async () => {
+    const api = getElectronAPI();
+
+    const quotaA = deferred<ClaudeUsageQuota | null>();
+    const quotaB = deferred<ClaudeUsageQuota | null>();
+    const burnRate = makeBurnRate();
+
+    // First call (mount) returns the slow "A" promise, second call
+    // (forced session-switch refetch) returns the fast "B" promise.
+    api.getQuota = vi.fn().mockReturnValueOnce(quotaA.promise);
+    api.refreshQuota = vi.fn().mockReturnValueOnce(quotaB.promise);
+    api.getBurnRate = vi.fn().mockResolvedValue(burnRate);
+
+    const { result, rerender } = renderHook(({ sessionId }) => useQuota(sessionId), {
+      initialProps: { sessionId: 'session-a' as string | null },
+    });
+
+    // Mount fetch (A) is in flight. Now switch sessions to trigger a second,
+    // overlapping forced fetch (B) before A resolves.
+    rerender({ sessionId: 'session-b' });
+    await waitFor(() => expect(api.refreshQuota).toHaveBeenCalledTimes(1));
+
+    // B (the newer request) resolves first...
+    act(() => {
+      quotaB.resolve(makeQuota({ five_hour: { utilization: 0.77, resets_at: '2026-01-01T00:00:00.000Z' } }));
+    });
+    await waitFor(() => expect(result.current.quota?.five_hour.utilization).toBe(0.77));
+
+    // ...then A (the older, superseded request) resolves late. Without the
+    // request-id guard this would clobber B's already-committed result.
+    act(() => {
+      quotaA.resolve(makeQuota({ five_hour: { utilization: 0.11, resets_at: '2026-01-01T00:00:00.000Z' } }));
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(result.current.quota?.five_hour.utilization).toBe(0.77);
+  });
+
+  it('sets error and clears isLoading when the fetch rejects', async () => {
+    const api = getElectronAPI();
+    api.getQuota = vi.fn().mockRejectedValue(new Error('boom'));
+    api.getBurnRate = vi.fn().mockResolvedValue(makeBurnRate());
+
+    const { result } = renderHook(() => useQuota(null));
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.error).toBe('boom');
+  });
+});

--- a/src/renderer/hooks/useQuota.ts
+++ b/src/renderer/hooks/useQuota.ts
@@ -22,11 +22,21 @@ export function useQuota(activeSessionId?: string | null): UseQuotaReturn {
   const [error, setError] = useState<string | null>(null);
   const hasFetched = useRef(false);
 
+  // Monotonic request id. Only the fetch that currently owns the latest id
+  // may commit state - guards against three independent triggers (initial
+  // mount, session-change refetch, 3-min interval) resolving out of order,
+  // which would otherwise let a slower/earlier fetch overwrite a newer
+  // session's quota. Bumped on unmount too, so a late-resolving fetch can
+  // never setState after the hook is gone.
+  const fetchIdRef = useRef(0);
+
   const fetchQuota = useCallback(async (forceRefresh = false) => {
     if (!window.electronAPI) {
       setError('Electron API not available');
       return;
     }
+
+    const fetchId = ++fetchIdRef.current;
 
     try {
       setIsLoading(true);
@@ -41,6 +51,8 @@ export function useQuota(activeSessionId?: string | null): UseQuotaReturn {
         window.electronAPI.getBurnRate(),
       ]);
 
+      if (fetchId !== fetchIdRef.current) return; // superseded by a newer fetch - drop this result
+
       setQuota(quotaResult);
       setBurnRate(burnRateResult);
 
@@ -48,11 +60,23 @@ export function useQuota(activeSessionId?: string | null): UseQuotaReturn {
         setError('No quota data available - check Claude Code credentials');
       }
     } catch (err) {
+      if (fetchId !== fetchIdRef.current) return; // superseded - don't surface a stale error either
+
       console.error('Failed to fetch quota:', err);
       setError(err instanceof Error ? err.message : 'Failed to load quota data');
     } finally {
-      setIsLoading(false);
+      if (fetchId === fetchIdRef.current) {
+        setIsLoading(false);
+      }
     }
+  }, []);
+
+  // Invalidate any in-flight fetch on unmount so a late resolution can never
+  // commit state (setState-after-unmount) once this hook instance is gone.
+  useEffect(() => {
+    return () => {
+      fetchIdRef.current += 1;
+    };
   }, []);
 
   // Initial fetch


### PR DESCRIPTION
Closes #155

## Problem
`useQuota` has three independent triggers that call `fetchQuota`: initial mount, a forced refetch on session change, and a 3-minute auto-refresh interval. These can overlap and resolve out of order. Concretely: mount fires a fetch for session A, the user switches sessions before it resolves (firing a second, forced fetch for session B), and if A's slower response lands after B's, it silently overwrites B's already-committed quota with stale/wrong data. No test previously covered this hook at all.

## Fix
Added a monotonic `fetchIdRef` counter in `useQuota.ts`:
- `fetchQuota` captures `fetchId = ++fetchIdRef.current` before awaiting.
- After the `Promise.all` (and in the catch/finally paths), state is only committed if `fetchId === fetchIdRef.current` — i.e. only the most recently-issued fetch is allowed to write `quota`/`burnRate`/`error`/`isLoading`.
- The ref is also bumped in an unmount cleanup effect, so a fetch that resolves after the hook is torn down can never call `setState` on a gone component.

No behavior change for the non-racing case: initial fetch, the 3-min interval, and manual `refresh()` all work exactly as before.

## Tests
Added `src/renderer/hooks/useQuota.test.ts` (first test file for this hook), following the existing hook-test conventions in the repo (`useIntegrations.test.ts`, `useSessionPreviews.test.ts` — `renderHook`/`act`/`waitFor` + the shared `electron-api-mock` helper):
- initial fetch populates `quota`/`burnRate` and clears `isLoading`
- session change triggers a forced refetch via `refreshQuota`
- **regression case**: an older fetch (A) is still in flight when a newer one (B) is triggered by a session switch; B resolves first and commits, then A resolves late — asserts A's stale result is dropped and B's value is retained. This test fails against the pre-fix code (A would overwrite B) and passes against the fix.
- a rejected fetch sets `error` and clears `isLoading`

## Verification
- `npx tsc --noEmit -p tsconfig.json` — clean
- `npx tsc --noEmit -p tsconfig.main.json` — clean
- `npx vitest run --config vitest.workspace.ts src/renderer/hooks/useQuota.test.ts` — 4/4 new tests pass
- `npm test` (full suite) — 100 files / 1118 tests pass, no regressions

No new dependencies.