### PR TITLE
test(remote): add TunnelController lifecycle branch coverage

### DIFF
--- a/src/main/remote/tunnel-controller.test.ts
+++ b/src/main/remote/tunnel-controller.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('./tunnel-manager', () => {
+  const TunnelManager = vi.fn();
+  TunnelManager.prototype.isRunning = vi.fn(() => false);
+  TunnelManager.prototype.start = vi.fn();
+  TunnelManager.prototype.stop = vi.fn();
+  TunnelManager.prototype.status = vi.fn();
+  return { TunnelManager, findCloudflared: vi.fn() };
+});
+
+vi.mock('./cloudflared-install', () => ({
+  downloadCloudflared: vi.fn(),
+  manualInstallHint: vi.fn(),
+}));
+
+import { TunnelController } from './tunnel-controller';
+import { TunnelManager, findCloudflared } from './tunnel-manager';
+import { downloadCloudflared, manualInstallHint } from './cloudflared-install';
+
+describe('TunnelController', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('start', () => {
+    it('returns the existing status and does not probe for cloudflared again when already running', async () => {
+      // First start() to construct the (mocked) TunnelManager and mark it running.
+      vi.mocked(findCloudflared).mockResolvedValue('cloudflared');
+      const initialStatus = { state: 'starting' as const };
+      vi.mocked(TunnelManager.prototype.start).mockResolvedValue(initialStatus);
+      const controller = new TunnelController('/managed');
+      await controller.start(8420);
+      expect(findCloudflared).toHaveBeenCalledTimes(1);
+      expect(TunnelManager).toHaveBeenCalledTimes(1);
+
+      // Now report the manager as running and call start() again.
+      vi.mocked(TunnelManager.prototype.isRunning).mockReturnValue(true);
+      const runningStatus = { state: 'running' as const, url: 'https://already-up.trycloudflare.com' };
+      vi.mocked(TunnelManager.prototype.status).mockReturnValue(runningStatus);
+
+      const status = await controller.start(8420);
+
+      expect(status).toEqual(runningStatus);
+      // Still only the one call from the first start() — no re-probe, no second manager.
+      expect(findCloudflared).toHaveBeenCalledTimes(1);
+      expect(TunnelManager).toHaveBeenCalledTimes(1);
+    });
+
+    it('returns an error status and constructs no TunnelManager when cloudflared is missing', async () => {
+      vi.mocked(findCloudflared).mockResolvedValue(null);
+      vi.mocked(manualInstallHint).mockReturnValue('install cloudflared manually');
+      const controller = new TunnelController('/managed');
+
+      const status = await controller.start(8420);
+
+      expect(status).toEqual({ state: 'error', error: 'install cloudflared manually' });
+      expect(manualInstallHint).toHaveBeenCalledWith(process.platform);
+      expect(TunnelManager).not.toHaveBeenCalled();
+    });
+
+    it('constructs a TunnelManager with the found binary and returns its start() status on the happy path', async () => {
+      vi.mocked(findCloudflared).mockResolvedValue('/usr/local/bin/cloudflared');
+      const happyStatus = { state: 'running' as const, url: 'https://happy-path.trycloudflare.com' };
+      vi.mocked(TunnelManager.prototype.start).mockResolvedValue(happyStatus);
+      const controller = new TunnelController('/managed');
+
+      const status = await controller.start(8420);
+
+      expect(TunnelManager).toHaveBeenCalledWith('/usr/local/bin/cloudflared');
+      expect(TunnelManager.prototype.start).toHaveBeenCalledWith(8420);
+      expect(status).toEqual(happyStatus);
+    });
+  });
+
+  describe('stop', () => {
+    it('stops the manager and resets state so status() reports off', async () => {
+      vi.mocked(findCloudflared).mockResolvedValue('cloudflared');
+      vi.mocked(TunnelManager.prototype.start).mockResolvedValue({ state: 'running' as const });
+      const controller = new TunnelController('/managed');
+      await controller.start(8420);
+
+      await controller.stop();
+
+      expect(TunnelManager.prototype.stop).toHaveBeenCalledTimes(1);
+      expect(controller.status()).toEqual({ state: 'off' });
+    });
+
+    it('is a no-op when no manager has been started', async () => {
+      const controller = new TunnelController('/managed');
+
+      await expect(controller.stop()).resolves.toBeUndefined();
+      expect(TunnelManager.prototype.stop).not.toHaveBeenCalled();
+      expect(controller.status()).toEqual({ state: 'off' });
+    });
+  });
+
+  describe('status', () => {
+    it('returns off when no manager has been started', () => {
+      const controller = new TunnelController('/managed');
+      expect(controller.status()).toEqual({ state: 'off' });
+    });
+
+    it("returns the manager's status when running", async () => {
+      vi.mocked(findCloudflared).mockResolvedValue('cloudflared');
+      vi.mocked(TunnelManager.prototype.start).mockResolvedValue({ state: 'starting' as const });
+      const runningStatus = { state: 'running' as const, url: 'https://status-check.trycloudflare.com' };
+      vi.mocked(TunnelManager.prototype.status).mockReturnValue(runningStatus);
+      const controller = new TunnelController('/managed');
+      await controller.start(8420);
+
+      expect(controller.status()).toEqual(runningStatus);
+    });
+  });
+
+  describe('isInstalled', () => {
+    it('returns true when findCloudflared resolves a binary', async () => {
+      vi.mocked(findCloudflared).mockResolvedValue('cloudflared');
+      const controller = new TunnelController('/managed');
+      expect(await controller.isInstalled()).toBe(true);
+    });
+
+    it('returns false when findCloudflared resolves null', async () => {
+      vi.mocked(findCloudflared).mockResolvedValue(null);
+      const controller = new TunnelController('/managed');
+      expect(await controller.isInstalled()).toBe(false);
+    });
+  });
+
+  describe('install', () => {
+    it('delegates to downloadCloudflared with the managed path', async () => {
+      vi.mocked(downloadCloudflared).mockResolvedValue(undefined);
+      const controller = new TunnelController('/managed');
+
+      await controller.install();
+
+      expect(downloadCloudflared).toHaveBeenCalledWith('/managed');
+    });
+  });
+});


### PR DESCRIPTION
Closes #177

## Summary

`src/main/remote/tunnel-controller.ts` had no test file despite owning the only branching logic that composes the Remote Access tunnel lifecycle. Added `src/main/remote/tunnel-controller.test.ts` covering every branch called out in the issue:

- `start()` short-circuits and returns the existing status (no re-probe via `findCloudflared`, no second `TunnelManager`) when the manager reports `isRunning() === true`.
- `start()` returns `{ state: 'error', error: manualInstallHint(process.platform) }` and constructs **no** `TunnelManager` when `findCloudflared` resolves `null`.
- `start()` happy path: constructs `TunnelManager(bin)` with the resolved binary, calls `mgr.start(port)`, returns its status.
- `stop()` calls `mgr.stop()` and nulls the manager (verified via a follow-up `status()` returning `{ state: 'off' }`); is a no-op when no manager exists.
- `status()` returns the manager's status when set, `{ state: 'off' }` otherwise.
- `isInstalled()` mirrors `findCloudflared`'s null/non-null result.
- `install()` delegates to `downloadCloudflared(managedPath)`.

10 new tests, all in the new file — no changes to production code.

## Approach

Mocked `./tunnel-manager` and `./cloudflared-install` with `vi.mock()`, mirroring the existing `vi.fn()` + `.prototype.method` class-mocking convention already used for `CLIManager`/`SessionPool` in `session-pool.test.ts` and `session-manager.test.ts` (confirmed via a codebase search before writing this — same shape, not a new pattern).

## Verification

- `npx tsc --noEmit -p tsconfig.json` — clean
- `npx tsc --noEmit -p tsconfig.main.json` — clean
- `npx vitest run --config vitest.workspace.ts --project main src/main/remote/tunnel-controller.test.ts` — 10/10 passing
- `npm test` (full suite) — 102 files / 1184 tests passing, zero regressions

No new dependencies.