### PR TITLE
feat(history): add useHistory + useCheckpoints renderer hooks

### DIFF
--- a/src/renderer/hooks/useCheckpoints.test.ts
+++ b/src/renderer/hooks/useCheckpoints.test.ts
@@ -1,0 +1,225 @@
+import { describe, it, expect, vi } from 'vitest';
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { getElectronAPI } from '../../../test/helpers/electron-api-mock';
+import { useCheckpoints } from './useCheckpoints';
+import type { Checkpoint } from '../../shared/types/checkpoint-types';
+
+const checkpoint: Checkpoint = {
+  id: 'c1',
+  sessionId: 's1',
+  name: 'Checkpoint One',
+  description: '',
+  tags: [],
+  isTemplate: false,
+  createdAt: 1,
+  historyPosition: 0,
+  historySegment: 0,
+};
+
+describe('useCheckpoints', () => {
+  it('loads checkpoints on mount and clears loading', async () => {
+    const api = getElectronAPI();
+    api.listCheckpoints = vi.fn().mockResolvedValue([checkpoint]);
+    const { result } = renderHook(() => useCheckpoints());
+    expect(result.current.loading).toBe(true);
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.checkpoints).toEqual([checkpoint]);
+    expect(result.current.error).toBeNull();
+  });
+
+  it('passes sessionId through to listCheckpoints on mount', async () => {
+    const api = getElectronAPI();
+    api.listCheckpoints = vi.fn().mockResolvedValue([]);
+    renderHook(() => useCheckpoints('s1'));
+    await waitFor(() => expect(api.listCheckpoints).toHaveBeenCalledWith('s1'));
+  });
+
+  it('sets error and keeps checkpoints empty when listCheckpoints rejects', async () => {
+    const api = getElectronAPI();
+    api.listCheckpoints = vi.fn().mockRejectedValue(new Error('disk error'));
+    const { result } = renderHook(() => useCheckpoints());
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.error).toBe('disk error');
+    expect(result.current.checkpoints).toEqual([]);
+  });
+
+  it('refresh(forSessionId) overrides the hook-level sessionId for that call', async () => {
+    const api = getElectronAPI();
+    api.listCheckpoints = vi.fn().mockResolvedValue([]);
+    const { result } = renderHook(() => useCheckpoints('s1'));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    await act(async () => {
+      await result.current.refresh('s2');
+    });
+    expect(api.listCheckpoints).toHaveBeenCalledWith('s2');
+  });
+
+  it('create passes through the created checkpoint and returns null on rejection', async () => {
+    const api = getElectronAPI();
+    api.listCheckpoints = vi.fn().mockResolvedValue([]);
+    api.createCheckpoint = vi.fn().mockResolvedValue(checkpoint);
+    const { result } = renderHook(() => useCheckpoints());
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    const request = { sessionId: 's1', name: 'Checkpoint One' } as any;
+    await expect(result.current.create(request)).resolves.toEqual(checkpoint);
+    expect(api.createCheckpoint).toHaveBeenCalledWith(request);
+
+    api.createCheckpoint = vi.fn().mockRejectedValue(new Error('write failed'));
+    await expect(result.current.create(request)).resolves.toBeNull();
+    await waitFor(() => expect(result.current.error).toBe('write failed'));
+  });
+
+  it('get passes through the result and returns null on rejection', async () => {
+    const api = getElectronAPI();
+    api.listCheckpoints = vi.fn().mockResolvedValue([]);
+    api.getCheckpoint = vi.fn().mockResolvedValue(checkpoint);
+    const { result } = renderHook(() => useCheckpoints());
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    await expect(result.current.get('c1')).resolves.toEqual(checkpoint);
+    expect(api.getCheckpoint).toHaveBeenCalledWith('c1');
+
+    api.getCheckpoint = vi.fn().mockRejectedValue(new Error('missing'));
+    await expect(result.current.get('c1')).resolves.toBeNull();
+    await waitFor(() => expect(result.current.error).toBe('missing'));
+  });
+
+  it('remove passes through the result and returns false on rejection', async () => {
+    const api = getElectronAPI();
+    api.listCheckpoints = vi.fn().mockResolvedValue([]);
+    api.deleteCheckpoint = vi.fn().mockResolvedValue(true);
+    const { result } = renderHook(() => useCheckpoints());
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    await expect(result.current.remove('c1')).resolves.toBe(true);
+    expect(api.deleteCheckpoint).toHaveBeenCalledWith('c1');
+
+    api.deleteCheckpoint = vi.fn().mockRejectedValue(new Error('locked'));
+    await expect(result.current.remove('c1')).resolves.toBe(false);
+    await waitFor(() => expect(result.current.error).toBe('locked'));
+  });
+
+  it('update patches the matching checkpoint in local state on success, and returns null on rejection', async () => {
+    const api = getElectronAPI();
+    api.listCheckpoints = vi.fn().mockResolvedValue([checkpoint]);
+    const updated = { ...checkpoint, name: 'Renamed' };
+    api.updateCheckpoint = vi.fn().mockResolvedValue(updated);
+    const { result } = renderHook(() => useCheckpoints());
+    await waitFor(() => expect(result.current.checkpoints).toEqual([checkpoint]));
+
+    await act(async () => {
+      const r = await result.current.update('c1', { name: 'Renamed' });
+      expect(r).toEqual(updated);
+    });
+    expect(api.updateCheckpoint).toHaveBeenCalledWith('c1', { name: 'Renamed' });
+    expect(result.current.checkpoints).toEqual([updated]);
+
+    api.updateCheckpoint = vi.fn().mockRejectedValue(new Error('conflict'));
+    await expect(result.current.update('c1', { name: 'X' })).resolves.toBeNull();
+    await waitFor(() => expect(result.current.error).toBe('conflict'));
+    // Local state must be unchanged by the failed update.
+    expect(result.current.checkpoints).toEqual([updated]);
+  });
+
+  it('exportCheckpoint passes through the content and returns null on rejection', async () => {
+    const api = getElectronAPI();
+    api.listCheckpoints = vi.fn().mockResolvedValue([]);
+    api.exportCheckpoint = vi.fn().mockResolvedValue('exported content');
+    const { result } = renderHook(() => useCheckpoints());
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    await expect(result.current.exportCheckpoint('c1', 'markdown' as any)).resolves.toBe(
+      'exported content',
+    );
+    expect(api.exportCheckpoint).toHaveBeenCalledWith('c1', 'markdown');
+
+    api.exportCheckpoint = vi.fn().mockRejectedValue(new Error('io error'));
+    await expect(result.current.exportCheckpoint('c1', 'markdown' as any)).resolves.toBeNull();
+    await waitFor(() => expect(result.current.error).toBe('io error'));
+  });
+
+  it('count passes through the result and falls back to 0 on rejection', async () => {
+    const api = getElectronAPI();
+    api.listCheckpoints = vi.fn().mockResolvedValue([]);
+    api.getCheckpointCount = vi.fn().mockResolvedValue(4);
+    const { result } = renderHook(() => useCheckpoints());
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    await expect(result.current.count('s1')).resolves.toBe(4);
+    expect(api.getCheckpointCount).toHaveBeenCalledWith('s1');
+
+    api.getCheckpointCount = vi.fn().mockRejectedValue(new Error('nope'));
+    await expect(result.current.count('s1')).resolves.toBe(0);
+    await waitFor(() => expect(result.current.error).toBe('nope'));
+  });
+
+  it('appends a checkpoint from onCheckpointCreated when no sessionId scope is set', async () => {
+    const api = getElectronAPI();
+    api.listCheckpoints = vi.fn().mockResolvedValue([]);
+    let push: ((c: Checkpoint) => void) | null = null;
+    api.onCheckpointCreated = vi.fn().mockImplementation((cb: (c: Checkpoint) => void) => {
+      push = cb;
+      return () => {
+        push = null;
+      };
+    });
+    const { result, unmount } = renderHook(() => useCheckpoints());
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    act(() => {
+      push?.(checkpoint);
+    });
+    expect(result.current.checkpoints).toEqual([checkpoint]);
+
+    unmount();
+    expect(push).toBeNull();
+  });
+
+  it('ignores onCheckpointCreated events for a different session when scoped by sessionId', async () => {
+    const api = getElectronAPI();
+    api.listCheckpoints = vi.fn().mockResolvedValue([]);
+    let push: ((c: Checkpoint) => void) | null = null;
+    api.onCheckpointCreated = vi.fn().mockImplementation((cb: (c: Checkpoint) => void) => {
+      push = cb;
+      return () => {
+        push = null;
+      };
+    });
+    const { result } = renderHook(() => useCheckpoints('s1'));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    act(() => {
+      push?.({ ...checkpoint, sessionId: 's2' });
+    });
+    expect(result.current.checkpoints).toEqual([]);
+
+    act(() => {
+      push?.({ ...checkpoint, sessionId: 's1' });
+    });
+    expect(result.current.checkpoints).toEqual([{ ...checkpoint, sessionId: 's1' }]);
+  });
+
+  it('removes a checkpoint from local state on onCheckpointDeleted, and unsubscribes on unmount', async () => {
+    const api = getElectronAPI();
+    api.listCheckpoints = vi.fn().mockResolvedValue([checkpoint]);
+    let push: ((id: string) => void) | null = null;
+    api.onCheckpointDeleted = vi.fn().mockImplementation((cb: (id: string) => void) => {
+      push = cb;
+      return () => {
+        push = null;
+      };
+    });
+    const { result, unmount } = renderHook(() => useCheckpoints());
+    await waitFor(() => expect(result.current.checkpoints).toEqual([checkpoint]));
+
+    act(() => {
+      push?.('c1');
+    });
+    expect(result.current.checkpoints).toEqual([]);
+
+    unmount();
+    expect(push).toBeNull();
+  });
+});

--- a/src/renderer/hooks/useCheckpoints.ts
+++ b/src/renderer/hooks/useCheckpoints.ts
@@ -1,0 +1,152 @@
+// Thin wrapper around the window.electronAPI checkpoint IPC contract.
+// Combines the loading/error/refresh shape of useRemoteAccess.ts with the
+// live-event-subscription-with-cleanup shape of useIntegrations.ts: checkpoint
+// creation/deletion can happen from other surfaces (e.g. another window or a
+// keyboard shortcut elsewhere), so local state stays in sync via
+// onCheckpointCreated / onCheckpointDeleted rather than polling.
+import { useState, useCallback, useEffect } from 'react';
+import type {
+  Checkpoint,
+  CheckpointCreateRequest,
+  CheckpointExportFormat,
+} from '../../shared/types/checkpoint-types';
+
+export interface UseCheckpointsApi {
+  checkpoints: Checkpoint[];
+  loading: boolean;
+  error: string | null;
+  refresh: (sessionId?: string) => Promise<void>;
+  create: (request: CheckpointCreateRequest) => Promise<Checkpoint | null>;
+  get: (id: string) => Promise<Checkpoint | null>;
+  remove: (id: string) => Promise<boolean>;
+  update: (
+    id: string,
+    patch: Partial<Pick<Checkpoint, 'name' | 'description' | 'tags' | 'isTemplate'>>,
+  ) => Promise<Checkpoint | null>;
+  exportCheckpoint: (id: string, format: CheckpointExportFormat) => Promise<string | null>;
+  count: (sessionId: string) => Promise<number>;
+}
+
+export function useCheckpoints(sessionId?: string): UseCheckpointsApi {
+  const [checkpoints, setCheckpoints] = useState<Checkpoint[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const refresh = useCallback(async (forSessionId?: string) => {
+    try {
+      const list = await window.electronAPI.listCheckpoints(forSessionId ?? sessionId);
+      setCheckpoints(list);
+      setError(null);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setLoading(false);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [sessionId]);
+
+  useEffect(() => {
+    void refresh();
+
+    const unsubscribeCreated = window.electronAPI.onCheckpointCreated?.((checkpoint) => {
+      if (sessionId && checkpoint.sessionId !== sessionId) return;
+      setCheckpoints((prev) => [...prev, checkpoint]);
+    });
+    const unsubscribeDeleted = window.electronAPI.onCheckpointDeleted?.((id) => {
+      setCheckpoints((prev) => prev.filter((c) => c.id !== id));
+    });
+
+    return () => {
+      unsubscribeCreated?.();
+      unsubscribeDeleted?.();
+    };
+  }, [refresh, sessionId]);
+
+  const create = useCallback(async (request: CheckpointCreateRequest) => {
+    try {
+      const checkpoint = await window.electronAPI.createCheckpoint(request);
+      setError(null);
+      return checkpoint;
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+      return null;
+    }
+  }, []);
+
+  const get = useCallback(async (id: string) => {
+    try {
+      const checkpoint = await window.electronAPI.getCheckpoint(id);
+      setError(null);
+      return checkpoint;
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+      return null;
+    }
+  }, []);
+
+  const remove = useCallback(async (id: string) => {
+    try {
+      const ok = await window.electronAPI.deleteCheckpoint(id);
+      setError(null);
+      return ok;
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+      return false;
+    }
+  }, []);
+
+  const update = useCallback(
+    async (
+      id: string,
+      patch: Partial<Pick<Checkpoint, 'name' | 'description' | 'tags' | 'isTemplate'>>,
+    ) => {
+      try {
+        const checkpoint = await window.electronAPI.updateCheckpoint(id, patch);
+        setError(null);
+        if (checkpoint) {
+          setCheckpoints((prev) => prev.map((c) => (c.id === id ? checkpoint : c)));
+        }
+        return checkpoint;
+      } catch (e) {
+        setError(e instanceof Error ? e.message : String(e));
+        return null;
+      }
+    },
+    [],
+  );
+
+  const exportCheckpoint = useCallback(async (id: string, format: CheckpointExportFormat) => {
+    try {
+      const content = await window.electronAPI.exportCheckpoint(id, format);
+      setError(null);
+      return content;
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+      return null;
+    }
+  }, []);
+
+  const count = useCallback(async (forSessionId: string) => {
+    try {
+      const n = await window.electronAPI.getCheckpointCount(forSessionId);
+      setError(null);
+      return n;
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+      return 0;
+    }
+  }, []);
+
+  return {
+    checkpoints,
+    loading,
+    error,
+    refresh,
+    create,
+    get,
+    remove,
+    update,
+    exportCheckpoint,
+    count,
+  };
+}

--- a/src/renderer/hooks/useHistory.test.ts
+++ b/src/renderer/hooks/useHistory.test.ts
@@ -1,0 +1,163 @@
+import { describe, it, expect, vi } from 'vitest';
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { getElectronAPI } from '../../../test/helpers/electron-api-mock';
+import { useHistory } from './useHistory';
+import type { HistorySessionEntry } from '../../shared/types/history-types';
+
+const session: HistorySessionEntry = {
+  id: 's1',
+  name: 'Session One',
+  workingDirectory: '/repo',
+  createdAt: 1,
+  lastUpdatedAt: 2,
+  sizeBytes: 100,
+  segmentCount: 0,
+};
+
+describe('useHistory', () => {
+  it('loads sessions on mount and clears loading', async () => {
+    const api = getElectronAPI();
+    api.listHistory = vi.fn().mockResolvedValue([session]);
+    const { result } = renderHook(() => useHistory());
+    expect(result.current.loading).toBe(true);
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.sessions).toEqual([session]);
+    expect(result.current.error).toBeNull();
+  });
+
+  it('sets error and keeps sessions empty when listHistory rejects', async () => {
+    const api = getElectronAPI();
+    api.listHistory = vi.fn().mockRejectedValue(new Error('disk error'));
+    const { result } = renderHook(() => useHistory());
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.error).toBe('disk error');
+    expect(result.current.sessions).toEqual([]);
+  });
+
+  it('getContent passes through the result and returns null on rejection', async () => {
+    const api = getElectronAPI();
+    api.listHistory = vi.fn().mockResolvedValue([]);
+    api.getHistory = vi.fn().mockResolvedValue('log contents');
+    const { result } = renderHook(() => useHistory());
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    await expect(result.current.getContent('s1')).resolves.toBe('log contents');
+    expect(api.getHistory).toHaveBeenCalledWith('s1');
+
+    api.getHistory = vi.fn().mockRejectedValue(new Error('missing'));
+    await expect(result.current.getContent('s1')).resolves.toBeNull();
+    await waitFor(() => expect(result.current.error).toBe('missing'));
+  });
+
+  it('search passes through results and returns [] on rejection', async () => {
+    const api = getElectronAPI();
+    api.listHistory = vi.fn().mockResolvedValue([]);
+    const searchResult = { session, matchCount: 1, previews: [] };
+    api.searchHistory = vi.fn().mockResolvedValue([searchResult]);
+    const { result } = renderHook(() => useHistory());
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    await expect(result.current.search('term', true)).resolves.toEqual([searchResult]);
+    expect(api.searchHistory).toHaveBeenCalledWith('term', true);
+
+    api.searchHistory = vi.fn().mockRejectedValue(new Error('bad query'));
+    await expect(result.current.search('term')).resolves.toEqual([]);
+    await waitFor(() => expect(result.current.error).toBe('bad query'));
+  });
+
+  it('remove refreshes sessions on success and returns false without refreshing on rejection', async () => {
+    const api = getElectronAPI();
+    api.listHistory = vi.fn().mockResolvedValue([session]);
+    api.deleteHistory = vi.fn().mockResolvedValue(true);
+    const { result } = renderHook(() => useHistory());
+    await waitFor(() => expect(result.current.sessions).toEqual([session]));
+
+    api.listHistory = vi.fn().mockResolvedValue([]);
+    await act(async () => {
+      const ok = await result.current.remove('s1');
+      expect(ok).toBe(true);
+    });
+    expect(api.listHistory).toHaveBeenCalled();
+    expect(result.current.sessions).toEqual([]);
+
+    api.deleteHistory = vi.fn().mockRejectedValue(new Error('locked'));
+    await act(async () => {
+      const ok = await result.current.remove('s1');
+      expect(ok).toBe(false);
+    });
+    expect(result.current.error).toBe('locked');
+  });
+
+  it('removeAll refreshes sessions on success and returns false on rejection', async () => {
+    const api = getElectronAPI();
+    api.listHistory = vi.fn().mockResolvedValue([session]);
+    api.deleteAllHistory = vi.fn().mockResolvedValue(true);
+    const { result } = renderHook(() => useHistory());
+    await waitFor(() => expect(result.current.sessions).toEqual([session]));
+
+    api.listHistory = vi.fn().mockResolvedValue([]);
+    await act(async () => {
+      const ok = await result.current.removeAll();
+      expect(ok).toBe(true);
+    });
+    expect(result.current.sessions).toEqual([]);
+
+    api.deleteAllHistory = vi.fn().mockRejectedValue(new Error('nope'));
+    await act(async () => {
+      const ok = await result.current.removeAll();
+      expect(ok).toBe(false);
+    });
+    expect(result.current.error).toBe('nope');
+  });
+
+  it('exportMarkdown and exportJson pass through and fall back to false on rejection', async () => {
+    const api = getElectronAPI();
+    api.listHistory = vi.fn().mockResolvedValue([]);
+    api.exportHistoryMarkdown = vi.fn().mockResolvedValue(true);
+    api.exportHistoryJson = vi.fn().mockResolvedValue(true);
+    const { result } = renderHook(() => useHistory());
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    await expect(result.current.exportMarkdown('s1', '/out.md')).resolves.toBe(true);
+    expect(api.exportHistoryMarkdown).toHaveBeenCalledWith('s1', '/out.md');
+    await expect(result.current.exportJson('s1', '/out.json')).resolves.toBe(true);
+    expect(api.exportHistoryJson).toHaveBeenCalledWith('s1', '/out.json');
+
+    api.exportHistoryMarkdown = vi.fn().mockRejectedValue(new Error('io error'));
+    await expect(result.current.exportMarkdown('s1', '/out.md')).resolves.toBe(false);
+    await waitFor(() => expect(result.current.error).toBe('io error'));
+
+    api.exportHistoryJson = vi.fn().mockRejectedValue(new Error('io error 2'));
+    await expect(result.current.exportJson('s1', '/out.json')).resolves.toBe(false);
+    await waitFor(() => expect(result.current.error).toBe('io error 2'));
+  });
+
+  it('getSettings/updateSettings/getStats pass through and fall back on rejection', async () => {
+    const api = getElectronAPI();
+    api.listHistory = vi.fn().mockResolvedValue([]);
+    const settings = { maxAgeDays: 30, maxSizeMB: 500, autoCleanup: true };
+    api.getHistorySettings = vi.fn().mockResolvedValue(settings);
+    api.updateHistorySettings = vi.fn().mockResolvedValue(true);
+    const stats = { totalSessions: 3, totalSizeBytes: 900, oldestSessionDate: 1, newestSessionDate: 3 };
+    api.getHistoryStats = vi.fn().mockResolvedValue(stats);
+    const { result } = renderHook(() => useHistory());
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    await expect(result.current.getSettings()).resolves.toEqual(settings);
+    await expect(result.current.updateSettings({ autoCleanup: false })).resolves.toBe(true);
+    expect(api.updateHistorySettings).toHaveBeenCalledWith({ autoCleanup: false });
+    await expect(result.current.getStats()).resolves.toEqual(stats);
+
+    api.getHistorySettings = vi.fn().mockRejectedValue(new Error('settings error'));
+    await expect(result.current.getSettings()).resolves.toBeNull();
+    await waitFor(() => expect(result.current.error).toBe('settings error'));
+
+    api.updateHistorySettings = vi.fn().mockRejectedValue(new Error('update error'));
+    await expect(result.current.updateSettings({})).resolves.toBe(false);
+    await waitFor(() => expect(result.current.error).toBe('update error'));
+
+    api.getHistoryStats = vi.fn().mockRejectedValue(new Error('stats error'));
+    await expect(result.current.getStats()).resolves.toBeNull();
+    await waitFor(() => expect(result.current.error).toBe('stats error'));
+  });
+});

--- a/src/renderer/hooks/useHistory.ts
+++ b/src/renderer/hooks/useHistory.ts
@@ -1,0 +1,166 @@
+// Thin wrapper around the window.electronAPI history IPC contract.
+// Mirrors the loading/error/refresh shape of useRemoteAccess.ts. History is
+// not live data (unlike remote-access tunnel status), so there is
+// deliberately no polling here — callers refresh explicitly after mutating.
+import { useState, useCallback, useEffect } from 'react';
+import type {
+  HistorySessionEntry,
+  HistorySettings,
+  HistorySearchResult,
+  HistoryStats,
+} from '../../shared/types/history-types';
+
+export interface UseHistoryApi {
+  sessions: HistorySessionEntry[];
+  loading: boolean;
+  error: string | null;
+  refresh: () => Promise<void>;
+  getContent: (id: string) => Promise<string | null>;
+  search: (query: string, caseSensitive?: boolean) => Promise<HistorySearchResult[]>;
+  remove: (id: string) => Promise<boolean>;
+  removeAll: () => Promise<boolean>;
+  exportMarkdown: (id: string, outputPath: string) => Promise<boolean>;
+  exportJson: (id: string, outputPath: string) => Promise<boolean>;
+  getSettings: () => Promise<HistorySettings | null>;
+  updateSettings: (patch: Partial<HistorySettings>) => Promise<boolean>;
+  getStats: () => Promise<HistoryStats | null>;
+}
+
+export function useHistory(): UseHistoryApi {
+  const [sessions, setSessions] = useState<HistorySessionEntry[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const refresh = useCallback(async () => {
+    try {
+      const list = await window.electronAPI.listHistory();
+      setSessions(list);
+      setError(null);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  const getContent = useCallback(async (id: string) => {
+    try {
+      const content = await window.electronAPI.getHistory(id);
+      setError(null);
+      return content;
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+      return null;
+    }
+  }, []);
+
+  const search = useCallback(async (query: string, caseSensitive?: boolean) => {
+    try {
+      const results = await window.electronAPI.searchHistory(query, caseSensitive);
+      setError(null);
+      return results;
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+      return [];
+    }
+  }, []);
+
+  const remove = useCallback(async (id: string) => {
+    try {
+      const ok = await window.electronAPI.deleteHistory(id);
+      setError(null);
+      if (ok) await refresh();
+      return ok;
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+      return false;
+    }
+  }, [refresh]);
+
+  const removeAll = useCallback(async () => {
+    try {
+      const ok = await window.electronAPI.deleteAllHistory();
+      setError(null);
+      if (ok) await refresh();
+      return ok;
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+      return false;
+    }
+  }, [refresh]);
+
+  const exportMarkdown = useCallback(async (id: string, outputPath: string) => {
+    try {
+      const ok = await window.electronAPI.exportHistoryMarkdown(id, outputPath);
+      setError(null);
+      return ok;
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+      return false;
+    }
+  }, []);
+
+  const exportJson = useCallback(async (id: string, outputPath: string) => {
+    try {
+      const ok = await window.electronAPI.exportHistoryJson(id, outputPath);
+      setError(null);
+      return ok;
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+      return false;
+    }
+  }, []);
+
+  const getSettings = useCallback(async () => {
+    try {
+      const settings = await window.electronAPI.getHistorySettings();
+      setError(null);
+      return settings;
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+      return null;
+    }
+  }, []);
+
+  const updateSettings = useCallback(async (patch: Partial<HistorySettings>) => {
+    try {
+      const ok = await window.electronAPI.updateHistorySettings(patch);
+      setError(null);
+      return ok;
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+      return false;
+    }
+  }, []);
+
+  const getStats = useCallback(async () => {
+    try {
+      const stats = await window.electronAPI.getHistoryStats();
+      setError(null);
+      return stats;
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+      return null;
+    }
+  }, []);
+
+  return {
+    sessions,
+    loading,
+    error,
+    refresh,
+    getContent,
+    search,
+    remove,
+    removeAll,
+    exportMarkdown,
+    exportJson,
+    getSettings,
+    updateSettings,
+    getStats,
+  };
+}


### PR DESCRIPTION
## Summary
Foundation for the Session History Explorer (epic #214, child 1). Adds two thin renderer hooks wrapping the `window.electronAPI` history and checkpoint IPC contract (`src/shared/ipc-contract.ts`), following the loading/error/refresh shape of `useRemoteAccess.ts` and, for checkpoints, the live-event-subscription-with-cleanup shape of `useIntegrations.ts`.

- `useHistory()` — wraps `listHistory/getHistory/searchHistory/deleteHistory/deleteAllHistory/exportHistoryMarkdown/exportHistoryJson/getHistorySettings/updateHistorySettings/getHistoryStats`. No polling: history isn't live data, so callers refresh explicitly after mutating (`remove`/`removeAll` auto-refresh on success).
- `useCheckpoints(sessionId?)` — wraps `listCheckpoints/createCheckpoint/getCheckpoint/deleteCheckpoint/updateCheckpoint/exportCheckpoint/getCheckpointCount`, plus subscribes to `onCheckpointCreated`/`onCheckpointDeleted` (sessionId-scoped filtering on create) since checkpoints can be created/deleted from other surfaces. Cleans up subscriptions on unmount. `update` patches local state on success without a full refresh.

Both hooks surface `error` as a string (falling back to `String(e)` for non-Error rejections) and never throw from their action callbacks — callers get `null`/`false`/`[]` fallbacks instead.

## Testing
- `useHistory.test.ts` (8 tests) and `useCheckpoints.test.ts` (13 tests) — mount-load, error-on-rejection, pass-through/fallback for every action, plus (checkpoints-only) event-driven append/remove, sessionId scoping, and unsubscribe-on-unmount verification. Uses the existing `getElectronAPI()` mock helper.
- `npx tsc --noEmit` clean on both `tsconfig.json` and `tsconfig.node.json`.
- Targeted run (`vitest --config vitest.workspace.ts --project renderer`) for the two new test files: 21/21 passing.
- Full suite (`npm test`): 1354/1354 passing across 113 files, no regressions.

Closes #215