### PR TITLE
fix(git): guard commitDiff hash against git argument injection

### DIFF
--- a/src/main/git-manager.test.ts
+++ b/src/main/git-manager.test.ts
@@ -380,6 +380,73 @@ describe('GitManager', () => {
     });
   });
 
+  describe('commitDiff', () => {
+    it('parses log + stat output into a GitCommitInfo, preserving a pipe in the subject', async () => {
+      const hash = 'abcdef1234567890abcdef1234567890abcdef12';
+      mockGitResponse(
+        `${hash}|abc1234|John Doe|john@test.com|2024-01-15T10:30:00+00:00|feat: add A|B feature`,
+        '',
+        0,
+      );
+      mockGitResponse(
+        [' src/foo.ts | 10 ++++---', ' 1 file changed, 6 insertions(+), 4 deletions(-)', ''].join('\n'),
+        '',
+        0,
+      );
+
+      const commit = await manager.commitDiff('/test', hash);
+
+      expect(mockExecFile).toHaveBeenCalledTimes(2);
+      expect(mockExecFile).toHaveBeenNthCalledWith(
+        1,
+        expect.any(String),
+        expect.arrayContaining(['log', '-1', hash, '--']),
+        expect.anything(),
+        expect.any(Function),
+      );
+      expect(mockExecFile).toHaveBeenNthCalledWith(
+        2,
+        expect.any(String),
+        expect.arrayContaining(['diff-tree', hash, '--']),
+        expect.anything(),
+        expect.any(Function),
+      );
+      expect(commit.hash).toBe(hash);
+      expect(commit.shortHash).toBe('abc1234');
+      expect(commit.authorName).toBe('John Doe');
+      expect(commit.authorEmail).toBe('john@test.com');
+      // Subject contains a literal '|' — must be rejoined, not truncated at the first split.
+      expect(commit.subject).toBe('feat: add A|B feature');
+      expect(commit.filesChanged).toBe(1);
+      expect(commit.insertions).toBe(6);
+      expect(commit.deletions).toBe(4);
+    });
+
+    it('sets filesChanged from a stat summary with no insertions/deletions parenthetical', async () => {
+      const hash = '1234567890abcdef1234567890abcdef12345678';
+      mockGitResponse(`${hash}|1234567|Jane Doe|jane@test.com|2024-02-01T00:00:00+00:00|chore: rename files`, '', 0);
+      mockGitResponse([' 2 files changed', ''].join('\n'), '', 0);
+
+      const commit = await manager.commitDiff('/test', hash);
+
+      expect(commit.filesChanged).toBe(2);
+      expect(commit.insertions).toBe(0);
+      expect(commit.deletions).toBe(0);
+    });
+
+    it('rejects a hash-like argument that could be parsed by git as an option, without calling execFile', async () => {
+      await expect(
+        manager.commitDiff('/test', '--output=/tmp/pwned'),
+      ).rejects.toThrow(/Invalid commit hash/);
+      expect(mockExecFile).not.toHaveBeenCalled();
+    });
+
+    it('rejects a short flag-like hash, without calling execFile', async () => {
+      await expect(manager.commitDiff('/test', '-1')).rejects.toThrow(/Invalid commit hash/);
+      expect(mockExecFile).not.toHaveBeenCalled();
+    });
+  });
+
   describe('staging operations', () => {
     it('stageFiles returns success', async () => {
       mockGitResponse('', '', 0);

--- a/src/main/git-manager.ts
+++ b/src/main/git-manager.ts
@@ -804,14 +804,24 @@ export class GitManager {
   }
 
   async commitDiff(workDir: string, hash: string): Promise<GitCommitInfo> {
+    // Guard against git argument injection: a hash beginning with '-' (e.g.
+    // '--output=<path>') would otherwise be parsed by git as an option
+    // rather than a revision, turning this read into an arbitrary-file-write
+    // primitive. Reject anything that isn't a hex object name before it
+    // ever reaches execGit.
+    if (!/^[0-9a-fA-F]{4,64}$/.test(hash)) {
+      throw new Error(`Invalid commit hash: ${hash}`);
+    }
+
     return this.withMutex(workDir, async () => {
-      // Get commit info
+      // Get commit info. The trailing '--' is belt-and-suspenders: it marks
+      // the end of options so a future caller can't reintroduce the gap.
       const logResult = await this.execGit(workDir, [
-        'log', `--format=%H|%h|%an|%ae|%aI|%s`, '-1', hash,
+        'log', `--format=%H|%h|%an|%ae|%aI|%s`, '-1', hash, '--',
       ]);
 
       const statResult = await this.execGit(workDir, [
-        'diff-tree', '--no-commit-id', '-r', '--stat', hash,
+        'diff-tree', '--no-commit-id', '-r', '--stat', hash, '--',
       ]);
 
       const parts = logResult.stdout.trim().split('|');


### PR DESCRIPTION
Closes #168

## What
`GitManager.commitDiff(workDir, hash)` passed `hash` positionally into two `execGit` calls (`log`, `diff-tree`) with no end-of-options marker. A hash value beginning with `-` (e.g. `--output=<path>`) would be parsed by git as an *option* rather than a revision, turning this read path into an arbitrary-file-write primitive via `git log --output=...`.

This mirrors the same defense-in-depth class as #162/#163: **not currently reachable** through the UI (the renderer only ever forwards hashes parsed out of git's own commit-list output), but worth closing off since `hash` is a plain string parameter on a method that could be called with less-trusted input in the future.

## Fix
- Reject any `hash` that isn't `4-64` hex characters *before* it ever reaches `execGit` (thrown as a plain `Error`, matching the existing precedent in `fileContent`'s path-escape guard — the IPC handler for `gitCommitDiff` already catches/logs/rethrows, so no handler-side change was needed).
- Added a trailing `'--'` to both `execGit` invocations (`log` and `diff-tree`) as a second, belt-and-suspenders layer, matching the `--` end-of-options convention already used elsewhere in this file for paths (`add --`, `diff --cached --`, `checkout --`).

## Tests
`commitDiff` had zero existing tests. Added `describe('commitDiff', ...)` with 4 cases:
1. Happy path — parses the `%H|%h|%an|%ae|%aI|%s` log line + `--stat` summary into a `GitCommitInfo`, using a subject that itself contains a literal `|` to exercise the `parts.slice(5).join('|')` rejoin.
2. Stat-summary edge case — a summary line with only the files-changed count (no insertions/deletions parenthetical) confirms `filesChanged` is set while `insertions`/`deletions` stay at `0`.
3 & 4. Injection rejection — `--output=/tmp/pwned` and `-1` both throw `Invalid commit hash` and `execFile` is asserted to never be called.

## Verification
- `npx tsc --noEmit -p tsconfig.json` — clean
- `npx tsc --noEmit -p tsconfig.main.json` — clean
- `npx vitest run --config vitest.workspace.ts src/main/git-manager.test.ts` — 62/62 passed (58 existing + 4 new)
- `npm test` (full suite) — 101 files / 1129 tests passed, 0 regressions

No new dependencies added.