### PR TITLE
test(remote): cover prod static-file branch; switch containment guard to isPathWithin

### DIFF
--- a/src/main/remote/remote-access-server.test.ts
+++ b/src/main/remote/remote-access-server.test.ts
@@ -7,6 +7,7 @@ import { RemoteAccessServer } from './remote-access-server';
 import { RemoteAuth } from './remote-auth';
 import { ClientHub } from './client-hub';
 import type { IPCRegistry } from '../ipc-registry';
+import { isPathWithin } from '../path-access';
 
 // End-to-end: boot the real server on an ephemeral port and drive it over real
 // HTTP + WebSocket. The IPC registry is stubbed (its own routing is unit-tested
@@ -126,6 +127,70 @@ describe('RemoteAccessServer (integration)', () => {
     const m = await res.json();
     expect(m.display).toBe('standalone');
     expect(m.start_url).toContain(`token=${encodeURIComponent(auth.getToken())}`);
+  });
+
+  // #191: the prod static-file branch (traversal guard, asset MIME, SPA
+  // fallback) had no coverage, and the containment check used a raw
+  // `filePath.startsWith(rendererDir)` — which wrongly treats a sibling
+  // directory that merely shares rendererDir as a string prefix (e.g.
+  // `<rendererDir>-secrets`) as "inside" it. The guard now uses isPathWithin.
+  describe('prod static-file serving', () => {
+    it('serves a real asset from rendererDir with the correct Content-Type and exact body', async () => {
+      const cookie = `${RemoteAuth.COOKIE}=${auth.getToken()}`;
+      const assetBody = 'console.log("omnidesk asset fixture");\n';
+      fs.writeFileSync(path.join(rendererDir, 'app.js'), assetBody);
+
+      const res = await fetch(`${base}/app.js`, { headers: { Cookie: cookie } });
+      expect(res.status).toBe(200);
+      expect(res.headers.get('content-type')).toContain('text/javascript');
+      expect(await res.text()).toBe(assetBody);
+    });
+
+    it('falls back to the injected index.html (200, not 404) for an unknown route', async () => {
+      const cookie = `${RemoteAuth.COOKIE}=${auth.getToken()}`;
+      const res = await fetch(`${base}/some/client/side/route`, { headers: { Cookie: cookie } });
+      expect(res.status).toBe(200);
+      const html = await res.text();
+      expect(html).toContain('OMNIDESK_TEST_BODY');
+      expect(html).toContain('/__omnidesk/web-bridge.js');
+    });
+
+    // These requests never actually escape rendererDir: the URL parser collapses
+    // '/../../etc/passwd' to '/etc/passwd' before it reaches our code, and
+    // path.join treats the percent-/backslash-encoded variants as ordinary
+    // (nonexistent) file names, not real '..' segments — so all three land back
+    // on the SPA fallback rather than a 403 or, worse, leaked content. The
+    // assertion is what actually matters here: nothing outside rendererDir (or
+    // the fixture's own files) is ever returned.
+    it.each([
+      ['dot-dot traversal', '/../../etc/passwd'],
+      ['percent-encoded traversal', '/%2e%2e/%2e%2e/x'],
+      ['backslash-encoded traversal', '/..%5c..%5cx'],
+    ])('does not leak content outside rendererDir for %s (%s)', async (_label, urlPath) => {
+      const cookie = `${RemoteAuth.COOKIE}=${auth.getToken()}`;
+      const res = await fetch(`${base}${urlPath}`, { headers: { Cookie: cookie } });
+      expect(res.status).not.toBe(403);
+      expect(res.status).not.toBe(500);
+      const body = await res.text();
+      // Whatever comes back, it must be our SPA fallback — never real system
+      // file content (e.g. an actual /etc/passwd would contain "root:").
+      expect(body).toContain('OMNIDESK_TEST_BODY');
+      expect(body).not.toContain('root:');
+    });
+
+    it('isPathWithin (unlike the old startsWith guard) rejects a sibling directory that merely shares rendererDir as a string prefix', () => {
+      // A path like `<rendererDir>-secrets` starts with the literal rendererDir
+      // string but is a sibling directory, not something inside it. The old
+      // `filePath.startsWith(rendererDir)` guard would have wrongly let this
+      // through; isPathWithin correctly rejects it because it enforces a path
+      // separator boundary. This can't be reached via a real HTTP request today
+      // (path.join always keeps filePath under rendererDir), but it's exactly
+      // the class of bug the switch to isPathWithin closes off for any future
+      // refactor of how filePath gets built.
+      const sibling = `${rendererDir}-secrets`;
+      expect(sibling.startsWith(rendererDir)).toBe(true); // the old guard's condition — would have allowed it
+      expect(isPathWithin(sibling, rendererDir)).toBe(false); // the new guard correctly rejects it
+    });
   });
 
   it('rejects a WebSocket upgrade without a valid cookie', async () => {

--- a/src/main/remote/remote-access-server.ts
+++ b/src/main/remote/remote-access-server.ts
@@ -9,6 +9,7 @@ import { generateWebBridgeScript } from './web-bridge';
 import { handleWsMessage } from './ws-router';
 import { injectRemoteHead, buildManifest, mimeFor } from './http-util';
 import { channels, contractKinds } from '../../shared/ipc-contract';
+import { isPathWithin } from '../path-access';
 
 export interface RemoteServerOptions {
   port: number;
@@ -197,7 +198,7 @@ export class RemoteAccessServer {
     const rendererDir = path.resolve(this.opts.rendererDir);
     const filePath = path.join(rendererDir, safeRel);
 
-    if (!filePath.startsWith(rendererDir)) {
+    if (!isPathWithin(filePath, rendererDir)) {
       res.writeHead(403).end('Forbidden');
       return;
     }


### PR DESCRIPTION
Closes #191

## Summary

`remote-access-server.ts`'s production static-file branch (traversal guard,
asset serving, SPA fallback) — the network-exposed handler that serves the
built SPA over the Cloudflare tunnel — had zero test coverage. It also used a
raw `filePath.startsWith(rendererDir)` containment check: a string prefix with
no path-separator boundary, which is exactly the sibling-directory escape
`isPathWithin` (`src/main/path-access.ts`) was written to prevent elsewhere in
this codebase (cf. #162/#163/#168).

## Changes

- `src/main/remote/remote-access-server.ts`: replaced
  `filePath.startsWith(rendererDir)` with `isPathWithin(filePath, rendererDir)`.
  No behavior change for legitimate in-tree paths — `path.normalize` on the
  leading-slash `url.pathname` already neutralizes `..` today, so this is
  defense-in-depth against a future refactor, not a fix for a demonstrable
  current exploit (matches the issue's own note).
- `src/main/remote/remote-access-server.test.ts`: added a `describe('prod
  static-file serving')` block with 5 new tests (all authenticated via the
  existing cookie):
  - Real asset served from `rendererDir` with `mimeFor`-derived Content-Type
    and byte-identical body.
  - Unknown route falls back to the injected `index.html` (200, not 404).
  - Three traversal variants (`/../../etc/passwd`, percent-encoded, and
    backslash-encoded) never leak content outside `rendererDir` — they all
    land on the SPA fallback.
  - Direct check that `isPathWithin` rejects a sibling directory that merely
    shares `rendererDir` as a string prefix (e.g. `<rendererDir>-secrets`),
    which the old `startsWith` guard would have wrongly allowed.

No new dependencies.

## Verification

- `npx tsc --noEmit` on both `tsconfig.json` and `tsconfig.main.json`: clean.
- Targeted: `vitest --project main src/main/remote/remote-access-server.test.ts`
  — 17/17 passing (12 pre-existing + 5 new).
- Full suite: `npm test` — 107 files / 1259 tests, all green, no regressions.