### PR TITLE
fix(git): guard addWorktree/removeWorktree against argument injection

### DIFF
--- a/src/main/git-manager.test.ts
+++ b/src/main/git-manager.test.ts
@@ -781,6 +781,150 @@ describe('GitManager', () => {
     });
   });
 
+  describe('addWorktree', () => {
+    const settings = { basePath: 'custom', customBasePath: '/base', cleanupOnSessionClose: 'ask' } as const;
+
+    it('rejects a customPath beginning with "-" without spawning execGit', async () => {
+      mockGitResponse('git version 2.42.0', '', 0); // getGitVersion()
+      const result = await manager.addWorktree(
+        { mainRepoPath: '/repo', branch: 'feature-x', isNewBranch: false, customPath: '--force' },
+        settings
+      );
+      expect(result.success).toBe(false);
+      expect(result.message).toMatch(/Invalid worktree path/);
+      expect(mockExecFile).toHaveBeenCalledTimes(1); // only getGitVersion, no worktree add
+    });
+
+    it('rejects a branch beginning with "-" without spawning execGit', async () => {
+      mockGitResponse('git version 2.42.0', '', 0);
+      const result = await manager.addWorktree(
+        { mainRepoPath: '/repo', branch: '--upload-pack=evil', isNewBranch: false },
+        settings
+      );
+      expect(result.success).toBe(false);
+      expect(result.message).toMatch(/Invalid branch name/);
+      expect(mockExecFile).toHaveBeenCalledTimes(1);
+    });
+
+    it('rejects a baseBranch beginning with "-" without spawning execGit', async () => {
+      mockGitResponse('git version 2.42.0', '', 0);
+      const result = await manager.addWorktree(
+        { mainRepoPath: '/repo', branch: 'feature-x', isNewBranch: true, baseBranch: '-b' },
+        settings
+      );
+      expect(result.success).toBe(false);
+      expect(result.message).toMatch(/Invalid base branch name/);
+      expect(mockExecFile).toHaveBeenCalledTimes(1);
+    });
+
+    it('creates a worktree with a new branch, passing --end-of-options before the path', async () => {
+      mockExistsSync.mockReturnValueOnce(true); // parent dir already exists, skip mkdirSync
+      mockGitResponse('git version 2.42.0', '', 0);
+      mockGitResponse('', '', 0); // worktree add
+
+      const result = await manager.addWorktree(
+        { mainRepoPath: '/repo', branch: 'feature-x', isNewBranch: true },
+        settings
+      );
+
+      expect(result.success).toBe(true);
+      expect(mockExecFile).toHaveBeenNthCalledWith(
+        2,
+        expect.any(String),
+        ['worktree', 'add', '-b', 'feature-x', '--end-of-options', path.join('/base', 'feature-x')],
+        expect.anything(),
+        expect.any(Function)
+      );
+    });
+
+    it('creates a worktree with a new branch and baseBranch appended after the path', async () => {
+      mockExistsSync.mockReturnValueOnce(true);
+      mockGitResponse('git version 2.42.0', '', 0);
+      mockGitResponse('', '', 0);
+
+      const result = await manager.addWorktree(
+        { mainRepoPath: '/repo', branch: 'feature-x', isNewBranch: true, baseBranch: 'develop' },
+        settings
+      );
+
+      expect(result.success).toBe(true);
+      expect(mockExecFile).toHaveBeenNthCalledWith(
+        2,
+        expect.any(String),
+        ['worktree', 'add', '-b', 'feature-x', '--end-of-options', path.join('/base', 'feature-x'), 'develop'],
+        expect.anything(),
+        expect.any(Function)
+      );
+    });
+
+    it('creates a worktree for an existing branch, with --end-of-options before the path and branch after', async () => {
+      mockExistsSync.mockReturnValueOnce(true);
+      mockGitResponse('git version 2.42.0', '', 0);
+      mockGitResponse('', '', 0);
+
+      const result = await manager.addWorktree(
+        { mainRepoPath: '/repo', branch: 'feature-x', isNewBranch: false },
+        settings
+      );
+
+      expect(result.success).toBe(true);
+      expect(mockExecFile).toHaveBeenNthCalledWith(
+        2,
+        expect.any(String),
+        ['worktree', 'add', '--end-of-options', path.join('/base', 'feature-x'), 'feature-x'],
+        expect.anything(),
+        expect.any(Function)
+      );
+    });
+  });
+
+  describe('removeWorktree', () => {
+    it('rejects a worktreePath beginning with "-" without spawning execGit', async () => {
+      const result = await manager.removeWorktree({
+        mainRepoPath: '/repo',
+        worktreePath: '--force',
+        force: false,
+      });
+      expect(result.success).toBe(false);
+      expect(result.message).toMatch(/Invalid worktree path/);
+      expect(mockExecFile).not.toHaveBeenCalled();
+    });
+
+    it('removes a worktree, passing --end-of-options before the path', async () => {
+      mockGitResponse('', '', 0);
+      const result = await manager.removeWorktree({
+        mainRepoPath: '/repo',
+        worktreePath: '/repo-worktrees/feature-x',
+        force: false,
+      });
+      expect(result.success).toBe(true);
+      expect(mockExecFile).toHaveBeenNthCalledWith(
+        1,
+        expect.any(String),
+        ['worktree', 'remove', '--end-of-options', '/repo-worktrees/feature-x'],
+        expect.anything(),
+        expect.any(Function)
+      );
+    });
+
+    it('removes a worktree with force, placing --force before --end-of-options', async () => {
+      mockGitResponse('', '', 0);
+      const result = await manager.removeWorktree({
+        mainRepoPath: '/repo',
+        worktreePath: '/repo-worktrees/feature-x',
+        force: true,
+      });
+      expect(result.success).toBe(true);
+      expect(mockExecFile).toHaveBeenNthCalledWith(
+        1,
+        expect.any(String),
+        ['worktree', 'remove', '--force', '--end-of-options', '/repo-worktrees/feature-x'],
+        expect.anything(),
+        expect.any(Function)
+      );
+    });
+  });
+
   describe('worktree path naming', () => {
     describe('sanitizeBranchNameForDir', () => {
       it('replaces forward slashes with a dash', () => {

--- a/src/main/git-manager.ts
+++ b/src/main/git-manager.ts
@@ -1059,6 +1059,23 @@ export class GitManager {
 
     const targetPath = request.customPath || this.computeWorktreePath(request.mainRepoPath, request.branch, settings);
 
+    // Guard against git argument injection: a target path, branch, or base
+    // branch beginning with '-' would otherwise be parsed by git as an option
+    // rather than a positional path/ref (e.g. a customPath of '--force' or a
+    // baseBranch of '-b'). Reject before it reaches execGit or the filesystem.
+    // Mirrors the guard added for commitDiff/switchBranch (#170/#175).
+    // computeWorktreePath's sanitizer only covers the auto-derived case, so
+    // this must also catch request.customPath, which bypasses it entirely.
+    if (targetPath.startsWith('-')) {
+      return { success: false, message: `Invalid worktree path: ${targetPath}`, errorCode: 'UNKNOWN' };
+    }
+    if (request.branch.startsWith('-')) {
+      return { success: false, message: `Invalid branch name: ${request.branch}`, errorCode: 'UNKNOWN' };
+    }
+    if (request.baseBranch && request.baseBranch.startsWith('-')) {
+      return { success: false, message: `Invalid base branch name: ${request.baseBranch}`, errorCode: 'UNKNOWN' };
+    }
+
     // Ensure parent directory exists
     const parentDir = path.dirname(targetPath);
     try {
@@ -1074,10 +1091,10 @@ export class GitManager {
       const buildArgs = (): string[] => {
         const args = ['worktree', 'add'];
         if (request.isNewBranch) {
-          args.push('-b', request.branch, targetPath);
+          args.push('-b', request.branch, '--end-of-options', targetPath);
           if (request.baseBranch) args.push(request.baseBranch);
         } else {
-          args.push(targetPath, request.branch);
+          args.push('--end-of-options', targetPath, request.branch);
         }
         return args;
       };
@@ -1128,10 +1145,15 @@ export class GitManager {
   }
 
   async removeWorktree(request: WorktreeRemoveRequest): Promise<GitOperationResult> {
+    // Guard against git argument injection: a worktreePath beginning with
+    // '-' would otherwise be parsed by git as an option. See addWorktree.
+    if (request.worktreePath.startsWith('-')) {
+      return { success: false, message: `Invalid worktree path: ${request.worktreePath}`, errorCode: 'UNKNOWN' };
+    }
     return this.withMutex(request.mainRepoPath, async () => {
       const args = ['worktree', 'remove'];
       if (request.force) args.push('--force');
-      args.push(request.worktreePath);
+      args.push('--end-of-options', request.worktreePath);
 
       const result = await this.execGit(request.mainRepoPath, args);
 


### PR DESCRIPTION
Closes #176

## Summary
Extends the git argument-injection guard pattern from #170 (`commitDiff`) and #175 (`switchBranch`/`createBranch`) to the last two unguarded `execGit` call sites: `addWorktree` and `removeWorktree` in `src/main/git-manager.ts`.

- `addWorktree`: rejects (returns `success: false`, no git spawned) when the resolved worktree path, `branch`, or `baseBranch` starts with `-`. Also inserts `--end-of-options` immediately before the positional path argument in both the new-branch (`worktree add -b <branch> --end-of-options <path> [<baseBranch>]`) and existing-branch (`worktree add --end-of-options <path> <branch>`) argv shapes, as defense in depth.
- `removeWorktree`: rejects when `worktreePath` starts with `-`. Inserts `--end-of-options` before the path, with `--force` (when requested) placed before the marker: `worktree remove [--force] --end-of-options <path>`.

## Testing
- Added 8 new unit tests to `src/main/git-manager.test.ts` (the issue suggested `src/main/__tests__/git-manager.test.ts`, but that path doesn't exist in this repo — tests live alongside the source in `src/main/git-manager.test.ts`, matching every other file in this directory):
  - 3 rejection tests for `addWorktree` (bad path / bad branch / bad baseBranch — each asserts `execFile` is never called beyond the version check, i.e. git is never spawned with the malicious arg)
  - 3 happy-path tests for `addWorktree` covering all argv shapes (new branch, new branch + baseBranch, existing branch) asserting exact argv including `--end-of-options` placement
  - 1 rejection test for `removeWorktree` (bad path, asserts `execFile` never called)
  - 2 happy-path tests for `removeWorktree` (with and without `--force`) asserting exact argv
- `npx tsc --noEmit -p tsconfig.json` — clean
- `npx tsc --noEmit -p tsconfig.main.json` — clean
- `npx vitest run --config vitest.workspace.ts --project main src/main/git-manager.test.ts` — 91/91 passed (was 83 before this change; +8 new)
- `npm test` (full suite) — 101 files / 1174 tests passed, no regressions

## Note
Manually validated `--end-of-options` behavior against real git (2.52.0.windows.1) in a scratch repo across all 4 argv shapes touched by this change before committing to the approach, since worktree argv construction has more branches than the earlier `commitDiff`/`switchBranch` guards.

No new dependencies.