### PR TITLE
fix(security): gate history export paths through isPathAllowed

### DIFF
--- a/src/main/ipc-handlers.test.ts
+++ b/src/main/ipc-handlers.test.ts
@@ -151,6 +151,139 @@ describe('IPC Handlers - openExternal', () => {
   });
 });
 
+describe('IPC Handlers - exportHistoryMarkdown / exportHistoryJson', () => {
+  // exportHistoryMarkdownGated/exportHistoryJsonGated (extracted from the real
+  // exportHistoryMarkdown/exportHistoryJson registry handlers) must gate
+  // outputPath through the same home/workspaces/approved-picked-root
+  // allowlist as writeFile/listSubdirectories/listGitRepos, rather than
+  // handing an arbitrary renderer-supplied path straight to HistoryManager
+  // (issue #163). isPathAllowedFn below is the real isPathAllowed from
+  // ./path-access, not a hand-copied reimplementation.
+  const homeDir = '/mock/home';
+  const workspaces = ['/mock/workspace'];
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('exportHistoryMarkdown blocks a path outside home/workspaces (forward slashes)', async () => {
+    const { exportHistoryMarkdownGated } = await import('./ipc-handlers');
+    const { isPathAllowed } = await import('./path-access');
+    const historyManager = { exportMarkdown: vi.fn() };
+    const isPathAllowedFn = (resolved: string) => isPathAllowed(resolved, homeDir, workspaces);
+
+    const result = await exportHistoryMarkdownGated(
+      historyManager as never,
+      isPathAllowedFn,
+      'session-1',
+      '/etc/passwd',
+    );
+
+    expect(result).toBe(false);
+    expect(historyManager.exportMarkdown).not.toHaveBeenCalled();
+  });
+
+  it('exportHistoryMarkdown blocks a path outside home/workspaces (Windows-style)', async () => {
+    const { exportHistoryMarkdownGated } = await import('./ipc-handlers');
+    const { isPathAllowed } = await import('./path-access');
+    const historyManager = { exportMarkdown: vi.fn() };
+    const isPathAllowedFn = (resolved: string) => isPathAllowed(resolved, homeDir, workspaces);
+
+    const result = await exportHistoryMarkdownGated(
+      historyManager as never,
+      isPathAllowedFn,
+      'session-1',
+      'C:\\Windows\\System32\\evil.md',
+    );
+
+    expect(result).toBe(false);
+    expect(historyManager.exportMarkdown).not.toHaveBeenCalled();
+  });
+
+  it('exportHistoryMarkdown exports when outputPath is under home', async () => {
+    const path = await import('path');
+    const { exportHistoryMarkdownGated } = await import('./ipc-handlers');
+    const { isPathAllowed } = await import('./path-access');
+    const historyManager = { exportMarkdown: vi.fn().mockResolvedValue(true) };
+    const isPathAllowedFn = (resolved: string) => isPathAllowed(resolved, homeDir, workspaces);
+    const inputPath = '/mock/home/exports/session-1.md';
+
+    const result = await exportHistoryMarkdownGated(
+      historyManager as never,
+      isPathAllowedFn,
+      'session-1',
+      inputPath,
+    );
+
+    expect(result).toBe(true);
+    // Compare against path.resolve() of the same input rather than a hardcoded
+    // literal — path.resolve() drive-letter-prefixes and backslash-separates
+    // Unix-style inputs when tests run on Windows.
+    expect(historyManager.exportMarkdown).toHaveBeenCalledWith(
+      'session-1',
+      path.resolve(inputPath),
+    );
+  });
+
+  it('exportHistoryJson blocks a path outside home/workspaces (forward slashes)', async () => {
+    const { exportHistoryJsonGated } = await import('./ipc-handlers');
+    const { isPathAllowed } = await import('./path-access');
+    const historyManager = { exportJson: vi.fn() };
+    const isPathAllowedFn = (resolved: string) => isPathAllowed(resolved, homeDir, workspaces);
+
+    const result = await exportHistoryJsonGated(
+      historyManager as never,
+      isPathAllowedFn,
+      'session-1',
+      '/etc/passwd',
+    );
+
+    expect(result).toBe(false);
+    expect(historyManager.exportJson).not.toHaveBeenCalled();
+  });
+
+  it('exportHistoryJson blocks a path outside home/workspaces (Windows-style)', async () => {
+    const { exportHistoryJsonGated } = await import('./ipc-handlers');
+    const { isPathAllowed } = await import('./path-access');
+    const historyManager = { exportJson: vi.fn() };
+    const isPathAllowedFn = (resolved: string) => isPathAllowed(resolved, homeDir, workspaces);
+
+    const result = await exportHistoryJsonGated(
+      historyManager as never,
+      isPathAllowedFn,
+      'session-1',
+      'C:\\Windows\\System32\\evil.json',
+    );
+
+    expect(result).toBe(false);
+    expect(historyManager.exportJson).not.toHaveBeenCalled();
+  });
+
+  it('exportHistoryJson exports when outputPath is under a registered workspace', async () => {
+    const path = await import('path');
+    const { exportHistoryJsonGated } = await import('./ipc-handlers');
+    const { isPathAllowed } = await import('./path-access');
+    const historyManager = { exportJson: vi.fn().mockResolvedValue(true) };
+    const isPathAllowedFn = (resolved: string) => isPathAllowed(resolved, homeDir, workspaces);
+    const inputPath = '/mock/workspace/exports/session-1.json';
+
+    const result = await exportHistoryJsonGated(
+      historyManager as never,
+      isPathAllowedFn,
+      'session-1',
+      inputPath,
+    );
+
+    expect(result).toBe(true);
+    // Compare against path.resolve() of the same input rather than a hardcoded
+    // literal — see the exportHistoryMarkdown "under home" test above.
+    expect(historyManager.exportJson).toHaveBeenCalledWith(
+      'session-1',
+      path.resolve(inputPath),
+    );
+  });
+});
+
 describe('IPC Handlers - getVersionInfo', () => {
   // Mirrors the handler body in ipc-handlers.ts: `(await probeClaudeVersion()) ?? undefined`,
   // combined with app.getVersion() and process.versions. probeClaudeVersion itself is

--- a/src/main/ipc-handlers.ts
+++ b/src/main/ipc-handlers.ts
@@ -103,6 +103,52 @@ export async function openExternalUrl(url: string): Promise<boolean> {
   return true;
 }
 
+/**
+ * Resolves and gates a renderer-supplied export outputPath through the
+ * home/workspaces/approved-picked-root allowlist (isPathAllowedFn) before
+ * delegating to HistoryManager, giving these handlers the same path parity
+ * as writeFile. Extracted from the exportHistoryMarkdown/exportHistoryJson
+ * registry handlers so the gating logic can be exercised directly in tests
+ * instead of a hand-copied reimplementation.
+ */
+export async function exportHistoryMarkdownGated(
+  historyManager: Pick<HistoryManager, 'exportMarkdown'>,
+  isPathAllowedFn: (resolved: string) => boolean,
+  sessionId: string,
+  outputPath: string,
+): Promise<boolean> {
+  const resolved = path.resolve(outputPath);
+  if (!isPathAllowedFn(resolved)) {
+    console.warn('[exportHistoryMarkdown] Blocked path outside home/workspaces:', resolved);
+    return false;
+  }
+  try {
+    return await historyManager.exportMarkdown(sessionId, resolved);
+  } catch (err) {
+    console.error('Failed to export markdown:', err);
+    return false;
+  }
+}
+
+export async function exportHistoryJsonGated(
+  historyManager: Pick<HistoryManager, 'exportJson'>,
+  isPathAllowedFn: (resolved: string) => boolean,
+  sessionId: string,
+  outputPath: string,
+): Promise<boolean> {
+  const resolved = path.resolve(outputPath);
+  if (!isPathAllowedFn(resolved)) {
+    console.warn('[exportHistoryJson] Blocked path outside home/workspaces:', resolved);
+    return false;
+  }
+  try {
+    return await historyManager.exportJson(sessionId, resolved);
+  } catch (err) {
+    console.error('Failed to export JSON:', err);
+    return false;
+  }
+}
+
 export function setupIPCHandlers(
   mainWindow: BrowserWindow,
   sessionManager: SessionManager,
@@ -514,13 +560,11 @@ export function setupIPCHandlers(
   });
 
   registry.handle('exportHistoryMarkdown', async (_e, sessionId, outputPath) => {
-    try { return await historyManager.exportMarkdown(sessionId, outputPath); }
-    catch (err) { console.error('Failed to export markdown:', err); return false; }
+    return exportHistoryMarkdownGated(historyManager, isPathAllowed, sessionId, outputPath);
   });
 
   registry.handle('exportHistoryJson', async (_e, sessionId, outputPath) => {
-    try { return await historyManager.exportJson(sessionId, outputPath); }
-    catch (err) { console.error('Failed to export JSON:', err); return false; }
+    return exportHistoryJsonGated(historyManager, isPathAllowed, sessionId, outputPath);
   });
 
   registry.handle('getHistorySettings', async () => historyManager.getSettings());


### PR DESCRIPTION
## Summary

`exportHistoryMarkdown`/`exportHistoryJson` handed the renderer-supplied `outputPath` straight to `HistoryManager`, unlike `writeFile`/`listSubdirectories`/`listGitRepos`, which resolve the path and check it against the home/workspaces/approved-picked-root allowlist first (`isPathAllowed`). Same defense-in-depth gap pattern as #115/#116/#150/#152/#162 — narrowing a renderer-influenced input to match the security posture already established for sibling handlers, even though the reachable-through-the-live-UI surface for this one is limited.

## Changes

- Extracted `exportHistoryMarkdownGated`/`exportHistoryJsonGated` in `src/main/ipc-handlers.ts`: each resolves `outputPath` via `path.resolve()`, checks it against `isPathAllowed`, and only then delegates to `HistoryManager`. Returns `false` (no write) when the path is outside the allowlist, mirroring `writeFile`'s existing pattern.
- The `exportHistoryMarkdown`/`exportHistoryJson` registry handlers now delegate to these extracted functions instead of calling `HistoryManager` directly.
- Added a new `describe` block in `ipc-handlers.test.ts` covering: blocked path outside home/workspaces (both forward-slash and Windows-style inputs) for both handlers, plus an allowed path under home / a registered workspace for each. Tests exercise the real `isPathAllowed` from `./path-access`, not a hand-copied reimplementation.

No new dependencies — reuses `path.resolve` and the existing `isPathAllowed` predicate already used by `writeFile`.

## Test plan

- [x] `npx tsc --noEmit -p tsconfig.json` — clean
- [x] `npx tsc --noEmit -p tsconfig.main.json` — clean
- [x] `npx vitest run --config vitest.workspace.ts src/main/ipc-handlers.test.ts` — 23/23 passed (6 new)
- [x] `npm test` — 101 files / 1131 tests passed, no regressions

Closes #163