### PR TITLE
test(integrations): add ConnectorRegistry coverage

### DIFF
--- a/src/main/integrations/connector-registry.test.ts
+++ b/src/main/integrations/connector-registry.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { ConnectorRegistry } from './connector-registry';
+import { TelegramConnector } from './connectors/telegram-connector';
+import { SlackConnector } from './connectors/slack-connector';
+import { DiscordConnector } from './connectors/discord-connector';
+import { WebhookConnector } from './connectors/webhook-connector';
+import type { IConnector } from './connector';
+import type { ConnectorId, ConnectorTestResult, OutboundMessage, SendOutcome } from '../../shared/integration-types';
+
+describe('ConnectorRegistry', () => {
+  let registry: ConnectorRegistry;
+
+  beforeEach(() => {
+    registry = new ConnectorRegistry();
+  });
+
+  it('auto-registers the Telegram connector on construction', () => {
+    expect(registry.get('telegram')).toBeInstanceOf(TelegramConnector);
+  });
+
+  it('auto-registers the Slack connector on construction', () => {
+    expect(registry.get('slack')).toBeInstanceOf(SlackConnector);
+  });
+
+  it('auto-registers the Discord connector on construction', () => {
+    expect(registry.get('discord')).toBeInstanceOf(DiscordConnector);
+  });
+
+  it('auto-registers the Webhook connector on construction', () => {
+    expect(registry.get('webhook')).toBeInstanceOf(WebhookConnector);
+  });
+
+  it('list() returns info for all four built-in connectors', () => {
+    const list = registry.list();
+    expect(list).toHaveLength(4);
+    const ids = list.map((c) => c.id);
+    expect(ids).toContain('telegram');
+    expect(ids).toContain('slack');
+    expect(ids).toContain('discord');
+    expect(ids).toContain('webhook');
+  });
+
+  it('get() on an unknown id throws "Connector not found: <id>"', () => {
+    expect(() => registry.get('unknown' as ConnectorId)).toThrow('Connector not found: unknown');
+  });
+
+  it('register() makes a newly registered connector retrievable via get()', () => {
+    const fakeConnector: IConnector<unknown> = {
+      id: 'webhook',
+      displayName: 'Fake Webhook',
+      isConfigured: () => true,
+      test: async (): Promise<ConnectorTestResult> => ({ ok: true }),
+      deliver: async (_cfg: unknown, _msg: OutboundMessage): Promise<SendOutcome> => ({ ok: true }),
+    };
+
+    registry.register(fakeConnector);
+
+    expect(registry.get('webhook')).toBe(fakeConnector);
+  });
+});


### PR DESCRIPTION
Closes #178

## Summary
Adds unit test coverage for `ConnectorRegistry` (`src/main/integrations/connector-registry.ts`), which previously had none.

- Auto-registration assertions for all four built-in connectors (Telegram, Slack, Discord, Webhook) via `get()`
- `list()` returns exactly 4 entries with the expected ids
- `get()` on an unknown id throws `Connector not found: <id>`
- `register()` overrides an existing entry and the override is retrievable via `get()`

No production code changes — test-only, low risk. No mocking needed: none of the four connectors have side-effecting constructors or module-level imports (unlike `ClaudeProvider`/`CodexProvider`, which need `child_process` mocked in `provider-registry.test.ts`), confirmed by inspecting each connector file before writing the test.

## Verification
- `npx tsc --noEmit -p tsconfig.json` — clean
- `npx tsc --noEmit -p tsconfig.main.json` — clean
- Targeted: `npx vitest run --config vitest.workspace.ts --project main src/main/integrations/connector-registry.test.ts` — 7/7 passed
- Full suite: `npm test` — 103 files / 1182 tests passed, no regressions