### PR TITLE
feat(cockpit): surface keyboard shortcut hints on row actions

### DIFF
--- a/src/renderer/components/shell/CockpitPanel.test.tsx
+++ b/src/renderer/components/shell/CockpitPanel.test.tsx
@@ -122,4 +122,33 @@ describe('CockpitPanel keyboard shortcuts', () => {
 
     expect(screen.getByText('Nothing needs you')).toBeInTheDocument();
   });
+
+  it('renders the Jump (↵) and Dismiss (d) key hints on every row', () => {
+    const items = [makeItem({ id: 's1', name: 'Session One', activityState: 'awaiting-input' })];
+    render(<CockpitPanel items={items} onJump={vi.fn()} onAcknowledge={vi.fn()} onClose={vi.fn()} />);
+
+    const jumpButton = screen.getByRole('button', { name: /Jump/ });
+    expect(jumpButton.querySelector('kbd.p4-kbd')).toHaveTextContent('↵');
+
+    const dismissButton = screen.getByRole('button', { name: /Dismiss/ });
+    expect(dismissButton.querySelector('kbd.p4-kbd')).toHaveTextContent('d');
+  });
+
+  it('renders the Ship-it (s) hint only when the row is done and onShipIt is provided', () => {
+    const doneItem = makeItem({ id: 's1', name: 'Session One', activityState: 'done' });
+    const { rerender } = render(
+      <CockpitPanel items={[doneItem]} onJump={vi.fn()} onAcknowledge={vi.fn()} onClose={vi.fn()} onShipIt={vi.fn()} />
+    );
+    const shipButton = screen.getByRole('button', { name: /Ship it/ });
+    expect(shipButton.querySelector('kbd.p4-kbd')).toHaveTextContent('s');
+
+    // Without onShipIt, the button (and its hint) shouldn't render even for a done item.
+    rerender(<CockpitPanel items={[doneItem]} onJump={vi.fn()} onAcknowledge={vi.fn()} onClose={vi.fn()} />);
+    expect(screen.queryByRole('button', { name: /Ship it/ })).not.toBeInTheDocument();
+
+    // Not-done items never show the Ship-it hint even when onShipIt is provided.
+    const runningItem = makeItem({ id: 's2', name: 'Session Two', activityState: 'awaiting-input' });
+    rerender(<CockpitPanel items={[runningItem]} onJump={vi.fn()} onAcknowledge={vi.fn()} onClose={vi.fn()} onShipIt={vi.fn()} />);
+    expect(screen.queryByRole('button', { name: /Ship it/ })).not.toBeInTheDocument();
+  });
 });

--- a/src/renderer/components/shell/CockpitPanel.tsx
+++ b/src/renderer/components/shell/CockpitPanel.tsx
@@ -113,7 +113,7 @@ export function CockpitPanel({ items, onJump, onAcknowledge, onClose, onShipIt }
 
                 <div style={{ display: 'flex', gap: 6, flexShrink: 0 }}>
                   <button className="p4-btn primary" style={{ padding: '4px 10px' }} onClick={() => jump(it.session.id)}>
-                    <P4Icon name="focus" size={12} /> Jump
+                    <P4Icon name="focus" size={12} /> Jump <kbd className="p4-kbd">↵</kbd>
                   </button>
                   {status === 'done' && onShipIt && (
                     <button
@@ -122,11 +122,11 @@ export function CockpitPanel({ items, onJump, onAcknowledge, onClose, onShipIt }
                       title="Turn this session's branch into a pull request"
                       onClick={() => { onShipIt(it.session.id, it.session.name); onClose(); }}
                     >
-                      <P4Icon name="branch" size={12} /> Ship it
+                      <P4Icon name="branch" size={12} /> Ship it <kbd className="p4-kbd">s</kbd>
                     </button>
                   )}
                   <button className="p4-btn" style={{ padding: '4px 10px' }} onClick={() => onAcknowledge(it.session.id)}>
-                    Dismiss
+                    Dismiss <kbd className="p4-kbd">d</kbd>
                   </button>
                 </div>
               </div>


### PR DESCRIPTION
## Summary

Closes #200.

`CockpitPanel`'s row action buttons (Jump / Ship it / Dismiss) had no visible key hints, even though #199 wired up `Enter` / `s` / `d` handlers for them. The sibling ⌘K Palette already surfaces per-action shortcuts inline via the `p4-kbd` class (`Palette.tsx:154-155`); Cockpit was inconsistent with that convention.

## Change

- Jump button: appended `<kbd className="p4-kbd">↵</kbd>`.
- Ship it button: appended `<kbd className="p4-kbd">s</kbd>` — only rendered under the pre-existing `status === 'done' && onShipIt` guard, so the hint only ever shows when the button itself shows.
- Dismiss button: appended `<kbd className="p4-kbd">d</kbd>`.
- Header `⎋` hint left untouched.

Purely presentational: no changes to `CockpitPanelProps`, handler signatures, or existing keyboard/click behavior (`handleKey` and the `onClick` handlers are untouched).

## Tests

Added to `CockpitPanel.test.tsx`:
- Jump and Dismiss hints render on every row.
- Ship-it hint renders only when the item is `done` AND `onShipIt` is provided; verified it's absent when either condition fails.

All 9 pre-existing keyboard-behavior tests still pass unmodified — hint markup doesn't affect them.

## Verification

- `npx tsc --noEmit -p tsconfig.json` — clean
- `npx tsc --noEmit -p tsconfig.main.json` — clean
- `npx vitest run --config vitest.workspace.ts --project renderer src/renderer/components/shell/CockpitPanel.test.tsx` — 11/11 passed
- `npm test` (full suite) — 111 files / 1316 tests passed (up from 1314, +2 new tests, zero regressions)

No new dependencies.