### PR TITLE
test(ipc-handlers): add listGitRepos path-gate + readBranch coverage

### DIFF
--- a/src/main/ipc-handlers.test.ts
+++ b/src/main/ipc-handlers.test.ts
@@ -12,6 +12,9 @@ vi.mock('electron', () => ({
 
 vi.mock('fs', () => ({
   existsSync: vi.fn(),
+  statSync: vi.fn(),
+  readFileSync: vi.fn(),
+  readdirSync: vi.fn(),
 }));
 
 // getVersionInfo delegates to probeClaudeVersion (execFile with a 5s timeout)
@@ -485,5 +488,258 @@ describe('IPC Handlers - gitWorktreeList reconciliation', () => {
     const result = await reconcile([worktree], [session]);
 
     expect(result[0].linkedSessionId).toBe('session-42');
+  });
+});
+
+describe('IPC Handlers - listGitRepos', () => {
+  // readGitBranch/listGitReposImpl (extracted from the real listGitRepos
+  // registry handler) parse .git entries — a directory for a regular repo, a
+  // `gitdir: <path>` pointer file for a linked worktree — to derive a branch
+  // label (issue #201). isPathAllowedFn below is the real isPathAllowed from
+  // ./path-access, not a hand-copied reimplementation (see the
+  // exportHistoryMarkdown tests above for the same rationale).
+  const homeDir = '/mock/home';
+  const workspaces = ['/mock/workspace'];
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('listGitReposImpl path gate', () => {
+    it('blocks a parentPath outside home/workspaces and never reads the directory', async () => {
+      const { listGitReposImpl } = await import('./ipc-handlers');
+      const { isPathAllowed } = await import('./path-access');
+      const fs = await import('fs');
+      const isPathAllowedFn = (resolved: string) => isPathAllowed(resolved, homeDir, workspaces);
+
+      const result = listGitReposImpl('/etc', isPathAllowedFn);
+
+      expect(result).toEqual([]);
+      expect(fs.readdirSync).not.toHaveBeenCalled();
+    });
+
+    it('lists repos under an allowed workspace path', async () => {
+      const path = await import('path');
+      const { listGitReposImpl } = await import('./ipc-handlers');
+      const { isPathAllowed } = await import('./path-access');
+      const fs = await import('fs');
+      const isPathAllowedFn = (resolved: string) => isPathAllowed(resolved, homeDir, workspaces);
+      const resolvedWorkspace = path.resolve('/mock/workspace');
+
+      vi.mocked(fs.existsSync).mockImplementation((p) => {
+        const resolved = String(p);
+        return resolved === path.join(resolvedWorkspace, 'repo-a', '.git');
+      });
+      vi.mocked(fs.readdirSync).mockReturnValue([
+        { name: 'repo-a', isDirectory: () => true },
+      ] as unknown as ReturnType<typeof fs.readdirSync>);
+      vi.mocked(fs.statSync).mockImplementation(() => {
+        throw new Error('not reached for this test');
+      });
+
+      const result = listGitReposImpl('/mock/workspace', isPathAllowedFn);
+
+      expect(result).toEqual([
+        {
+          name: 'repo-a',
+          path: path.join(resolvedWorkspace, 'repo-a'),
+          workspacePath: resolvedWorkspace,
+          branch: undefined,
+        },
+      ]);
+    });
+  });
+
+  describe('listGitReposImpl enumeration contract', () => {
+    it('includes the workspace itself when it is a repo, skips dot-dirs and non-repo dirs, and sorts by name', async () => {
+      const path = await import('path');
+      const { listGitReposImpl } = await import('./ipc-handlers');
+      const { isPathAllowed } = await import('./path-access');
+      const fs = await import('fs');
+      const isPathAllowedFn = (resolved: string) => isPathAllowed(resolved, homeDir, workspaces);
+      const resolvedWorkspace = path.resolve('/mock/workspace');
+
+      const gitPaths = new Set([
+        path.join(resolvedWorkspace, '.git'),
+        path.join(resolvedWorkspace, 'zebra', '.git'),
+        path.join(resolvedWorkspace, 'alpha', '.git'),
+      ]);
+      vi.mocked(fs.existsSync).mockImplementation((p) => gitPaths.has(String(p)));
+      vi.mocked(fs.readdirSync).mockReturnValue([
+        { name: 'zebra', isDirectory: () => true },
+        { name: '.hidden', isDirectory: () => true },
+        { name: 'alpha', isDirectory: () => true },
+        { name: 'not-a-repo', isDirectory: () => true },
+        { name: 'a-file', isDirectory: () => false },
+      ] as unknown as ReturnType<typeof fs.readdirSync>);
+      vi.mocked(fs.statSync).mockImplementation(() => {
+        throw new Error('branch resolution not under test here');
+      });
+
+      const result = listGitReposImpl('/mock/workspace', isPathAllowedFn);
+
+      // Sorted alphabetically by name, including the workspace-itself entry
+      // (its name is the workspace's own basename, so it sorts alongside
+      // "alpha" and "zebra" rather than always being first).
+      expect(result.map((r) => r.name)).toEqual(
+        [path.basename(resolvedWorkspace), 'alpha', 'zebra'].sort((a, b) => a.localeCompare(b)),
+      );
+      expect(result.every((r) => r.workspacePath === resolvedWorkspace)).toBe(true);
+    });
+
+    it('returns the repos collected so far if readdirSync throws', async () => {
+      const path = await import('path');
+      const { listGitReposImpl } = await import('./ipc-handlers');
+      const { isPathAllowed } = await import('./path-access');
+      const fs = await import('fs');
+      const isPathAllowedFn = (resolved: string) => isPathAllowed(resolved, homeDir, workspaces);
+      const resolvedWorkspace = path.resolve('/mock/workspace');
+
+      vi.mocked(fs.existsSync).mockImplementation(
+        (p) => String(p) === path.join(resolvedWorkspace, '.git'),
+      );
+      vi.mocked(fs.readdirSync).mockImplementation(() => {
+        throw new Error('permission denied');
+      });
+      vi.mocked(fs.statSync).mockImplementation(() => {
+        throw new Error('branch resolution not under test here');
+      });
+
+      const result = listGitReposImpl('/mock/workspace', isPathAllowedFn);
+
+      expect(result.map((r) => r.name)).toEqual([path.basename(resolvedWorkspace)]);
+    });
+  });
+
+  describe('readGitBranch', () => {
+    it('reads the branch from a regular .git directory on refs/heads', async () => {
+      const { readGitBranch } = await import('./ipc-handlers');
+      const fs = await import('fs');
+
+      vi.mocked(fs.statSync).mockReturnValue({ isDirectory: () => true } as ReturnType<
+        typeof fs.statSync
+      >);
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      vi.mocked(fs.readFileSync).mockReturnValue('ref: refs/heads/main\n');
+
+      const result = readGitBranch('/mock/workspace/repo-a/.git');
+
+      expect(result).toBe('main');
+    });
+
+    it('falls back to a 7-char short SHA for a detached HEAD', async () => {
+      const { readGitBranch } = await import('./ipc-handlers');
+      const fs = await import('fs');
+
+      vi.mocked(fs.statSync).mockReturnValue({ isDirectory: () => true } as ReturnType<
+        typeof fs.statSync
+      >);
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      vi.mocked(fs.readFileSync).mockReturnValue('abcdef1234567890\n');
+
+      const result = readGitBranch('/mock/workspace/repo-a/.git');
+
+      expect(result).toBe('abcdef1');
+    });
+
+    it('resolves a worktree .git file with a relative gitdir pointer', async () => {
+      const path = await import('path');
+      const { readGitBranch } = await import('./ipc-handlers');
+      const fs = await import('fs');
+      // The .git entry for a worktree checkout, e.g.
+      // /mock/workspace/feature-worktree/.git
+      const worktreeGitFile = '/mock/workspace/feature-worktree/.git';
+      const expectedHead = path.join(
+        path.resolve(path.dirname(worktreeGitFile), '../main-repo/.git/worktrees/feature'),
+        'HEAD',
+      );
+
+      vi.mocked(fs.statSync).mockReturnValue({ isDirectory: () => false } as ReturnType<
+        typeof fs.statSync
+      >);
+      vi.mocked(fs.readFileSync).mockImplementation((p) => {
+        if (String(p) === worktreeGitFile) {
+          return 'gitdir: ../main-repo/.git/worktrees/feature\n';
+        }
+        if (String(p) === expectedHead) {
+          return 'ref: refs/heads/feature-branch\n';
+        }
+        throw new Error(`unexpected readFileSync(${String(p)})`);
+      });
+      vi.mocked(fs.existsSync).mockImplementation((p) => String(p) === expectedHead);
+
+      const result = readGitBranch(worktreeGitFile);
+
+      expect(result).toBe('feature-branch');
+    });
+
+    it('resolves a worktree .git file with an absolute gitdir pointer', async () => {
+      const path = await import('path');
+      const { readGitBranch } = await import('./ipc-handlers');
+      const fs = await import('fs');
+      const worktreeGitFile = '/mock/workspace/feature-worktree/.git';
+      const absoluteGitDir = path.resolve('/mock/workspace/main-repo/.git/worktrees/feature');
+      const expectedHead = path.join(absoluteGitDir, 'HEAD');
+
+      vi.mocked(fs.statSync).mockReturnValue({ isDirectory: () => false } as ReturnType<
+        typeof fs.statSync
+      >);
+      vi.mocked(fs.readFileSync).mockImplementation((p) => {
+        if (String(p) === worktreeGitFile) {
+          return `gitdir: ${absoluteGitDir}\n`;
+        }
+        if (String(p) === expectedHead) {
+          return 'ref: refs/heads/feature-branch\n';
+        }
+        throw new Error(`unexpected readFileSync(${String(p)})`);
+      });
+      vi.mocked(fs.existsSync).mockImplementation((p) => String(p) === expectedHead);
+
+      const result = readGitBranch(worktreeGitFile);
+
+      expect(result).toBe('feature-branch');
+    });
+
+    it('returns undefined when the .git file pointer does not match the gitdir: pattern', async () => {
+      const { readGitBranch } = await import('./ipc-handlers');
+      const fs = await import('fs');
+
+      vi.mocked(fs.statSync).mockReturnValue({ isDirectory: () => false } as ReturnType<
+        typeof fs.statSync
+      >);
+      vi.mocked(fs.readFileSync).mockReturnValue('not a gitdir pointer\n');
+
+      const result = readGitBranch('/mock/workspace/feature-worktree/.git');
+
+      expect(result).toBeUndefined();
+    });
+
+    it('returns undefined when the resolved HEAD file does not exist', async () => {
+      const { readGitBranch } = await import('./ipc-handlers');
+      const fs = await import('fs');
+
+      vi.mocked(fs.statSync).mockReturnValue({ isDirectory: () => true } as ReturnType<
+        typeof fs.statSync
+      >);
+      vi.mocked(fs.existsSync).mockReturnValue(false);
+
+      const result = readGitBranch('/mock/workspace/repo-a/.git');
+
+      expect(result).toBeUndefined();
+      expect(fs.readFileSync).not.toHaveBeenCalled();
+    });
+
+    it('returns undefined when statSync throws', async () => {
+      const { readGitBranch } = await import('./ipc-handlers');
+      const fs = await import('fs');
+
+      vi.mocked(fs.statSync).mockImplementation(() => {
+        throw new Error('ENOENT');
+      });
+
+      const result = readGitBranch('/mock/workspace/repo-a/.git');
+
+      expect(result).toBeUndefined();
+    });
   });
 });

--- a/src/main/ipc-handlers.ts
+++ b/src/main/ipc-handlers.ts
@@ -149,6 +149,75 @@ export async function exportHistoryJsonGated(
   }
 }
 
+/**
+ * Resolves the branch label shown for a repo entry in the repo picker.
+ * `gitPath` is the `.git` entry inside a candidate repo dir: a directory for
+ * a regular repo, or a file (a `gitdir: <path>` pointer) for a linked
+ * worktree. Extracted from the listGitRepos registry handler so this parsing
+ * — the part most likely to regress — can be exercised directly in tests.
+ */
+export function readGitBranch(gitPath: string): string | undefined {
+  try {
+    const stat = fs.statSync(gitPath);
+    const headFile = stat.isDirectory()
+      ? path.join(gitPath, 'HEAD')
+      : (() => {
+          const ptr = fs.readFileSync(gitPath, 'utf8').trim();
+          const m = ptr.match(/^gitdir:\s*(.+)$/);
+          if (!m) return null;
+          const dir = path.isAbsolute(m[1]) ? m[1] : path.resolve(path.dirname(gitPath), m[1]);
+          return path.join(dir, 'HEAD');
+        })();
+    if (!headFile || !fs.existsSync(headFile)) return undefined;
+    const head = fs.readFileSync(headFile, 'utf8').trim();
+    const m = head.match(/^ref:\s*refs\/heads\/(.+)$/);
+    return m ? m[1] : head.slice(0, 7); // detached HEAD: short SHA
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Resolves and gates parentPath through the home/workspaces allowlist, then
+ * enumerates candidate git repos beneath it (the workspace itself, plus its
+ * top-level, non-dot subdirectories that contain a `.git` entry). Extracted
+ * from the listGitRepos registry handler so the gate and enumeration/sort
+ * contract can be exercised directly in tests.
+ */
+export function listGitReposImpl(
+  parentPath: string,
+  isPathAllowedFn: (resolved: string) => boolean,
+): GitRepoEntry[] {
+  const resolved = path.resolve(parentPath);
+  if (!isPathAllowedFn(resolved)) {
+    console.warn('[listGitRepos] Blocked path outside home/workspaces:', resolved);
+    return [];
+  }
+  const repos: GitRepoEntry[] = [];
+  const considerEntry = (name: string, fullPath: string) => {
+    const gitPath = path.join(fullPath, '.git');
+    if (!fs.existsSync(gitPath)) return;
+    repos.push({ name, path: fullPath, workspacePath: resolved, branch: readGitBranch(gitPath) });
+  };
+  try {
+    // First, is the workspace path ITSELF a git repo?
+    if (fs.existsSync(path.join(resolved, '.git'))) {
+      considerEntry(path.basename(resolved), resolved);
+    }
+    // Then enumerate top-level subdirs as candidate repos.
+    const entries = fs.readdirSync(resolved, { withFileTypes: true });
+    for (const entry of entries) {
+      if (!entry.isDirectory() || entry.name.startsWith('.')) continue;
+      considerEntry(entry.name, path.join(resolved, entry.name));
+    }
+    repos.sort((a, b) => a.name.localeCompare(b.name));
+    return repos;
+  } catch (err) {
+    console.error('Failed to list git repos:', err);
+    return repos;
+  }
+}
+
 export function setupIPCHandlers(
   mainWindow: BrowserWindow,
   sessionManager: SessionManager,
@@ -346,55 +415,7 @@ export function setupIPCHandlers(
   });
 
   registry.handle('listGitRepos', async (_e, parentPath): Promise<GitRepoEntry[]> => {
-    const resolved = path.resolve(parentPath);
-    if (!isPathAllowed(resolved)) {
-      console.warn('[listGitRepos] Blocked path outside home/workspaces:', resolved);
-      return [];
-    }
-    const repos: GitRepoEntry[] = [];
-    const readBranch = (gitPath: string): string | undefined => {
-      try {
-        // .git can be a directory (regular repo) or a file (worktree pointing at the parent .git).
-        const stat = fs.statSync(gitPath);
-        const headFile = stat.isDirectory()
-          ? path.join(gitPath, 'HEAD')
-          : (() => {
-              const ptr = fs.readFileSync(gitPath, 'utf8').trim();
-              const m = ptr.match(/^gitdir:\s*(.+)$/);
-              if (!m) return null;
-              const dir = path.isAbsolute(m[1]) ? m[1] : path.resolve(path.dirname(gitPath), m[1]);
-              return path.join(dir, 'HEAD');
-            })();
-        if (!headFile || !fs.existsSync(headFile)) return undefined;
-        const head = fs.readFileSync(headFile, 'utf8').trim();
-        const m = head.match(/^ref:\s*refs\/heads\/(.+)$/);
-        return m ? m[1] : head.slice(0, 7); // detached HEAD: short SHA
-      } catch {
-        return undefined;
-      }
-    };
-    const considerEntry = (name: string, fullPath: string) => {
-      const gitPath = path.join(fullPath, '.git');
-      if (!fs.existsSync(gitPath)) return;
-      repos.push({ name, path: fullPath, workspacePath: resolved, branch: readBranch(gitPath) });
-    };
-    try {
-      // First, is the workspace path ITSELF a git repo?
-      if (fs.existsSync(path.join(resolved, '.git'))) {
-        considerEntry(path.basename(resolved), resolved);
-      }
-      // Then enumerate top-level subdirs as candidate repos.
-      const entries = fs.readdirSync(resolved, { withFileTypes: true });
-      for (const entry of entries) {
-        if (!entry.isDirectory() || entry.name.startsWith('.')) continue;
-        considerEntry(entry.name, path.join(resolved, entry.name));
-      }
-      repos.sort((a, b) => a.name.localeCompare(b.name));
-      return repos;
-    } catch (err) {
-      console.error('Failed to list git repos:', err);
-      return repos;
-    }
+    return listGitReposImpl(parentPath, isPathAllowed);
   });
 
   registry.handle('createDirectory', async (_e, dirPath) => {


### PR DESCRIPTION
Closes #201

## What
Adds test coverage for the `listGitRepos` IPC handler: the path-access
gate and the `.git` entry parsing that derives a branch label (regular
repo directory vs. linked-worktree pointer file).

## Why a small production change was needed
The handler's logic (branch resolution + directory enumeration) lived
entirely inside the `registry.handle('listGitRepos', ...)` closure, so
it couldn't be exercised directly. Extracted it into two exported,
dependency-injected functions — `readGitBranch` and `listGitReposImpl`
— following the same pattern already used in this file for
`exportHistoryMarkdown`/`exportHistoryJson`. The registry handler is
now a one-line call into `listGitReposImpl`. **Behavior is unchanged**;
this is a pure testability extraction, not a logic change.

## Test coverage added (11 new tests)
- **Path gate**: a `parentPath` outside home/workspaces is rejected
  with `[]` and `readdirSync` is never called; an allowed path lists
  repos with the exact `GitRepoEntry` shape.
- **Enumeration contract**: workspace-itself is included as a repo
  when it has a `.git` entry; dot-directories and non-`.git` dirs are
  skipped; results are sorted alphabetically by name (including the
  workspace-itself entry, which sorts by its own basename rather than
  always being first — verified this matches actual handler behavior,
  not an assumption); if `readdirSync` throws, whatever repos were
  already collected are still returned instead of the whole call
  failing.
- **`readGitBranch`**: regular `.git` dir with a `refs/heads` ref;
  detached HEAD → 7-char short SHA; linked worktree `.git` file with a
  relative `gitdir:` pointer; same with an absolute pointer; malformed
  pointer → `undefined`; missing HEAD file → `undefined` (and
  `readFileSync` is never called); `statSync` throwing → `undefined`.

Path-gate tests use the real `isPathAllowed` from `./path-access`
(not a reimplementation), matching this file's existing convention.

## Verification
- `npx tsc --noEmit -p tsconfig.json` — clean
- `npx tsc --noEmit -p tsconfig.main.json` — clean
- Targeted: `npx vitest run --config vitest.workspace.ts --project main src/main/ipc-handlers.test.ts` → 34/34 passing (23 pre-existing + 11 new, zero regressions)
- Full suite: `npm test` → 111 test files / 1314 tests passing, zero regressions

No new dependencies added.