### PR TITLE
feat(cockpit): show wait duration in attention cockpit rows

### DIFF
--- a/src/renderer/components/shell/CockpitPanel.test.tsx
+++ b/src/renderer/components/shell/CockpitPanel.test.tsx
@@ -1,10 +1,13 @@
-import { describe, it, expect, vi } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, act } from '@testing-library/react';
 import { CockpitPanel } from './CockpitPanel';
 import type { AttentionItem } from '../../hooks/useAttentionQueue';
 import type { TabData } from '../ui/Tab';
 
-function makeItem(overrides: Partial<TabData> & { id: string; name: string }): AttentionItem {
+function makeItem(
+  overrides: Partial<TabData> & { id: string; name: string },
+  itemOverrides: Partial<AttentionItem> = {},
+): AttentionItem {
   const session: TabData = {
     id: overrides.id,
     name: overrides.name,
@@ -23,6 +26,7 @@ function makeItem(overrides: Partial<TabData> & { id: string; name: string }): A
     preview: '',
     lastActivityAt: Date.now(),
     acknowledged: false,
+    ...itemOverrides,
   };
 }
 
@@ -150,5 +154,94 @@ describe('CockpitPanel keyboard shortcuts', () => {
     const runningItem = makeItem({ id: 's2', name: 'Session Two', activityState: 'awaiting-input' });
     rerender(<CockpitPanel items={[runningItem]} onJump={vi.fn()} onAcknowledge={vi.fn()} onClose={vi.fn()} onShipIt={vi.fn()} />);
     expect(screen.queryByRole('button', { name: /Ship it/ })).not.toBeInTheDocument();
+  });
+});
+
+describe('CockpitPanel waiting duration (#212)', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('shows a "waiting {duration}" fragment for a row with a known lastActivityAt', () => {
+    const now = Date.now();
+    vi.setSystemTime(now);
+    const items = [
+      makeItem(
+        { id: 's1', name: 'Session One', activityState: 'awaiting-input' },
+        { lastActivityAt: now - 90 * 1000 },
+      ),
+    ];
+    render(<CockpitPanel items={items} onJump={vi.fn()} onAcknowledge={vi.fn()} onClose={vi.fn()} />);
+
+    expect(screen.getByText(/waiting 1m/)).toBeInTheDocument();
+  });
+
+  it('renders no waiting fragment when lastActivityAt is 0 (unknown)', () => {
+    const items = [
+      makeItem(
+        { id: 's1', name: 'Session One', activityState: 'awaiting-input' },
+        { lastActivityAt: 0 },
+      ),
+    ];
+    render(<CockpitPanel items={items} onJump={vi.fn()} onAcknowledge={vi.fn()} onClose={vi.fn()} />);
+
+    // Word-boundary regex: "awaiting input" (the status chip) legitimately
+    // contains the substring "waiting" and must not cause a false positive.
+    expect(screen.queryByText(/\bwaiting\b/)).not.toBeInTheDocument();
+  });
+
+  it('refreshes the displayed duration every 15s while the panel stays open', () => {
+    const now = Date.now();
+    vi.setSystemTime(now);
+    const items = [
+      makeItem(
+        { id: 's1', name: 'Session One', activityState: 'awaiting-input' },
+        { lastActivityAt: now - 50 * 1000 },
+      ),
+    ];
+    render(<CockpitPanel items={items} onJump={vi.fn()} onAcknowledge={vi.fn()} onClose={vi.fn()} />);
+
+    expect(screen.getByText(/waiting 50s/)).toBeInTheDocument();
+
+    // Advance real elapsed time (via lastActivityAt staying fixed while "now" moves)
+    // past the next minute boundary and past the 15s refresh tick.
+    act(() => {
+      vi.setSystemTime(now + 20 * 1000);
+      vi.advanceTimersByTime(15000);
+    });
+
+    expect(screen.getByText(/waiting 1m/)).toBeInTheDocument();
+    expect(screen.queryByText(/waiting 50s/)).not.toBeInTheDocument();
+  });
+
+  it('clears the refresh interval on unmount (no leak, no post-unmount state update)', () => {
+    const clearSpy = vi.spyOn(global, 'clearInterval');
+    const items = [
+      makeItem(
+        { id: 's1', name: 'Session One', activityState: 'awaiting-input' },
+        { lastActivityAt: Date.now() - 1000 },
+      ),
+    ];
+    const { unmount } = render(
+      <CockpitPanel items={items} onJump={vi.fn()} onAcknowledge={vi.fn()} onClose={vi.fn()} />
+    );
+
+    unmount();
+
+    expect(clearSpy).toHaveBeenCalled();
+
+    // Advancing timers after unmount must not throw or warn about updates on
+    // an unmounted component — the interval callback should never fire again.
+    expect(() => {
+      act(() => {
+        vi.advanceTimersByTime(60000);
+      });
+    }).not.toThrow();
+
+    clearSpy.mockRestore();
   });
 });

--- a/src/renderer/components/shell/CockpitPanel.tsx
+++ b/src/renderer/components/shell/CockpitPanel.tsx
@@ -4,7 +4,7 @@
 import { useEffect, useRef, useState } from 'react';
 import { P4Icon } from './P4Icon';
 import {
-  colorBg, colorFg, initials, agentLetter,
+  colorBg, colorFg, initials, agentLetter, formatWaitDuration,
   STATUS_META, type RepoColor,
 } from './shell-utils';
 import { mapTabStatus } from './SessionRail';
@@ -22,6 +22,14 @@ interface CockpitPanelProps {
 export function CockpitPanel({ items, onJump, onAcknowledge, onClose, onShipIt }: CockpitPanelProps) {
   const [sel, setSel] = useState(0);
   const rowsRef = useRef<HTMLDivElement | null>(null);
+
+  // Ticks every 15s so each row's "waiting {duration}" label stays fresh
+  // while the overlay is open, without re-deriving the attention queue itself.
+  const [now, setNow] = useState(() => Date.now());
+  useEffect(() => {
+    const id = setInterval(() => setNow(Date.now()), 15000);
+    return () => clearInterval(id);
+  }, []);
 
   useEffect(() => { rowsRef.current?.focus(); }, []);
   useEffect(() => { if (sel > items.length - 1) setSel(Math.max(0, items.length - 1)); }, [items.length, sel]);
@@ -107,6 +115,7 @@ export function CockpitPanel({ items, onJump, onAcknowledge, onClose, onShipIt }
                   </div>
                   <div className="sub" style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
                     {it.repoName ? `${it.repoName} · ` : ''}{agentLetter(it.session.providerId)}
+                    {it.lastActivityAt > 0 ? ` · waiting ${formatWaitDuration(now - it.lastActivityAt)}` : ''}
                     {it.preview ? ` · ${it.preview}` : ''}
                   </div>
                 </div>

--- a/src/renderer/components/shell/shell-utils.test.ts
+++ b/src/renderer/components/shell/shell-utils.test.ts
@@ -1,5 +1,31 @@
 import { describe, it, expect } from 'vitest';
-import { resolveSessionWorktree, isSessionStopped } from './shell-utils';
+import { resolveSessionWorktree, isSessionStopped, formatWaitDuration } from './shell-utils';
+
+describe('formatWaitDuration', () => {
+  it('is "just now" for anything under 5s, including 0', () => {
+    expect(formatWaitDuration(0)).toBe('just now');
+    expect(formatWaitDuration(4999)).toBe('just now');
+  });
+
+  it('renders seconds from 5s up to (not including) 60s', () => {
+    expect(formatWaitDuration(5000)).toBe('5s');
+    expect(formatWaitDuration(59000)).toBe('59s');
+  });
+
+  it('renders minutes from 60s up to (not including) 60m', () => {
+    expect(formatWaitDuration(60000)).toBe('1m');
+    expect(formatWaitDuration(59 * 60000)).toBe('59m');
+  });
+
+  it('renders hours from 60m onward', () => {
+    expect(formatWaitDuration(60 * 60000)).toBe('1h');
+    expect(formatWaitDuration(5 * 60 * 60000 + 1)).toBe('5h');
+  });
+
+  it('clamps negative elapsed (clock skew) to "just now" instead of throwing', () => {
+    expect(formatWaitDuration(-500)).toBe('just now');
+  });
+});
 
 describe('isSessionStopped', () => {
   it('is true only once the process is gone (exited or errored)', () => {

--- a/src/renderer/components/shell/shell-utils.ts
+++ b/src/renderer/components/shell/shell-utils.ts
@@ -152,6 +152,24 @@ export function resolveSessionWorktree(
   }
 }
 
+/** Format an elapsed-ms duration as a compact "waiting for" label — used by
+ *  the attention cockpit (⌘J) next to each row, since attention items are
+ *  already ranked by lastActivityAt but that wait was never surfaced visually.
+ *  Buckets: <5s "just now", <60s "{n}s", <60m "{n}m", else "{n}h". No "ago"
+ *  suffix (the caller supplies the "waiting " prefix) and no day/date
+ *  fallback — unlike formatLastActive, this is for short-lived in-session
+ *  waits, not "last active" history. */
+export const formatWaitDuration = (msElapsed: number): string => {
+  const ms = Math.max(0, msElapsed);
+  if (ms < 5000) return 'just now';
+  const s = Math.floor(ms / 1000);
+  if (s < 60) return `${s}s`;
+  const m = Math.floor(s / 60);
+  if (m < 60) return `${m}m`;
+  const h = Math.floor(m / 60);
+  return `${h}h`;
+};
+
 /** Format a Date or epoch ms as "Nh ago", "Nd ago", etc. — used in rail meta. */
 export const formatLastActive = (date: Date | number | undefined): string => {
   if (!date) return '—';


### PR DESCRIPTION
Closes #212

## Summary
The attention cockpit (⌘J overlay) ranks items partly by `lastActivityAt`
(longest-waiting first) but never surfaced that wait duration to the user.

- Add `formatWaitDuration(msElapsed)` to `shell-utils.ts`: `<5s` → "just now",
  `<60s` → "{n}s", `<60m` → "{n}m", else "{n}h".
- Wire it into `CockpitPanel`'s row sub-line as " · waiting {duration}",
  shown only when `lastActivityAt` is known (`> 0`).
- Add a 15s refresh tick (`setInterval`, cleared on unmount) so the
  displayed duration stays live while the panel is open.
- Unit tests for the formatter's bucket boundaries.
- Component tests for the fragment appearing/not appearing, the 15s
  refresh updating the display, and no interval leak after unmount.

## Verification
- Full test suite: `npm run test` → 111 test files, 1333 tests passed, 0 failures.
- Full build: `npm run build` (`tsc && vite build`) → succeeded, no type errors.

No changes to `useAttentionQueue.ts` ranking/acknowledgement logic or any
StatusBar pill — scoped to the cockpit row display only.