### PR TITLE
fix(git): guard branch arg in switchBranch/createBranch against git argument injection

### DIFF
--- a/src/main/git-manager.test.ts
+++ b/src/main/git-manager.test.ts
@@ -447,6 +447,65 @@ describe('GitManager', () => {
     });
   });
 
+  describe('switchBranch', () => {
+    it('checks out an existing branch', async () => {
+      mockGitResponse('', '', 0);
+
+      const result = await manager.switchBranch('/test', 'feature/foo');
+
+      expect(mockExecFile).toHaveBeenCalledTimes(1);
+      expect(mockExecFile).toHaveBeenNthCalledWith(
+        1,
+        expect.any(String),
+        expect.arrayContaining(['checkout', '--end-of-options', 'feature/foo']),
+        expect.anything(),
+        expect.any(Function),
+      );
+      expect(result.success).toBe(true);
+    });
+
+    it('rejects a branch name that could be parsed as a git option, without calling execFile', async () => {
+      const result = await manager.switchBranch('/test', '-f');
+
+      expect(result.success).toBe(false);
+      expect(result.message).toMatch(/Invalid branch name/);
+      expect(mockExecFile).not.toHaveBeenCalled();
+    });
+
+    it('rejects an --orphan-style branch name, without calling execFile', async () => {
+      const result = await manager.switchBranch('/test', '--orphan');
+
+      expect(result.success).toBe(false);
+      expect(mockExecFile).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('createBranch', () => {
+    it('creates and checks out a new branch', async () => {
+      mockGitResponse('', '', 0);
+
+      const result = await manager.createBranch('/test', 'feature/bar');
+
+      expect(mockExecFile).toHaveBeenCalledTimes(1);
+      expect(mockExecFile).toHaveBeenNthCalledWith(
+        1,
+        expect.any(String),
+        expect.arrayContaining(['checkout', '-b', '--end-of-options', 'feature/bar']),
+        expect.anything(),
+        expect.any(Function),
+      );
+      expect(result.success).toBe(true);
+    });
+
+    it('rejects a branch name that could be parsed as a git option, without calling execFile', async () => {
+      const result = await manager.createBranch('/test', '-f');
+
+      expect(result.success).toBe(false);
+      expect(result.message).toMatch(/Invalid branch name/);
+      expect(mockExecFile).not.toHaveBeenCalled();
+    });
+  });
+
   describe('staging operations', () => {
     it('stageFiles returns success', async () => {
       mockGitResponse('', '', 0);

--- a/src/main/git-manager.ts
+++ b/src/main/git-manager.ts
@@ -700,16 +700,31 @@ export class GitManager {
   // ── Public API: Branches ──
 
   async switchBranch(workDir: string, branch: string): Promise<GitOperationResult> {
+    // Guard against git argument injection: a branch name beginning with '-'
+    // (e.g. '-f') would otherwise be parsed by git as an option rather than a
+    // ref, e.g. forcing a destructive checkout that discards uncommitted
+    // changes. Reject before it ever reaches execGit. Mirrors the guard added
+    // for commitDiff (#168/#170).
+    if (branch.startsWith('-')) {
+      return this.makeError(`Invalid branch name: ${branch}`, 1);
+    }
     return this.withMutex(workDir, async () => {
-      const result = await this.execGit(workDir, ['checkout', branch]);
+      // The '--end-of-options' marker is belt-and-suspenders: it marks the
+      // end of options so a future caller can't reintroduce the gap.
+      const result = await this.execGit(workDir, ['checkout', '--end-of-options', branch]);
       if (result.exitCode !== 0) return this.makeError(result.stderr, result.exitCode);
       return { success: true, message: `Switched to branch '${branch}'`, errorCode: null };
     });
   }
 
   async createBranch(workDir: string, branch: string): Promise<GitOperationResult> {
+    // See switchBranch: reject a branch name that could be parsed as a git
+    // option before it reaches execGit.
+    if (branch.startsWith('-')) {
+      return this.makeError(`Invalid branch name: ${branch}`, 1);
+    }
     return this.withMutex(workDir, async () => {
-      const result = await this.execGit(workDir, ['checkout', '-b', branch]);
+      const result = await this.execGit(workDir, ['checkout', '-b', '--end-of-options', branch]);
       if (result.exitCode !== 0) return this.makeError(result.stderr, result.exitCode);
       return { success: true, message: `Created and switched to branch '${branch}'`, errorCode: null };
     });


### PR DESCRIPTION
Closes #171

## Summary
Mirrors the guard added for `commitDiff` in #168/#170: a branch name beginning with `-` (e.g. `-f`, `--orphan`) would otherwise be parsed by git as an *option* rather than a ref/branch operand. `switchBranch`'s branch argument currently comes from an internally-parsed branch list (defense-in-depth), while `createBranch`'s is free user-typed text (more directly reachable) — both get the same guard for consistency and future-proofing.

## Changes
- `GitManager.switchBranch` and `GitManager.createBranch` in `src/main/git-manager.ts` now reject any branch argument starting with `-` **before** it reaches `execGit`, returning a normal `GitOperationResult` error (`success: false`, message `Invalid branch name: ...`) rather than an unhandled throw — matching this method's existing return-type contract (unlike `commitDiff`, which throws because it returns a bare `GitCommitInfo`).
- Both `checkout` invocations now also include `--end-of-options` as belt-and-suspenders, so git itself refuses to interpret the branch operand as an option even if the explicit guard were ever removed.
- Added test coverage in `src/main/git-manager.test.ts`: happy-path checks that `checkout`/`checkout -b` still get called with `--end-of-options` and the branch name for valid input, plus rejection tests (`-f`, `--orphan`) asserting `execFile` is never invoked and the result carries `success: false`.

## Verification
- `npx tsc --noEmit` clean on both `tsconfig.json` and `tsconfig.main.json`.
- Targeted suite: `git-manager.test.ts` — 82/82 passing (5 new, 77 pre-existing), 0 regressions.
- Full suite: `npm test` — 1158/1158 passing across 101 files, 0 regressions.

No new dependencies added.