### PR TITLE
fix(previews): prune per-session state in useSessionPreviews on session end

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -231,6 +231,13 @@ function App() {
   const sessionIdList = useMemo(() => sessions.map(s => s.id), [sessions]);
   useRemoteDeepLink({ sessionIds: sessionIdList, onJump: handleMobileSelectSession });
 
+  // Drop preview state (snapshot lines, last-activity, internal buffers) for
+  // any session that's no longer live, so closed sessions don't accumulate
+  // forever in useSessionPreviews (renderer-side analog of #139/#104).
+  useEffect(() => {
+    previews.prune(sessionIdList);
+  }, [previews.prune, sessionIdList]);
+
   // ─── Attention cockpit: cross-repo "who needs you" queue + backgrounded toasts ───
   const repoOf = useCallback((s: TabData) => {
     const id = repoIdForSession(visibleRepos, sessions, s.id);

--- a/src/renderer/hooks/useSessionPreviews.test.ts
+++ b/src/renderer/hooks/useSessionPreviews.test.ts
@@ -129,4 +129,64 @@ describe('useSessionPreviews', () => {
     expect(result.current.outputSnapshots.s1).toEqual(['a', 'b']);
     expect(result.current.lastActivityAt.s1).toBeGreaterThan(0);
   });
+
+  it('prune drops all state for sessions no longer live, keeping the survivor intact', () => {
+    const { result } = renderHook(() => useSessionPreviews());
+    const emitter = makeEmitter();
+    act(() => {
+      result.current.attach(emitter.onOutput);
+    });
+
+    act(() => {
+      emitter.emit('s1', 'session one line\n');
+      emitter.emit('s2', 'session two line\n');
+      vi.advanceTimersByTime(200);
+    });
+
+    expect(result.current.outputSnapshots.s1).toEqual(['session one line']);
+    expect(result.current.outputSnapshots.s2).toEqual(['session two line']);
+    expect(result.current.lastActivityAt.s1).toBeGreaterThan(0);
+    expect(result.current.lastActivityAt.s2).toBeGreaterThan(0);
+
+    act(() => {
+      result.current.prune(['s1']);
+    });
+
+    expect(result.current.outputSnapshots.s1).toEqual(['session one line']);
+    expect(result.current.outputSnapshots).not.toHaveProperty('s2');
+    expect(result.current.lastActivityAt.s1).toBeGreaterThan(0);
+    expect(result.current.lastActivityAt).not.toHaveProperty('s2');
+
+    // Internal buffers for the pruned session are gone too: re-emitting for s2
+    // after prune starts it fresh rather than appending to old (now-deleted)
+    // buffered lines.
+    act(() => {
+      emitter.emit('s2', 'brand new after prune\n');
+      vi.advanceTimersByTime(200);
+    });
+    expect(result.current.outputSnapshots.s2).toEqual(['brand new after prune']);
+  });
+
+  it('prune is a no-op (identity-stable) when nothing needs to be removed', () => {
+    const { result } = renderHook(() => useSessionPreviews());
+    const emitter = makeEmitter();
+    act(() => {
+      result.current.attach(emitter.onOutput);
+    });
+
+    act(() => {
+      emitter.emit('s1', 'hello\n');
+      vi.advanceTimersByTime(200);
+    });
+
+    const snapshotsBefore = result.current.outputSnapshots;
+    const activityBefore = result.current.lastActivityAt;
+
+    act(() => {
+      result.current.prune(['s1']);
+    });
+
+    expect(result.current.outputSnapshots).toBe(snapshotsBefore);
+    expect(result.current.lastActivityAt).toBe(activityBefore);
+  });
 });

--- a/src/renderer/hooks/useSessionPreviews.ts
+++ b/src/renderer/hooks/useSessionPreviews.ts
@@ -30,6 +30,14 @@ export interface SessionPreviewsApi {
   attach: (
     onOutput: (callback: (sessionId: string, data: string) => void) => () => void
   ) => () => void;
+  /**
+   * Drop all per-session state for ids not in `liveIds`. Call this whenever
+   * the live session set changes (e.g. on session close) so a session's
+   * snapshot lines, timestamp, and internal buffers don't outlive it.
+   * No-op (identity-stable) when nothing was removed, so it never forces an
+   * extra render.
+   */
+  prune: (liveIds: string[] | Set<string>) => void;
 }
 
 export function useSessionPreviews(): SessionPreviewsApi {
@@ -104,11 +112,35 @@ export function useSessionPreviews(): SessionPreviewsApi {
     [ingest]
   );
 
+  const prune = useCallback((liveIds: string[] | Set<string>) => {
+    const live = liveIds instanceof Set ? liveIds : new Set(liveIds);
+
+    for (const id of linesRef.current.keys()) {
+      if (!live.has(id)) linesRef.current.delete(id);
+    }
+    for (const id of carryRef.current.keys()) {
+      if (!live.has(id)) carryRef.current.delete(id);
+    }
+    for (const id of pendingRef.current) {
+      if (!live.has(id)) pendingRef.current.delete(id);
+    }
+
+    const dropStale = <T,>(prev: Record<string, T>): Record<string, T> => {
+      const staleIds = Object.keys(prev).filter(id => !live.has(id));
+      if (staleIds.length === 0) return prev;
+      const next = { ...prev };
+      for (const id of staleIds) delete next[id];
+      return next;
+    };
+    setOutputSnapshots(dropStale);
+    setLastActivityAt(dropStale);
+  }, []);
+
   useEffect(() => () => {
     if (flushTimerRef.current !== null) {
       window.clearTimeout(flushTimerRef.current);
     }
   }, []);
 
-  return { outputSnapshots, lastActivityAt, attach };
+  return { outputSnapshots, lastActivityAt, attach, prune };
 }


### PR DESCRIPTION
Closes #160

## Problem
`useSessionPreviews` (used by the Grid tiles to show a rolling stdout preview per session) accumulates per-session state forever: `outputSnapshots`/`lastActivityAt` React state plus three internal buffers (`linesRef`, `carryRef`, `pendingRef` — all keyed Maps/Sets). Nothing removed an entry once its session closed, so the hook leaked memory proportional to total sessions ever opened across the app's lifetime. Renderer-side analog of the leaks already fixed for main-process state in #139 and #104.

## Change
- Added `prune(liveIds: string[] | Set<string>)` to `SessionPreviewsApi` and implemented it in `useSessionPreviews.ts`: drops all per-session entries (state + the three internal Maps/Sets) for ids not in `liveIds`.
- `prune` is identity-stable — when there's nothing to remove it returns the same object reference for `outputSnapshots`/`lastActivityAt`, so it never forces a spurious re-render.
- Wired it into `App.tsx`: a small effect keyed on `[previews.prune, sessionIdList]` (the hook already computes `sessionIdList` for `useRemoteDeepLink`) calls `previews.prune(sessionIdList)` whenever the live session set changes. Deliberately depends on `previews.prune` (stable via `useCallback([])`), not the whole `previews` object (recreated every render), so this doesn't fire on every render — distinct from the pre-existing `attach` effect, which does depend on the whole object and is untouched.

## Verification
- `npx tsc --noEmit -p tsconfig.json` — clean
- `npx tsc --noEmit -p tsconfig.main.json` — clean
- `npx vitest run --config vitest.workspace.ts --project renderer src/renderer/hooks/useSessionPreviews.test.ts` — 7 passed (2 new: prune drops state for a closed session while keeping the survivor intact, including that a re-emit after prune starts the internal buffer fresh; prune is a no-op/identity-stable when nothing needs removing)
- Full suite: `npm test` — 101 files / 1127 tests passed, no regressions

No new dependencies.