### PR TITLE
feat(cockpit): keyboard Dismiss and Ship-it shortcuts in CockpitPanel

### DIFF
--- a/src/renderer/components/shell/CockpitPanel.test.tsx
+++ b/src/renderer/components/shell/CockpitPanel.test.tsx
@@ -1,0 +1,125 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { CockpitPanel } from './CockpitPanel';
+import type { AttentionItem } from '../../hooks/useAttentionQueue';
+import type { TabData } from '../ui/Tab';
+
+function makeItem(overrides: Partial<TabData> & { id: string; name: string }): AttentionItem {
+  const session: TabData = {
+    id: overrides.id,
+    name: overrides.name,
+    workingDirectory: '/tmp/repo',
+    permissionMode: 'standard',
+    status: overrides.status ?? 'running',
+    activityState: overrides.activityState,
+    providerId: overrides.providerId ?? 'claude',
+    kind: 'agent',
+  };
+  return {
+    session,
+    repoId: 'repo-1',
+    repoName: 'omnidesk',
+    state: (overrides.activityState as any) ?? 'awaiting-input',
+    preview: '',
+    lastActivityAt: Date.now(),
+    acknowledged: false,
+  };
+}
+
+describe('CockpitPanel keyboard shortcuts', () => {
+  it('ArrowDown then Enter jumps to the selected session and closes', () => {
+    const items = [
+      makeItem({ id: 's1', name: 'Session One', activityState: 'awaiting-input' }),
+      makeItem({ id: 's2', name: 'Session Two', activityState: 'awaiting-input' }),
+    ];
+    const onJump = vi.fn();
+    const onClose = vi.fn();
+    render(
+      <CockpitPanel items={items} onJump={onJump} onAcknowledge={vi.fn()} onClose={onClose} />
+    );
+
+    const dialog = screen.getByRole('dialog', { name: 'Attention cockpit' });
+    fireEvent.keyDown(dialog, { key: 'ArrowDown' });
+    fireEvent.keyDown(dialog, { key: 'Enter' });
+
+    expect(onJump).toHaveBeenCalledWith('s2');
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('Escape closes the panel without jumping or acknowledging', () => {
+    const items = [makeItem({ id: 's1', name: 'Session One', activityState: 'awaiting-input' })];
+    const onJump = vi.fn();
+    const onAcknowledge = vi.fn();
+    const onClose = vi.fn();
+    render(
+      <CockpitPanel items={items} onJump={onJump} onAcknowledge={onAcknowledge} onClose={onClose} />
+    );
+
+    fireEvent.keyDown(screen.getByRole('dialog'), { key: 'Escape' });
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(onJump).not.toHaveBeenCalled();
+    expect(onAcknowledge).not.toHaveBeenCalled();
+  });
+
+  (['d', 'Backspace', 'Delete'] as const).forEach((key) => {
+    it(`'${key}' dismisses the selected item without closing the panel`, () => {
+      const items = [makeItem({ id: 's1', name: 'Session One', activityState: 'errored' })];
+      const onAcknowledge = vi.fn();
+      const onClose = vi.fn();
+      render(
+        <CockpitPanel items={items} onJump={vi.fn()} onAcknowledge={onAcknowledge} onClose={onClose} />
+      );
+
+      fireEvent.keyDown(screen.getByRole('dialog'), { key });
+
+      expect(onAcknowledge).toHaveBeenCalledWith('s1');
+      expect(onClose).not.toHaveBeenCalled();
+    });
+  });
+
+  it("'s' triggers Ship-it and closes when the selected item is done", () => {
+    const items = [makeItem({ id: 's1', name: 'Session One', status: 'running', activityState: 'done' })];
+    const onShipIt = vi.fn();
+    const onClose = vi.fn();
+    render(
+      <CockpitPanel items={items} onJump={vi.fn()} onAcknowledge={vi.fn()} onClose={onClose} onShipIt={onShipIt} />
+    );
+
+    fireEvent.keyDown(screen.getByRole('dialog'), { key: 's' });
+
+    expect(onShipIt).toHaveBeenCalledWith('s1', 'Session One');
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("'s' is a no-op when the selected item is not done", () => {
+    const items = [makeItem({ id: 's1', name: 'Session One', activityState: 'awaiting-input' })];
+    const onShipIt = vi.fn();
+    const onClose = vi.fn();
+    render(
+      <CockpitPanel items={items} onJump={vi.fn()} onAcknowledge={vi.fn()} onClose={onClose} onShipIt={onShipIt} />
+    );
+
+    fireEvent.keyDown(screen.getByRole('dialog'), { key: 's' });
+
+    expect(onShipIt).not.toHaveBeenCalled();
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it("'s' is a no-op on a done item when onShipIt is not provided", () => {
+    const items = [makeItem({ id: 's1', name: 'Session One', activityState: 'done' })];
+    const onClose = vi.fn();
+    render(
+      <CockpitPanel items={items} onJump={vi.fn()} onAcknowledge={vi.fn()} onClose={onClose} />
+    );
+
+    expect(() => fireEvent.keyDown(screen.getByRole('dialog'), { key: 's' })).not.toThrow();
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it('renders the empty state when there are no items', () => {
+    render(<CockpitPanel items={[]} onJump={vi.fn()} onAcknowledge={vi.fn()} onClose={vi.fn()} />);
+
+    expect(screen.getByText('Nothing needs you')).toBeInTheDocument();
+  });
+});

--- a/src/renderer/components/shell/CockpitPanel.tsx
+++ b/src/renderer/components/shell/CockpitPanel.tsx
@@ -33,6 +33,19 @@ export function CockpitPanel({ items, onJump, onAcknowledge, onClose, onShipIt }
     else if (e.key === 'ArrowUp') { setSel(s => Math.max(0, s - 1)); e.preventDefault(); }
     else if (e.key === 'Enter') { const it = items[sel]; if (it) jump(it.session.id); e.preventDefault(); }
     else if (e.key === 'Escape') { onClose(); }
+    else if (e.key === 'd' || e.key === 'Backspace' || e.key === 'Delete') {
+      const it = items[sel]; if (!it) return;
+      e.preventDefault();
+      onAcknowledge(it.session.id);
+    }
+    else if (e.key === 's') {
+      const it = items[sel]; if (!it) return;
+      e.preventDefault();
+      if (mapTabStatus(it.session) === 'done' && onShipIt) {
+        onShipIt(it.session.id, it.session.name);
+        onClose();
+      }
+    }
   };
 
   return (


### PR DESCRIPTION
## Summary
Closes #198.

Adds two keyboard shortcuts to the attention cockpit (⌘J) beyond the existing arrow-key navigation and Enter-to-jump:

- **`d` / Backspace / Delete** — dismiss (acknowledge) the currently-selected item without closing the panel, so you can work through a queue of several items one key at a time.
- **`s`** — trigger the "Ship it" handoff (session → PR) for the selected item, but only when that item's status is `done` and an `onShipIt` handler was passed in. It's a no-op otherwise (wrong status, or no handler wired up) — mirrors the existing "Ship it" button's own guard (`status === 'done' && onShipIt`).

No visual changes; this only extends `CockpitPanel`'s `handleKey`.

## Why
Issue #198 asked for keyboard-only dismiss/ship-it so the cockpit can be driven entirely without a mouse, matching the existing ArrowUp/ArrowDown/Enter/Escape shortcuts.

## Verification
- New file `CockpitPanel.test.tsx` (9 tests): ArrowDown+Enter jump-and-close, Escape close (no jump/ack), each of `d`/Backspace/Delete dismissing without closing, Ship-it firing and closing on a done item, Ship-it no-op on a non-done item, Ship-it no-op when `onShipIt` isn't provided, and the empty-state render.
- Full renderer Vitest project: **48 files / 368 tests passing** (`npx vitest run --config vitest.workspace.ts --project renderer`).
- `npx tsc --noEmit`: clean, no errors.

## Dependencies
None added.