### PR TITLE
test(providers): add direct unit tests for isSafeModelToken/MODEL_TOKEN_PATTERN

### DIFF
--- a/src/main/providers/provider.test.ts
+++ b/src/main/providers/provider.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest';
+import { isSafeModelToken, MODEL_TOKEN_PATTERN } from './provider';
+
+// Direct unit tests for the shared model trust-boundary guard (see #182).
+// Pins the accept/reject contract at its source so a widening edit to
+// MODEL_TOKEN_PATTERN fails here, not only incidentally in a provider's
+// buildCommand tests.
+
+const validTokens = ['claude-sonnet-4-5', 'gpt-4.1', 'o3', 'GPT-4', 'haiku'];
+
+const injectionPayloads = [
+  ';rm -rf /',
+  '$(whoami)',
+  '`whoami`',
+  'a b',
+  'a|b',
+  'a&b',
+  'a>b',
+  'a\nb',
+  '../etc',
+  'a/b',
+];
+
+describe('isSafeModelToken', () => {
+  it.each(validTokens)('accepts valid model token %s', (token) => {
+    expect(isSafeModelToken(token)).toBe(true);
+  });
+
+  it('rejects undefined', () => {
+    expect(isSafeModelToken(undefined)).toBe(false);
+  });
+
+  it('rejects the empty string', () => {
+    expect(isSafeModelToken('')).toBe(false);
+  });
+
+  it.each(injectionPayloads)('rejects injection payload %j', (payload) => {
+    expect(isSafeModelToken(payload)).toBe(false);
+  });
+});
+
+describe('MODEL_TOKEN_PATTERN', () => {
+  it.each(validTokens)('matches valid model token %s', (token) => {
+    expect(MODEL_TOKEN_PATTERN.test(token)).toBe(true);
+  });
+
+  it.each(injectionPayloads)('does not match injection payload %j', (payload) => {
+    expect(MODEL_TOKEN_PATTERN.test(payload)).toBe(false);
+  });
+
+  it('does not match the empty string', () => {
+    expect(MODEL_TOKEN_PATTERN.test('')).toBe(false);
+  });
+});


### PR DESCRIPTION
Closes #182

## Summary
`isSafeModelToken` / `MODEL_TOKEN_PATTERN` in `src/main/providers/provider.ts` are the shared last-line-of-defense guard on untrusted `request.model` before it's interpolated into a `--model <value>` flag (reachable over the remote WS bridge per #116). Four modules depend on it (`claude-provider`, `codex-provider`, `cli-manager`, `session-manager`) but there was no `provider.test.ts` — the guard's own accept/reject contract was only exercised incidentally through other files' `buildCommand` tests.

## Change
Added `src/main/providers/provider.test.ts` (coverage-only, no changes to `provider.ts`):
- Accepts real model tokens: `claude-sonnet-4-5`, `gpt-4.1`, `o3`, `GPT-4` (case-insensitive), `haiku`.
- Rejects `undefined` and `''` (the type-guard narrowing branches).
- Rejects shell/command-injection payloads: `;rm -rf /`, `$(whoami)`, backtick command, space, `|`, `&`, `>`, embedded newline, `../etc`, `a/b`.
- Mirrors the same accept/reject set directly against `MODEL_TOKEN_PATTERN` so a future pattern edit is caught at the source, not just downstream.

Follows the existing precedent of testing a security guard directly (`src/main/path-access.test.ts`).

## Verification
- `npx tsc --noEmit -p tsconfig.json` — clean
- `npx tsc --noEmit -p tsconfig.main.json` — clean
- `npx vitest run --config vitest.workspace.ts --project main src/main/providers/provider.test.ts` — 33/33 passing
- `npm test` (full suite) — 102 files / 1198 tests passing, zero regressions

No new dependencies.