### PR TITLE
test(git-manager): add unit tests for worktree path naming

### DIFF
--- a/src/main/git-manager.test.ts
+++ b/src/main/git-manager.test.ts
@@ -655,6 +655,93 @@ describe('GitManager', () => {
     });
   });
 
+  describe('worktree path naming', () => {
+    describe('sanitizeBranchNameForDir', () => {
+      it('replaces forward slashes with a dash', () => {
+        expect(manager.sanitizeBranchNameForDir('feature/foo')).toBe('feature-foo');
+      });
+
+      it('replaces backslashes with a dash', () => {
+        expect(manager.sanitizeBranchNameForDir('feature\\bar')).toBe('feature-bar');
+      });
+
+      it('neutralizes path traversal sequences (no ".." or separator survives)', () => {
+        const result = manager.sanitizeBranchNameForDir('../../etc');
+        expect(result).not.toContain('..');
+        expect(result).not.toMatch(/[/\\]/);
+      });
+
+      it('rewrites a leading dot to an underscore', () => {
+        expect(manager.sanitizeBranchNameForDir('.hidden')).toBe('_hidden');
+      });
+
+      it('rewrites a trailing ".lock" (case-insensitive)', () => {
+        expect(manager.sanitizeBranchNameForDir('HEAD.lock')).toBe('HEAD_lock');
+        expect(manager.sanitizeBranchNameForDir('HEAD.LOCK')).toBe('HEAD_lock');
+      });
+
+      it('strips git-invalid and whitespace characters, then collapses dashes', () => {
+        expect(manager.sanitizeBranchNameForDir('wip: fix? [x]')).toBe('wip-fix-x');
+      });
+
+      it('collapses repeated dashes produced by adjacent separators', () => {
+        expect(manager.sanitizeBranchNameForDir('a//b')).toBe('a-b');
+        expect(manager.sanitizeBranchNameForDir('a--b')).toBe('a-b');
+      });
+
+      it('trims leading and trailing dashes', () => {
+        expect(manager.sanitizeBranchNameForDir('-foo-')).toBe('foo');
+      });
+
+      it('caps the result at 100 characters', () => {
+        const longName = 'a'.repeat(120);
+        const result = manager.sanitizeBranchNameForDir(longName);
+        expect(result).toHaveLength(100);
+        expect(result).toBe('a'.repeat(100));
+      });
+
+      it('falls back to "worktree" when sanitizing yields an empty string', () => {
+        expect(manager.sanitizeBranchNameForDir('///')).toBe('worktree');
+      });
+    });
+
+    describe('computeWorktreePath', () => {
+      const mainRepoPath = path.join('some', 'nested', 'myrepo');
+      const repoName = path.basename(mainRepoPath);
+
+      it('sibling: joins <dirname(mainRepoPath)>/<repoName>-worktrees/<sanitized>', () => {
+        const settings = { basePath: 'sibling', cleanupOnSessionClose: 'ask' } as const;
+        const result = manager.computeWorktreePath(mainRepoPath, 'feature/x', settings);
+        expect(result).toBe(path.join(path.dirname(mainRepoPath), `${repoName}-worktrees`, 'feature-x'));
+      });
+
+      it('subdirectory: joins <mainRepoPath>/.worktrees/<sanitized>', () => {
+        const settings = { basePath: 'subdirectory', cleanupOnSessionClose: 'ask' } as const;
+        const result = manager.computeWorktreePath(mainRepoPath, 'feature/x', settings);
+        expect(result).toBe(path.join(mainRepoPath, '.worktrees', 'feature-x'));
+      });
+
+      it('custom with customBasePath: joins <customBasePath>/<sanitized>', () => {
+        const customBasePath = path.join('custom', 'base');
+        const settings = { basePath: 'custom', customBasePath, cleanupOnSessionClose: 'ask' } as const;
+        const result = manager.computeWorktreePath(mainRepoPath, 'feature/x', settings);
+        expect(result).toBe(path.join(customBasePath, 'feature-x'));
+      });
+
+      it('custom without customBasePath: falls back to the sibling-style default', () => {
+        const settings = { basePath: 'custom', cleanupOnSessionClose: 'ask' } as const;
+        const result = manager.computeWorktreePath(mainRepoPath, 'feature/x', settings);
+        expect(result).toBe(path.join(path.dirname(mainRepoPath), `${repoName}-worktrees`, 'feature-x'));
+      });
+
+      it('sanitizes the branch name before joining it into the path', () => {
+        const settings = { basePath: 'subdirectory', cleanupOnSessionClose: 'ask' } as const;
+        const result = manager.computeWorktreePath(mainRepoPath, 'wip: fix? [x]', settings);
+        expect(path.basename(result)).toBe('wip-fix-x');
+      });
+    });
+  });
+
   describe('destroy', () => {
     it('cleans up watchers and timers', () => {
       manager.destroy();


### PR DESCRIPTION
## Summary

Adds a `describe('worktree path naming')` block to `git-manager.test.ts` covering two previously-untested pure functions: `sanitizeBranchNameForDir` and `computeWorktreePath`. Both are pure (no fs/execGit involved), so no new mocking infrastructure was needed.

**`sanitizeBranchNameForDir`** (9 cases):
- slash/backslash replacement
- path-traversal neutralization (`../../etc` → no `..` or separators survive)
- leading-dot rewrite (`.hidden` → `_hidden`)
- trailing `.lock` rewrite, case-insensitive
- invalid-char stripping (`~^:?*[]@{}` + whitespace) with dash collapsing
- repeated/edge dash collapsing and trimming
- 100-char cap
- empty-string fallback to `'worktree'`

**`computeWorktreePath`** (5 cases):
- all four `basePath` modes: `sibling`, `subdirectory`, `custom` (with `customBasePath`), `custom` (falls back to sibling-style default when `customBasePath` is unset)
- confirms the branch name is sanitized before being joined into the path

Expected values for `computeWorktreePath` are computed via `path.join`/`path.dirname`/`path.basename` on the same inputs the production code uses, rather than hardcoded path-string literals, so the assertions hold across the Windows/macOS/Ubuntu CI matrix this repo runs.

**No production code was changed.** I hand-traced every regex chain in `sanitizeBranchNameForDir` (including the security-relevant `../../etc` traversal case) against the issue's acceptance criteria and confirmed the current implementation already satisfies all of them — this is a pure test-coverage addition.

Closes #166

## Test plan

- [x] `npx tsc --noEmit -p tsconfig.json` — clean
- [x] `npx tsc --noEmit -p tsconfig.main.json` — clean
- [x] `npx vitest run --config vitest.workspace.ts src/main/git-manager.test.ts` — 73/73 passed (14 new cases added)
- [x] `npm test` (full suite) — 101 files / 1140 tests passed, 0 regressions