### PR TITLE
fix(security): drop file:// from openExternal allowed schemes

### DIFF
--- a/src/main/ipc-handlers.test.ts
+++ b/src/main/ipc-handlers.test.ts
@@ -7,7 +7,7 @@ import type { SessionMetadata } from '../shared/ipc-types';
 // Mock both so the test drives production code instead of a hand-copied
 // reimplementation of the handler's control flow.
 vi.mock('electron', () => ({
-  shell: { showItemInFolder: vi.fn() },
+  shell: { showItemInFolder: vi.fn(), openExternal: vi.fn() },
 }));
 
 vi.mock('fs', () => ({
@@ -97,6 +97,57 @@ describe('IPC Handlers - revealInExplorer', () => {
 
     expect(result).toBe(false);
     expect(shell.showItemInFolder).not.toHaveBeenCalled();
+  });
+});
+
+describe('IPC Handlers - openExternal', () => {
+  // openExternalUrl (extracted from the real openExternal registry handler)
+  // narrows the allowed-scheme check to http/https only — file:// and any
+  // other scheme (e.g. javascript:) must be rejected before shell.openExternal
+  // is ever called, matching Electron's guidance against passing untrusted
+  // schemes to shell.openExternal (issue #162).
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('opens an http:// URL and returns true', async () => {
+    const { openExternalUrl } = await import('./ipc-handlers');
+    const { shell } = await import('electron');
+
+    const result = await openExternalUrl('http://example.com');
+
+    expect(result).toBe(true);
+    expect(shell.openExternal).toHaveBeenCalledWith('http://example.com');
+  });
+
+  it('opens an https:// URL and returns true', async () => {
+    const { openExternalUrl } = await import('./ipc-handlers');
+    const { shell } = await import('electron');
+
+    const result = await openExternalUrl('https://example.com/pr/123');
+
+    expect(result).toBe(true);
+    expect(shell.openExternal).toHaveBeenCalledWith('https://example.com/pr/123');
+  });
+
+  it('blocks a file:// URL and does not call shell.openExternal', async () => {
+    const { openExternalUrl } = await import('./ipc-handlers');
+    const { shell } = await import('electron');
+
+    const result = await openExternalUrl('file:///C:/Windows/System32/calc.exe');
+
+    expect(result).toBe(false);
+    expect(shell.openExternal).not.toHaveBeenCalled();
+  });
+
+  it('blocks an arbitrary non-http scheme (e.g. javascript:) and does not call shell.openExternal', async () => {
+    const { openExternalUrl } = await import('./ipc-handlers');
+    const { shell } = await import('electron');
+
+    const result = await openExternalUrl('javascript:alert(1)');
+
+    expect(result).toBe(false);
+    expect(shell.openExternal).not.toHaveBeenCalled();
   });
 });
 

--- a/src/main/ipc-handlers.ts
+++ b/src/main/ipc-handlers.ts
@@ -80,6 +80,29 @@ export async function revealSessionInExplorer(
   }
 }
 
+/**
+ * Validates the scheme of a renderer-supplied URL and, if allowed, opens it
+ * via the OS's default handler. Extracted from the `openExternal` registry
+ * handler so it can be exercised directly in tests instead of via a
+ * hand-copied reimplementation.
+ *
+ * Only http/https are allowed. `file://` is intentionally rejected: unlike
+ * http/https, a `file://` URL asks the OS to open the target with its
+ * default handler, which can launch executables/scripts (Electron's security
+ * guidance warns against passing non-web schemes to shell.openExternal with
+ * untrusted input). Both current callers (Terminal clickable links, ShipIt's
+ * PR link) only ever pass http/https, so no caller needs `file://`.
+ */
+export async function openExternalUrl(url: string): Promise<boolean> {
+  const allowed = /^https?:\/\//i.test(url);
+  if (!allowed) {
+    console.warn('openExternal: blocked non-http/https URL:', url);
+    return false;
+  }
+  await shell.openExternal(url);
+  return true;
+}
+
 export function setupIPCHandlers(
   mainWindow: BrowserWindow,
   sessionManager: SessionManager,
@@ -827,14 +850,7 @@ export function setupIPCHandlers(
   // ── Shell ──
 
   registry.handle('openExternal', async (_e, url) => {
-    // Validate scheme before opening: only allow http, https, file
-    const allowed = /^(https?|file):\/\//i.test(url);
-    if (!allowed) {
-      console.warn('openExternal: blocked non-http/https/file URL:', url);
-      return false;
-    }
-    await shell.openExternal(url);
-    return true;
+    return openExternalUrl(url);
   });
 
   // ── Agent View availability ──


### PR DESCRIPTION
Closes #162

## What changed
The `openExternal` IPC handler previously allowed `http`, `https`, and `file` schemes before calling `shell.openExternal(url)`. `file://` is dropped from the allow-list: passing a `file://` URL to `shell.openExternal` asks the OS to open the target with its default handler, which can launch executables/scripts on the host if a malicious/compromised renderer ever supplied one. This is defense-in-depth, matching the same pattern as prior hardening work in this codebase (#116/#150/#152).

Both current callers only ever pass http/https already, so this is a pure hardening change with no behavior change for legitimate use:
- `Terminal.tsx` (WebLinksAddon clickable terminal links)
- `ShipItSheet.tsx` (PR link open)

## How
Extracted the validation+open logic out of the inline `registry.handle('openExternal', ...)` closure into a standalone exported `openExternalUrl(url): Promise<boolean>` function in `src/main/ipc-handlers.ts`, mirroring the existing `revealSessionInExplorer` extraction pattern already used in this file. The registry handler now just delegates to it. This lets the logic be unit tested directly instead of duplicating/reimplementing it in the test file.

Added 4 new tests in `src/main/ipc-handlers.test.ts` (`describe('IPC Handlers - openExternal', ...)`):
- allows `http://` URL, calls `shell.openExternal`
- allows `https://` URL, calls `shell.openExternal`
- blocks `file://` URL, does not call `shell.openExternal`
- blocks arbitrary scheme (`javascript:`), does not call `shell.openExternal`

No dependency changes.

## Verification
- `npx tsc --noEmit -p tsconfig.json` — clean
- `npx tsc --noEmit -p tsconfig.main.json` — clean
- `npx vitest run --config vitest.workspace.ts --project main src/main/ipc-handlers.test.ts` — 17/17 passed (13 pre-existing + 4 new)
- `npm test` (full suite) — 100 files / 1122 tests passed, zero regressions