### PR TITLE
feat(session-state): add headless ScreenModel with debounced settle (#196)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@xenova/transformers": "^2.17.2",
         "@xterm/addon-fit": "^0.10.0",
         "@xterm/addon-web-links": "^0.11.0",
+        "@xterm/headless": "5.5.0",
         "@xterm/xterm": "^5.5.0",
         "electron-updater": "^6.8.3",
         "lucide-react": "^0.563.0",
@@ -48,6 +49,10 @@
         "typescript": "^5.3.0",
         "vite": "^5.0.0",
         "vitest": "^4.0.18"
+      },
+      "engines": {
+        "node": ">=20.0.0",
+        "npm": ">=10.0.0"
       }
     },
     "node_modules/@acemir/cssom": {
@@ -3140,6 +3145,12 @@
       "peerDependencies": {
         "@xterm/xterm": "^5.0.0"
       }
+    },
+    "node_modules/@xterm/headless": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/@xterm/headless/-/headless-5.5.0.tgz",
+      "integrity": "sha512-5xXB7kdQlFBP82ViMJTwwEc3gKCLGKR/eoxQm4zge7GPBl86tCdI0IdPJjoKd8mUSFXz5V7i/25sfsEkP4j46g==",
+      "license": "MIT"
     },
     "node_modules/@xterm/xterm": {
       "version": "5.5.0",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "@xenova/transformers": "^2.17.2",
     "@xterm/addon-fit": "^0.10.0",
     "@xterm/addon-web-links": "^0.11.0",
+    "@xterm/headless": "5.5.0",
     "@xterm/xterm": "^5.5.0",
     "electron-updater": "^6.8.3",
     "lucide-react": "^0.563.0",

--- a/src/main/session-state/screen-model.test.ts
+++ b/src/main/session-state/screen-model.test.ts
@@ -1,0 +1,197 @@
+import { describe, it, expect } from 'vitest';
+import { ScreenModel, type ScreenSnapshot } from './screen-model';
+import { claudeApprovalFrames } from '../../../test/fixtures/agent-screens/claude-approval-frames';
+import { codexAltScreenLeaveFrames } from '../../../test/fixtures/agent-screens/codex-altscreen-leave-frames';
+
+/**
+ * A virtual-clock fake scheduler. Unlike the single-slot harness used by
+ * classifier.test.ts, ScreenModel can have TWO independent timers armed at
+ * once (flushTimer + settleTimer) with different delays, so this fake
+ * tracks an arbitrary number of pending timers against a virtual `now` and
+ * fires whichever are due, in deadline order, when advanced.
+ */
+function makeFakeScheduler() {
+  let now = 0;
+  let nextHandle = 1;
+  const pending = new Map<number, { at: number; fn: () => void }>();
+
+  const setTimer = (fn: () => void, ms: number) => {
+    const handle = nextHandle++;
+    pending.set(handle, { at: now + ms, fn });
+    return handle as unknown as ReturnType<typeof setTimeout>;
+  };
+
+  const clearTimer = (h: ReturnType<typeof setTimeout>) => {
+    pending.delete(h as unknown as number);
+  };
+
+  /** Advance virtual time and fire all timers now due, in deadline order. */
+  const advance = (ms: number) => {
+    now += ms;
+    for (;;) {
+      let dueHandle: number | null = null;
+      let dueAt = Infinity;
+      for (const [handle, entry] of pending) {
+        if (entry.at <= now && entry.at < dueAt) {
+          dueAt = entry.at;
+          dueHandle = handle;
+        }
+      }
+      if (dueHandle === null) break;
+      const entry = pending.get(dueHandle)!;
+      pending.delete(dueHandle);
+      entry.fn();
+    }
+  };
+
+  const pendingCount = () => pending.size;
+
+  return { setTimer, clearTimer, advance, pendingCount };
+}
+
+function makeModel(overrides: Partial<Parameters<typeof ScreenModel.prototype.write>> = {}) {
+  const scheduler = makeFakeScheduler();
+  const snapshots: ScreenSnapshot[] = [];
+  const model = new ScreenModel({
+    quiescenceMs: 300,
+    flushIntervalMs: 16,
+    onSettled: (s) => snapshots.push(s),
+    setTimer: scheduler.setTimer,
+    clearTimer: scheduler.clearTimer,
+  });
+  return { model, scheduler, snapshots };
+}
+
+/** Feed frames with a small virtual gap between each, then let flush+settle run out. */
+function feedFrames(
+  model: ScreenModel,
+  scheduler: ReturnType<typeof makeFakeScheduler>,
+  frames: string[],
+  gapMs = 5
+) {
+  for (const frame of frames) {
+    model.write(frame);
+    scheduler.advance(gapMs);
+  }
+  // Run the clock forward past both the flush interval and the quiescence
+  // window so any trailing coalesced write and the final settle fire.
+  scheduler.advance(500);
+}
+
+/**
+ * Poll a predicate using REAL time until it's true. `Terminal.write()`
+ * (from @xterm/headless) completes asynchronously off the real Node event
+ * loop, not off the fake scheduler used for flushTimer/settleTimer — so once
+ * checkSettled() has fired (via scheduler.advance), the resulting onSettled
+ * callback may still be pending a real event-loop tick. The fake scheduler
+ * can't be used to wait for this: it only fires timers it owns, synchronously,
+ * so it would never yield to the real tick the write's completion depends on.
+ */
+async function waitFor(predicate: () => boolean, timeoutMs = 2000): Promise<void> {
+  const start = Date.now();
+  while (!predicate()) {
+    if (Date.now() - start > timeoutMs) {
+      throw new Error('waitFor timed out');
+    }
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  }
+}
+
+describe('ScreenModel', () => {
+  it('renders a box-drawn prompt at its absolute cursor position (Claude approval fixture)', async () => {
+    const { model, scheduler, snapshots } = makeModel();
+    feedFrames(model, scheduler, claudeApprovalFrames);
+    await waitFor(() => snapshots.length > 0);
+    model.dispose();
+
+    expect(snapshots.length).toBeGreaterThan(0);
+    const last = snapshots[snapshots.length - 1];
+    expect(last.altScreenActive).toBe(true);
+    // Box-drawing prompt lines landed at the rows/cols they were painted at,
+    // not appended at the tail — this is exactly what the tail-based
+    // line-reducer cannot do.
+    expect(last.lines[3]).toContain('Run `rm -rf build/`?');
+    expect(last.lines[2]).toContain('╭');
+    expect(last.lines[4]).toContain('╰');
+    // Final frame replaced the spinner with the awaiting-input affordance.
+    expect(last.lines[6]).toContain('❯ Yes / No');
+    expect(last.lines[6]).not.toMatch(/[⠋⠙⠹⠸⠼⠴⠦⠧]/);
+  });
+
+  it('tracks alt-screen enter and leave, returning to the normal buffer (Codex fixture)', async () => {
+    const { model, scheduler, snapshots } = makeModel();
+
+    // Feed only the alt-screen portion first and settle.
+    const altPortion = codexAltScreenLeaveFrames.slice(0, -2);
+    feedFrames(model, scheduler, altPortion);
+    await waitFor(() => snapshots.length > 0);
+    expect(snapshots[snapshots.length - 1].altScreenActive).toBe(true);
+
+    // Now feed the leave + trailing scrollback line and settle again.
+    const rest = codexAltScreenLeaveFrames.slice(-2);
+    const countBefore = snapshots.length;
+    feedFrames(model, scheduler, rest);
+    await waitFor(() => snapshots.length > countBefore);
+    model.dispose();
+
+    const last = snapshots[snapshots.length - 1];
+    expect(last.altScreenActive).toBe(false);
+    expect(last.lines.join('\n')).toContain('Applied patch and ran tests: 42 passed, 0 failed.');
+  });
+
+  it('debounces rapid churn into exactly one settle snapshot per quiet period', async () => {
+    const { model, scheduler, snapshots } = makeModel();
+
+    // Simulate a burst of spinner repaints, each arriving well within the
+    // quiescence window (300ms) of the previous one — no settle should fire
+    // mid-burst.
+    model.write('\x1b[?1049h\x1b[2J\x1b[H');
+    for (let i = 0; i < 20; i++) {
+      model.write(`\x1b[5;1Hspinner frame ${i}`);
+      scheduler.advance(10); // well under quiescenceMs
+    }
+    expect(snapshots.length).toBe(0);
+
+    // Now let the screen go quiet.
+    scheduler.advance(500);
+    await waitFor(() => snapshots.length === 1);
+
+    expect(snapshots.length).toBe(1);
+    expect(snapshots[0].lines[4]).toContain('spinner frame 19');
+    model.dispose();
+  });
+
+  it('caps emulator write frequency under a continuous spinner burst (update-frequency cap)', async () => {
+    const { model, scheduler, snapshots } = makeModel();
+
+    const WRITE_COUNT = 200;
+    for (let i = 0; i < WRITE_COUNT; i++) {
+      model.write(`\x1b[3;1Hspin ${i}`);
+      scheduler.advance(2); // much faster than flushIntervalMs (16ms)
+    }
+    scheduler.advance(500);
+    await waitFor(() => snapshots.length === 1);
+    model.dispose();
+
+    const counters = model.getCostCounters();
+    // Many small writes should have been coalesced into far fewer emulator
+    // writes (bounded by elapsed-time / flushIntervalMs), not one per write().
+    expect(counters.writeCallCount).toBeLessThan(WRITE_COUNT / 4);
+    // Exactly one render for this single settle — the expensive grid read
+    // must never run per-flush, only once per settle.
+    expect(counters.renderCount).toBe(1);
+    expect(snapshots.length).toBe(1);
+
+    // Rough cost note for the PR: with a 200-write / 2ms-interval burst
+    // (a much faster spinner than any real CLI produces) over a 16ms flush
+    // cadence, the emulator only had to parse ~counters.writeCallCount
+    // batches and render once — i.e. cost is bounded by wall-clock time
+    // elapsed, not by how many chunks the PTY happens to flush.
+  });
+
+  it('does not emit a settle snapshot before dispose if nothing was ever written', () => {
+    const { model, snapshots } = makeModel();
+    model.dispose();
+    expect(snapshots.length).toBe(0);
+  });
+});

--- a/src/main/session-state/screen-model.ts
+++ b/src/main/session-state/screen-model.ts
@@ -1,0 +1,226 @@
+// Headless rendered-screen model for agent sessions.
+//
+// The existing line-reducer (../../shared/line-reducer.ts) turns a raw PTY
+// tail into a bounded set of "logical lines" using structural byte parsing
+// (\n, \r, CSI K/A/B/G). That's enough for shells and most CLI output, but it
+// cannot correctly model:
+//   - alt-screen enter/leave (a full-screen TUI redraws the whole viewport;
+//     the reducer has no notion of "this is a different screen buffer")
+//   - absolute cursor positioning (CSI H / CSI f) used by TUIs to paint a
+//     status line, a box-drawn prompt, or a spinner at an arbitrary
+//     row/column instead of just appending at the tail
+//
+// ScreenModel fixes this by feeding raw bytes into a real headless VT
+// emulator (@xterm/headless) and reading back its rendered grid. It is
+// intentionally NOT wired into session-manager/classifier/UI yet (#196) —
+// this is infra only, added and tested in isolation so the rest of the
+// system's behavior is provably unchanged.
+//
+// Two independent timers, mirroring the update-frequency / debounce split
+// used by SessionStateClassifier (./classifier.ts):
+//   - flushTimer   caps how often raw writes are pushed into the emulator.
+//                  A busy spinner can emit dozens of small chunks per
+//                  second; each `Terminal.write()` call walks the terminal's
+//                  parser, so writing every chunk individually re-parses far
+//                  more than needed. Chunks arriving within FLUSH_INTERVAL_MS
+//                  of each other are coalesced into one write.
+//   - settleTimer  the debounced "screen has stopped churning" signal.
+//                  Reading the grid (renderLines()) is the expensive part
+//                  (walks every row, builds strings) so it must never run
+//                  per-frame — only once, after QUIESCENCE_MS of no new
+//                  writes, producing a single ScreenSnapshot per settle.
+//
+// This keeps the two costs separate: flush caps *parse* cost, settle caps
+// *render* cost, and only settle ever triggers onSettled().
+
+import { Terminal } from '@xterm/headless';
+
+/** A fully-rendered, debounced snapshot of the emulated screen. */
+export interface ScreenSnapshot {
+  /** Rendered rows, top to bottom, trailing whitespace trimmed. Length === rows. */
+  lines: string[];
+  /** True if the alternate screen buffer (full-screen TUI) is active. */
+  altScreenActive: boolean;
+  /** 0-based cursor row within the active buffer's viewport. */
+  cursorRow: number;
+  /** 0-based cursor column. */
+  cursorCol: number;
+}
+
+export interface ScreenModelOptions {
+  /** Emulated terminal width. Defaults to 80. */
+  cols?: number;
+  /** Emulated terminal height. Defaults to 24. */
+  rows?: number;
+  /** Quiet window before a settle snapshot is emitted (ms). Default 300. */
+  quiescenceMs?: number;
+  /** Minimum interval between emulator writes (ms), caps parse cost. Default 16 (~60Hz). */
+  flushIntervalMs?: number;
+  /** Called at most once per settle, with the rendered snapshot. */
+  onSettled: (snapshot: ScreenSnapshot) => void;
+  /** Injectable timer hooks (tests). Default to global setTimeout/clearTimeout. */
+  setTimer?: (fn: () => void, ms: number) => ReturnType<typeof setTimeout>;
+  clearTimer?: (h: ReturnType<typeof setTimeout>) => void;
+}
+
+const DEFAULT_COLS = 80;
+const DEFAULT_ROWS = 24;
+const DEFAULT_QUIESCENCE_MS = 300;
+const DEFAULT_FLUSH_INTERVAL_MS = 16;
+
+export class ScreenModel {
+  private readonly term: Terminal;
+  private readonly quiescenceMs: number;
+  private readonly flushIntervalMs: number;
+  private readonly onSettled: (snapshot: ScreenSnapshot) => void;
+  private readonly setTimer: (fn: () => void, ms: number) => ReturnType<typeof setTimeout>;
+  private readonly clearTimer: (h: ReturnType<typeof setTimeout>) => void;
+
+  private pendingChunks: string[] = [];
+  private flushTimer: ReturnType<typeof setTimeout> | null = null;
+  private settleTimer: ReturnType<typeof setTimeout> | null = null;
+  private disposed = false;
+
+  // `Terminal.write()` is asynchronous: it queues data and parses it on a
+  // later tick (verified empirically — the buffer is stale even one
+  // microtask after write() returns, and only reflects the write once its
+  // completion callback fires). A settle must never render before every
+  // write it depends on has actually landed, so we track in-flight writes
+  // and defer rendering until they drain, guarded by a generation counter
+  // so a stale wait (superseded by newer data) never emits.
+  private writesInFlight = 0;
+  private writeWaiters: Array<() => void> = [];
+  private generation = 0;
+
+  /** Rough cost accounting, surfaced for the PR's perf write-up (not perf-critical itself). */
+  private writeCallCount = 0;
+  private flushCount = 0;
+  private renderCount = 0;
+
+  constructor(opts: ScreenModelOptions) {
+    this.term = new Terminal({
+      cols: opts.cols ?? DEFAULT_COLS,
+      rows: opts.rows ?? DEFAULT_ROWS,
+      allowProposedApi: true, // required for buffer.active (IBufferNamespace)
+      scrollback: 0, // we only ever read the live viewport, never history
+    });
+    this.quiescenceMs = opts.quiescenceMs ?? DEFAULT_QUIESCENCE_MS;
+    this.flushIntervalMs = opts.flushIntervalMs ?? DEFAULT_FLUSH_INTERVAL_MS;
+    this.onSettled = opts.onSettled;
+    this.setTimer = opts.setTimer ?? ((fn, ms) => setTimeout(fn, ms));
+    this.clearTimer = opts.clearTimer ?? ((h) => clearTimeout(h));
+  }
+
+  /** Feed a raw PTY output chunk. Coalesced into the emulator at flushIntervalMs cadence. */
+  write(data: string): void {
+    if (this.disposed || !data) return;
+    this.pendingChunks.push(data);
+    this.generation++;
+    if (this.flushTimer === null) {
+      this.flushTimer = this.setTimer(() => this.flush(), this.flushIntervalMs);
+    }
+    // Any new byte resets the quiescence window: the screen is still churning.
+    this.armSettleTimer();
+  }
+
+  /**
+   * Force any pending writes into the emulator. `Terminal.write()` is async
+   * (see the class-level comment): its effect is only visible once its own
+   * completion callback fires. `onDone`, when provided, is invoked exactly
+   * once that write has actually landed (or immediately, if there was
+   * nothing to flush) — callers that need to read the buffer afterward MUST
+   * wait for it rather than assuming this call is synchronous.
+   */
+  private flush(onDone?: () => void): void {
+    this.flushTimer = null;
+    if (this.disposed || this.pendingChunks.length === 0) {
+      if (onDone) onDone();
+      return;
+    }
+    const batch = this.pendingChunks.join('');
+    this.pendingChunks = [];
+    this.flushCount++;
+    this.writeCallCount++;
+    this.writesInFlight++;
+    this.term.write(batch, () => {
+      this.writesInFlight--;
+      if (onDone) onDone();
+      if (this.writesInFlight === 0 && this.writeWaiters.length > 0) {
+        const waiters = this.writeWaiters;
+        this.writeWaiters = [];
+        for (const w of waiters) w();
+      }
+    });
+  }
+
+  private armSettleTimer(): void {
+    if (this.settleTimer !== null) {
+      this.clearTimer(this.settleTimer);
+    }
+    this.settleTimer = this.setTimer(() => this.checkSettled(), this.quiescenceMs);
+  }
+
+  private checkSettled(): void {
+    this.settleTimer = null;
+    if (this.disposed) return;
+    // Make sure any coalesced-but-not-yet-written chunks land before we render,
+    // otherwise the snapshot could lag behind the last input by one flush tick.
+    // Because `Terminal.write()` is async, "landed" means waiting for its
+    // completion callback — never rendering right after issuing it. `gen`
+    // guards against a stale wait firing after newer data has already
+    // superseded it (a fresh write() bumps `generation`, so this emit becomes
+    // a no-op and the newer, already-rearmed settle handles it instead).
+    const gen = this.generation;
+    const emit = () => {
+      if (this.disposed || this.generation !== gen) return;
+      this.onSettled(this.renderSnapshot());
+    };
+    if (this.pendingChunks.length > 0) {
+      this.flush(emit);
+    } else if (this.writesInFlight > 0) {
+      this.writeWaiters.push(emit);
+    } else {
+      emit();
+    }
+  }
+
+  /** Read the current emulator grid. Only called from a settle — never per-write. */
+  private renderSnapshot(): ScreenSnapshot {
+    this.renderCount++;
+    const buffer = this.term.buffer.active;
+    const lines: string[] = [];
+    for (let y = 0; y < this.term.rows; y++) {
+      const line = buffer.getLine(buffer.viewportY + y);
+      lines.push(line ? line.translateToString(true) : '');
+    }
+    return {
+      lines,
+      altScreenActive: buffer.type === 'alternate',
+      cursorRow: buffer.cursorY,
+      cursorCol: buffer.cursorX,
+    };
+  }
+
+  /** Rough cost counters for perf reporting (writes coalesced, flushes, renders). */
+  getCostCounters(): { writeCallCount: number; flushCount: number; renderCount: number } {
+    return {
+      writeCallCount: this.writeCallCount,
+      flushCount: this.flushCount,
+      renderCount: this.renderCount,
+    };
+  }
+
+  dispose(): void {
+    if (this.disposed) return;
+    this.disposed = true;
+    if (this.flushTimer !== null) {
+      this.clearTimer(this.flushTimer);
+      this.flushTimer = null;
+    }
+    if (this.settleTimer !== null) {
+      this.clearTimer(this.settleTimer);
+      this.settleTimer = null;
+    }
+    this.term.dispose();
+  }
+}

--- a/test/fixtures/agent-screens/claude-approval-frames.ts
+++ b/test/fixtures/agent-screens/claude-approval-frames.ts
@@ -1,0 +1,33 @@
+// Synthetic-but-realistic frame sequence modeled on Claude Code's TUI
+// approval-prompt flow: enter alt screen, draw a box-drawn confirmation
+// prompt, cycle a braille spinner a few times while "thinking", then settle
+// on the final prompt text awaiting a keypress.
+//
+// NOTE (disclosed in PR #196): these bytes are hand-authored to match
+// documented/observed real-world behavior (alt-screen usage, braille
+// spinner cycling, box-drawing prompts) — they are not a literal capture
+// of a live session. Building a genuine capture harness was out of scope
+// for this behavior-neutral infra change.
+
+const ESC = '\x1b';
+const ENTER_ALT_SCREEN = `${ESC}[?1049h`;
+const CLEAR_AND_HOME = `${ESC}[2J${ESC}[H`;
+const cursorTo = (row: number, col: number) => `${ESC}[${row};${col}H`;
+
+const SPINNER_FRAMES = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧'];
+
+export const claudeApprovalFrames: string[] = [
+  // Enter the alternate screen buffer and clear it — this is the transition
+  // the line-tail reducer cannot model but ScreenModel must.
+  ENTER_ALT_SCREEN + CLEAR_AND_HOME,
+  // Draw a box-drawn prompt at a fixed viewport position.
+  cursorTo(3, 3) + '╭─────────────────────────────╮',
+  cursorTo(4, 3) + '│ Run `rm -rf build/`?        │',
+  cursorTo(5, 3) + '╰─────────────────────────────╯',
+  // Spinner churn: repeated single-cell repaints at the same absolute
+  // position while a background check runs — this is the "many small
+  // repaints in a burst" case the settle/flush split exists for.
+  ...SPINNER_FRAMES.map((frame) => cursorTo(7, 3) + frame + ' checking workspace…'),
+  // Final settle: spinner replaced by the awaiting-input affordance.
+  cursorTo(7, 3) + '❯ Yes / No' + ' '.repeat(20),
+];

--- a/test/fixtures/agent-screens/codex-altscreen-leave-frames.ts
+++ b/test/fixtures/agent-screens/codex-altscreen-leave-frames.ts
@@ -1,0 +1,28 @@
+// Synthetic-but-realistic frame sequence modeled on Codex CLI's
+// working-to-done flow: enter alt screen for a live progress view, cycle a
+// spinner while working, then LEAVE the alt screen back to the normal
+// buffer and print a final plain-text summary line — the counterpart to
+// claude-approval-frames.ts, which never leaves the alt screen.
+//
+// NOTE (disclosed in PR #196): hand-authored to match documented/observed
+// real-world behavior, not a literal capture of a live session — see the
+// same disclosure in claude-approval-frames.ts.
+
+const ESC = '\x1b';
+const ENTER_ALT_SCREEN = `${ESC}[?1049h`;
+const EXIT_ALT_SCREEN = `${ESC}[?1049l`;
+const CLEAR_AND_HOME = `${ESC}[2J${ESC}[H`;
+const cursorTo = (row: number, col: number) => `${ESC}[${row};${col}H`;
+
+const SPINNER_FRAMES = ['⠋', '⠙', '⠹', '⠸', '⠼'];
+
+export const codexAltScreenLeaveFrames: string[] = [
+  ENTER_ALT_SCREEN + CLEAR_AND_HOME,
+  cursorTo(1, 1) + 'Codex — applying patch',
+  ...SPINNER_FRAMES.map((frame) => cursorTo(2, 1) + frame + ' running tests…'),
+  // Leave the alt screen: the full-screen progress view closes and the
+  // terminal returns to the normal buffer/scrollback.
+  EXIT_ALT_SCREEN,
+  // Plain scrollback output printed after returning to the normal buffer.
+  'Applied patch and ran tests: 42 passed, 0 failed.\r\n',
+];


### PR DESCRIPTION
Closes #196

## What
Adds `ScreenModel`, a headless VT-emulator-backed screen model for agent
sessions. It feeds raw PTY bytes into `@xterm/headless` and maintains a
correctly-rendered grid, then emits a debounced "settled snapshot" once
repaint churn quiesces.

The existing tail-based `line-reducer.ts` works for shells/most CLI output
but can't model:
- alt-screen enter/leave (a full-screen TUI redraws the whole viewport)
- absolute cursor positioning (`CSI H`/`CSI f`) used to paint a status line,
  box-drawn prompt, or spinner at an arbitrary row/col instead of appending
  at the tail

`ScreenModel` fixes both by reading back the emulator's real buffer instead
of re-deriving structure from a byte tail.

## Design: two independent timers
Mirrors the update-frequency/debounce split already used by
`SessionStateClassifier` (`classifier.ts`):
- **flush timer** (default 16ms) caps how often raw chunks are parsed by the
  emulator — a busy spinner can emit dozens of small chunks/sec; coalescing
  avoids re-parsing per chunk.
- **settle timer** (default 300ms quiescence) caps how often the buffer is
  actually rendered into a `ScreenSnapshot` — the expensive part (walks
  every row, builds strings) — so it runs **at most once per quiet period**,
  never per-flush.

Only `settle` ever calls `onSettled()`.

## Cost cap, measured
`getCostCounters()` test (200 writes at a 2ms interval — much faster than
any real CLI spinner — against the default 16ms flush cadence) asserts:
- `writeCallCount < WRITE_COUNT / 4` (i.e. fewer than 50 actual emulator
  writes for 200 incoming chunks — cost bounded by wall-clock time elapsed,
  not by how many chunks the PTY happens to flush)
- `renderCount === 1` (the expensive grid read never runs per-flush, only
  once for the single settle)

## A real subtlety: `Terminal.write()` is asynchronous
`@xterm/headless`'s `Terminal.write(data, callback?)` queues data and parses
it on a later tick — the buffer is stale even one microtask after `write()`
returns, and only reflects the write once its completion callback fires.
A settle must never render before every write it depends on has actually
landed, so `ScreenModel` tracks in-flight writes (`writesInFlight`,
`writeWaiters`) and defers `checkSettled()`'s render until they drain. A
`generation` counter guards against a stale deferred settle firing after
newer data has already superseded it.

This also shaped the test harness: a virtual-clock fake scheduler drives
`flushTimer`/`settleTimer` deterministically, but can't wait for
`Terminal.write()`'s real completion callback (driven by the real Node
event loop). Tests combine the fake scheduler (for timer determinism) with
a real-time `waitFor(predicate)` poll (for the async write to actually
land).

## Fixtures
`test/fixtures/agent-screens/claude-approval-frames.ts` and
`codex-altscreen-leave-frames.ts` are **hand-authored, not literal captures
of live sessions** — built to match documented/observed real-world behavior
(alt-screen usage, braille spinner cycling, box-drawing prompts, alt-screen
leave back to scrollback). Building a genuine capture harness was out of
scope for this behavior-neutral infra change; disclosed as a comment in
both files.

## Dependency: `@xterm/headless`
Pinned to `5.5.0`. Justification:
- **Why needed**: correct alt-screen + absolute-cursor-position rendering
  requires a real VT100/xterm state machine, not tail-scanning bytes.
- **Why not hand-rolled**: a full VT100/xterm parser (CSI/OSC/DCS sequences,
  alt-screen buffer swap, scroll regions, etc.) is substantial and easy to
  get subtly wrong. `@xterm/headless` is the headless build of the same
  engine family already used by the renderer's `@xterm/xterm`, so behavior
  parity between what the user's terminal renders and what this model sees
  is close to free.
- **Size/cost**: it's a parser + buffer model with no DOM/rendering
  dependencies (that's what "headless" strips out); it's already a
  transitive concern for this codebase via the renderer's xterm usage.

## Scope
Infra only, per #196 — **NOT wired into session-manager/classifier/UI**.
Nothing consumes `ScreenModel` yet; it's added and tested in isolation.

## Verification
- `tsc --noEmit` clean on both `tsconfig.json` and `tsconfig.main.json`
- Targeted: `vitest run --project main src/main/session-state/screen-model.test.ts` — 5/5 passing
- Full suite: `vitest run --config vitest.workspace.ts` (all 3 projects) — 111 files / 1303 tests passing, 0 regressions — confirms zero behavior change to existing session-state handling