### PR TITLE
fix(integrations): agent awaiting-approval says "needs approval", not "needs your input"

### DIFF
--- a/src/main/integrations/message-format.test.ts
+++ b/src/main/integrations/message-format.test.ts
@@ -26,6 +26,22 @@ describe('formatMessage', () => {
     expect(text).toContain('needs approval');
   });
 
+  it('agent awaiting-approval says "needs approval" and is not downgraded to "needs your input"', () => {
+    const text = formatMessage(evt({
+      sessionKind: 'agent', state: 'awaiting-approval',
+      repoName: 'omnidesk', sessionName: 'fix-terminal-garble',
+    }));
+    expect(text).toContain('needs approval');
+    expect(text).not.toContain('needs your input');
+  });
+
+  it('agent done says "finished"', () => {
+    const text = formatMessage(evt({
+      sessionKind: 'agent', type: 'done', state: 'done', sessionName: 's',
+    }));
+    expect(text).toContain('finished');
+  });
+
   it('done and errored have distinct copy', () => {
     expect(formatMessage(evt({ type: 'done', state: 'done', sessionName: 's' }))).toContain('finished');
     expect(formatMessage(evt({ type: 'errored', state: 'errored', sessionName: 's' }))).toContain('errored');

--- a/src/main/integrations/message-format.ts
+++ b/src/main/integrations/message-format.ts
@@ -1,6 +1,7 @@
 // Pure message formatting for outbound integration events.
-// Agent sessions only ever signal awaiting-input (terminal bell) — copy must
-// never claim approval-level detail for them.
+// Agent sessions now signal working / awaiting-approval / awaiting-input /
+// done via the screen classifier (see session-manager.ts), so copy reflects
+// the real state for both agent and shell sessions alike.
 import type { IntegrationEvent } from '../../shared/integration-types';
 
 const OFFLINE_LINE = 'OmniDesk remote is offline — open the desktop app.';
@@ -8,7 +9,7 @@ const OFFLINE_LINE = 'OmniDesk remote is offline — open the desktop app.';
 function stateLabel(event: IntegrationEvent): string {
   switch (event.state) {
     case 'awaiting-approval':
-      return event.sessionKind === 'agent' ? 'needs your input' : 'needs approval';
+      return 'needs approval';
     case 'awaiting-input':
       return 'needs your input';
     case 'errored':


### PR DESCRIPTION
Closes #209

## Problem

`message-format.ts` special-cased `sessionKind === 'agent'` in `stateLabel`
to downgrade `awaiting-approval` to the generic bell-path copy "needs your
input". That was correct pre-#207/#205, when agents could only ever ring
the terminal bell. Now that the screen classifier drives agent sessions
through `working` / `awaiting-approval` / `awaiting-input` / `done` just
like shells, the downgrade flattens exactly the distinction epic #195 set
out to create: a Claude/Codex session genuinely blocked on an approval
prompt sent "needs your input" over Slack/Telegram/Discord/webhook instead
of "needs approval".

## Change

- `stateLabel`: dropped the `sessionKind === 'agent'` special-case for
  `awaiting-approval` — agents and shells both render "needs approval".
  `awaiting-input` (bell path) is untouched.
- Rewrote the stale file-header comment (previously asserted "agent
  sessions only ever signal awaiting-input") to describe the current,
  screen-classifier-driven reality.
- Added tests: agent `awaiting-approval` → "needs approval" (and does not
  say "needs your input"), and agent `done` → "finished" — both untested
  gaps flagged in the issue.

No routing/debounce/attention-policy changes — those already handle
`awaiting-approval` correctly (`AttentionPolicy`, rail, overlay). Purely a
formatting/copy correctness fix. Closes the integrations half of epic #195
child 4 (rail/overlay parts already shipped in earlier PRs).

No new dependencies.

## Verification

- `npx tsc --noEmit` clean on both `tsconfig.json` and `tsconfig.node.json`
- Targeted: `message-format.test.ts` 20/20 passing (18 pre-existing + 2 new)
- Full suite: `npm test` → 111 files / 1324 tests, all green (up from 1322)