### PR TITLE
test(hooks): add coverage for useProvider capabilities cache and mount undefined-guard

### DIFF
--- a/src/renderer/hooks/useProvider.test.ts
+++ b/src/renderer/hooks/useProvider.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { getElectronAPI, resetElectronAPI } from '../../../test/helpers/electron-api-mock';
+import { useProvider } from './useProvider';
+import type { ProviderInfo, ProviderCapabilities } from '../../shared/types/provider-types';
+
+function makeProviderInfo(id: 'claude' | 'codex'): ProviderInfo {
+  return {
+    id,
+    displayName: id,
+    cliCommand: id,
+    capabilities: {
+      modelSwitching: true,
+      agentTeams: false,
+      quota: false,
+      readinessDetection: true,
+      permissionModes: ['standard'],
+    },
+  };
+}
+
+function makeCapabilities(overrides: Partial<ProviderCapabilities> = {}): ProviderCapabilities {
+  return {
+    modelSwitching: true,
+    agentTeams: false,
+    quota: false,
+    readinessDetection: true,
+    permissionModes: ['standard'],
+    ...overrides,
+  };
+}
+
+describe('useProvider', () => {
+  let api: ReturnType<typeof getElectronAPI>;
+
+  beforeEach(() => {
+    api = resetElectronAPI();
+  });
+
+  describe('mount loading', () => {
+    it('populates providers and availableProviders from listProviders/getAvailableProviders', async () => {
+      const providers = [makeProviderInfo('claude'), makeProviderInfo('codex')];
+      const available = [makeProviderInfo('claude')];
+      api.listProviders.mockResolvedValue(providers);
+      api.getAvailableProviders.mockResolvedValue(available);
+
+      const { result } = renderHook(() => useProvider());
+
+      await waitFor(() => expect(result.current.providers).toEqual(providers));
+      expect(result.current.availableProviders).toEqual(available);
+    });
+
+    it('falls back to [] when listProviders/getAvailableProviders resolve undefined', async () => {
+      // Default mock resolves undefined (see electron-api-mock buildElectronAPIMock);
+      // this exercises the `?? []` guard called out in issue #186.
+      const { result } = renderHook(() => useProvider());
+
+      await waitFor(() => expect(result.current.providers).toEqual([]));
+      expect(result.current.availableProviders).toEqual([]);
+    });
+  });
+
+  describe('getCapabilities cache', () => {
+    it('calls getProviderCapabilities exactly once per providerId and returns the cached value after', async () => {
+      const caps = makeCapabilities();
+      api.getProviderCapabilities.mockResolvedValue(caps);
+
+      const { result } = renderHook(() => useProvider());
+      // Flush the mount effect's provider-loading state updates before driving
+      // getCapabilities, so React state updates don't leak outside act().
+      await waitFor(() => expect(result.current.providers).toEqual([]));
+
+      const first = await result.current.getCapabilities('claude');
+      const second = await result.current.getCapabilities('claude');
+      const third = await result.current.getCapabilities('claude');
+
+      expect(first).toEqual(caps);
+      expect(second).toEqual(caps);
+      expect(third).toEqual(caps);
+      expect(api.getProviderCapabilities).toHaveBeenCalledTimes(1);
+      expect(api.getProviderCapabilities).toHaveBeenCalledWith('claude');
+    });
+
+    it('caches two distinct providerIds independently', async () => {
+      const claudeCaps = makeCapabilities({ modelSwitching: true });
+      const codexCaps = makeCapabilities({ modelSwitching: false });
+      api.getProviderCapabilities.mockImplementation(async (id: string) =>
+        id === 'claude' ? claudeCaps : codexCaps
+      );
+
+      const { result } = renderHook(() => useProvider());
+      await waitFor(() => expect(result.current.providers).toEqual([]));
+
+      const claudeFirst = await result.current.getCapabilities('claude');
+      const codexFirst = await result.current.getCapabilities('codex');
+      const claudeSecond = await result.current.getCapabilities('claude');
+      const codexSecond = await result.current.getCapabilities('codex');
+
+      expect(claudeFirst).toEqual(claudeCaps);
+      expect(codexFirst).toEqual(codexCaps);
+      expect(claudeSecond).toEqual(claudeCaps);
+      expect(codexSecond).toEqual(codexCaps);
+      expect(api.getProviderCapabilities).toHaveBeenCalledTimes(2);
+      expect(api.getProviderCapabilities).toHaveBeenNthCalledWith(1, 'claude');
+      expect(api.getProviderCapabilities).toHaveBeenNthCalledWith(2, 'codex');
+    });
+  });
+});


### PR DESCRIPTION
Closes #186

## Summary

Adds `src/renderer/hooks/useProvider.test.ts`, the last untested renderer hook (every sibling in `src/renderer/hooks/` already has one; `useRepos` was covered separately in #185/PR #188). Test-only change, no runtime code touched.

Covers the two behaviors called out in the issue:
1. **Per-`providerId` capabilities cache** (`useProvider.ts:20-27`) — `getCapabilities(id)` calls `getProviderCapabilities` exactly once per id and returns the cached value on repeat calls; two distinct ids cache independently (asserted via mock call counts, including `toHaveBeenNthCalledWith`).
2. **Undefined-guard on mount** (`useProvider.ts:11-16`) — asserts `providers`/`availableProviders` fall back to `[]` when `listProviders()`/`getAvailableProviders()` resolve `undefined` (the default behavior of the shared `electron-api-mock` helper), and that they populate correctly when the mocks resolve real arrays.

4 tests total, mirroring the `renderHook` + shared `electron-api-mock` pattern used throughout this directory (e.g. `useDrag.test.ts`).

## Verification

- `npx tsc --noEmit -p tsconfig.json` — clean
- `npx tsc --noEmit -p tsconfig.main.json` — clean
- Targeted: `npx vitest run --config vitest.workspace.ts --project renderer src/renderer/hooks/useProvider.test.ts` — 4/4 passing
- Full suite: `npm test` — 105 files / 1228 tests passing, zero regressions
- Rebased onto latest `main` (post #187/#188 merges) and re-verified tsc + targeted test afterward

No new dependencies.