### PR TITLE
feat(shell): add Session History Explorer panel

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -7,7 +7,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import {
   RepoActivityBar, SessionRail, MainView, RepoSwitcher,
   AddRepoSheet, NewSessionSheet, Palette, RightInspector,
-  TitleBar, StatusBar, RemoteAccessPanel, VoiceSettingsPanel, IntegrationsPanel, ShipItSheet, P4Icon,
+  TitleBar, StatusBar, RemoteAccessPanel, VoiceSettingsPanel, IntegrationsPanel, ShipItSheet, HistoryPanel, P4Icon,
   sessionsForRepo, liveCount, resolveSessionWorktree,
   type ViewMode, type PaletteAction, type NewSessionForm, type NewSessionPrefill,
 } from './components/shell';
@@ -154,6 +154,7 @@ function App() {
   const [showRemote, setShowRemote] = useState(false);
   const [showIntegrations, setShowIntegrations] = useState(false);
   const [showVoiceSettings, setShowVoiceSettings] = useState(false);
+  const [showHistory, setShowHistory] = useState(false);
   const [navOpen, setNavOpen] = useState(false); // mobile drawer (activity bar + rail)
   const touchMode = useTouchMode();
   // Pending close confirmation. null while no prompt is open.
@@ -498,11 +499,12 @@ function App() {
         if (showRemote)     setShowRemote(false);
         if (showVoiceSettings) setShowVoiceSettings(false);
         if (showIntegrations) setShowIntegrations(false);
+        if (showHistory)    setShowHistory(false);
       }
     };
     window.addEventListener('keydown', onKey);
     return () => window.removeEventListener('keydown', onKey);
-  }, [showPalette, showCockpit, showNewSession, showAddRepo, showRemote, showVoiceSettings, showIntegrations, cycleSession]);
+  }, [showPalette, showCockpit, showNewSession, showAddRepo, showRemote, showVoiceSettings, showIntegrations, showHistory, cycleSession]);
 
   useEffect(() => {
     const open = () => setShowVoiceSettings(true);
@@ -551,6 +553,11 @@ function App() {
       id: 'integrations', icon: 'bolt', title: 'Integrations…',
       sub: 'Telegram / Slack / Discord / webhook alerts + GitHub ship-it',
       run: () => { setShowPalette(false); setShowIntegrations(true); },
+    },
+    {
+      id: 'history', icon: 'history', title: 'Session history…',
+      sub: 'Browse recorded sessions and their transcripts',
+      run: () => { setShowPalette(false); setShowHistory(true); },
     },
     {
       id: 'issue-intake', icon: 'branch', title: 'Start from GitHub issue…',
@@ -712,6 +719,7 @@ function App() {
           />
         )}
         {showVoiceSettings && <VoiceSettingsPanel onClose={() => setShowVoiceSettings(false)} />}
+        {showHistory && <HistoryPanel onClose={() => setShowHistory(false)} />}
         {nonGitChoice && (
           <NonGitFolderDialog
             name={nonGitChoice.name}
@@ -957,6 +965,7 @@ function App() {
         />
       )}
       {showVoiceSettings && <VoiceSettingsPanel onClose={() => setShowVoiceSettings(false)} />}
+      {showHistory && <HistoryPanel onClose={() => setShowHistory(false)} />}
 
       {confirmClose && (() => {
         const target = sessions.find(s => s.id === confirmClose.id);

--- a/src/renderer/components/shell/HistoryPanel.test.tsx
+++ b/src/renderer/components/shell/HistoryPanel.test.tsx
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { getElectronAPI } from '../../../../test/helpers/electron-api-mock';
+import { HistoryPanel } from './HistoryPanel';
+import type { HistorySessionEntry } from '../../../shared/types/history-types';
+
+function makeSession(overrides: Partial<HistorySessionEntry> = {}): HistorySessionEntry {
+  return {
+    id: 's1',
+    name: 'fix auth bug',
+    workingDirectory: 'C:\\repos\\omnidesk',
+    createdAt: Date.now() - 120_000,
+    lastUpdatedAt: Date.now() - 60_000,
+    sizeBytes: 2048,
+    segmentCount: 0,
+    ...overrides,
+  };
+}
+
+function setupApi(sessions: HistorySessionEntry[] = [makeSession()]) {
+  const api = getElectronAPI();
+  api.listHistory = vi.fn().mockResolvedValue(sessions);
+  api.getHistory = vi.fn().mockResolvedValue('transcript line 1\ntranscript line 2');
+  return api;
+}
+
+describe('HistoryPanel', () => {
+  it('lists recorded sessions newest-first with name and working directory', async () => {
+    const older = makeSession({ id: 's-old', name: 'older session', lastUpdatedAt: Date.now() - 3_600_000 });
+    const newer = makeSession({ id: 's-new', name: 'newer session', lastUpdatedAt: Date.now() - 1_000 });
+    setupApi([older, newer]);
+
+    render(<HistoryPanel onClose={() => {}} />);
+
+    await waitFor(() => expect(screen.getByTestId('history-row-s-new')).toBeInTheDocument());
+    expect(screen.getByTestId('history-row-s-old')).toBeInTheDocument();
+    expect(screen.getByText('newer session')).toBeInTheDocument();
+    expect(screen.getByText('older session')).toBeInTheDocument();
+    expect(screen.getAllByText('C:\\repos\\omnidesk').length).toBe(2);
+
+    // newest-first: s-new row should precede s-old row in the DOM
+    const rows = screen.getAllByRole('button').filter((el) => el.dataset.testid?.startsWith('history-row-'));
+    expect(rows[0]).toHaveAttribute('data-testid', 'history-row-s-new');
+    expect(rows[1]).toHaveAttribute('data-testid', 'history-row-s-old');
+  });
+
+  it('selecting a session loads and displays its transcript', async () => {
+    const api = setupApi([makeSession({ id: 's1' })]);
+    render(<HistoryPanel onClose={() => {}} />);
+
+    await waitFor(() => screen.getByTestId('history-row-s1'));
+    fireEvent.click(screen.getByTestId('history-row-s1'));
+
+    await waitFor(() => expect(api.getHistory).toHaveBeenCalledWith('s1'));
+    await waitFor(() =>
+      expect(screen.getByTestId('history-content')).toHaveTextContent('transcript line 1')
+    );
+  });
+
+  it('shows a graceful message when the transcript content is missing', async () => {
+    const api = setupApi([makeSession({ id: 's1' })]);
+    api.getHistory = vi.fn().mockResolvedValue(null);
+    render(<HistoryPanel onClose={() => {}} />);
+
+    await waitFor(() => screen.getByTestId('history-row-s1'));
+    fireEvent.click(screen.getByTestId('history-row-s1'));
+
+    await waitFor(() =>
+      expect(screen.getByText(/could not be loaded/)).toBeInTheDocument()
+    );
+  });
+
+  it('shows an empty state when there are no recorded sessions', async () => {
+    setupApi([]);
+    render(<HistoryPanel onClose={() => {}} />);
+    await waitFor(() => expect(screen.getByText('No recorded sessions yet.')).toBeInTheDocument());
+  });
+
+  it('shows an error state when listHistory fails', async () => {
+    const api = getElectronAPI();
+    api.listHistory = vi.fn().mockRejectedValue(new Error('disk read failed'));
+    render(<HistoryPanel onClose={() => {}} />);
+    await waitFor(() => expect(screen.getByText('disk read failed')).toBeInTheDocument());
+  });
+
+  it('calls onClose when the close button is clicked', async () => {
+    setupApi();
+    const onClose = vi.fn();
+    render(<HistoryPanel onClose={onClose} />);
+    await waitFor(() => screen.getByTestId('history-row-s1'));
+    fireEvent.click(screen.getByLabelText('Close'));
+    expect(onClose).toHaveBeenCalled();
+  });
+});

--- a/src/renderer/components/shell/HistoryPanel.tsx
+++ b/src/renderer/components/shell/HistoryPanel.tsx
@@ -1,0 +1,131 @@
+// @atlas-entrypoint: Session History Explorer — read-only browser for recorded
+// session transcripts (epic #214 child 2). Left pane lists recorded sessions
+// newest-first; right pane shows the full transcript for the selected one.
+// Search/export/delete/settings are deferred to later children of #214.
+import { useCallback, useMemo, useState } from 'react';
+import { P4Icon } from './P4Icon';
+import { formatLastActive } from './shell-utils';
+import { useHistory } from '../../hooks/useHistory';
+
+interface HistoryPanelProps {
+  onClose: () => void;
+}
+
+/** Humanize a byte count as e.g. "1.2 KB" / "3.4 MB". */
+function formatSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  const kb = bytes / 1024;
+  if (kb < 1024) return `${kb.toFixed(1)} KB`;
+  const mb = kb / 1024;
+  return `${mb.toFixed(1)} MB`;
+}
+
+export function HistoryPanel({ onClose }: HistoryPanelProps) {
+  const { sessions, loading, error, getContent } = useHistory();
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [content, setContent] = useState<string | null>(null);
+  const [contentLoading, setContentLoading] = useState(false);
+  const [contentMissing, setContentMissing] = useState(false);
+
+  const sorted = useMemo(
+    () => [...sessions].sort((a, b) => b.lastUpdatedAt - a.lastUpdatedAt),
+    [sessions]
+  );
+
+  const selectSession = useCallback(async (id: string) => {
+    setSelectedId(id);
+    setContentLoading(true);
+    setContentMissing(false);
+    setContent(null);
+    try {
+      const result = await getContent(id);
+      if (result === null) {
+        setContentMissing(true);
+      } else {
+        setContent(result);
+      }
+    } finally {
+      setContentLoading(false);
+    }
+  }, [getContent]);
+
+  return (
+    <div className="p4-overlay" onClick={(e) => { if (e.target === e.currentTarget) onClose(); }}>
+      <div className="p4-sheet" role="dialog" aria-modal="true" aria-label="Session History">
+        <div className="p4-sheet-head">
+          <div className="icon"><P4Icon name="history" size={16} /></div>
+          <div>
+            <div className="t">Session History</div>
+            <div className="d">Browse recorded sessions and their full transcripts.</div>
+          </div>
+          <button className="x" onClick={onClose} aria-label="Close">
+            <P4Icon name="x" size={14} />
+          </button>
+        </div>
+
+        <div className="p4-sheet-body" style={{ display: 'flex', gap: 12, minHeight: 320 }}>
+          <div style={{ flex: '0 0 45%', overflowY: 'auto', borderRight: '1px solid var(--border, #2a2a2a)', paddingRight: 8 }}>
+            {loading ? (
+              <div className="p4-form-row"><span className="d">Loading…</span></div>
+            ) : error ? (
+              <div className="p4-form-row">
+                <span className="d" style={{ color: 'var(--danger, #F7678E)' }}>{error}</span>
+              </div>
+            ) : sorted.length === 0 ? (
+              <div className="p4-form-row"><span className="d">No recorded sessions yet.</span></div>
+            ) : (
+              sorted.map((s) => (
+                <div
+                  key={s.id}
+                  className="p4-form-row"
+                  data-testid={`history-row-${s.id}`}
+                  role="button"
+                  tabIndex={0}
+                  onClick={() => void selectSession(s.id)}
+                  onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') void selectSession(s.id); }}
+                  style={{
+                    cursor: 'pointer',
+                    background: selectedId === s.id ? 'var(--surface-hover, rgba(255,255,255,0.06))' : undefined,
+                  }}
+                >
+                  <div className="t" style={{ fontWeight: 600 }}>{s.name}</div>
+                  <div className="d">{s.workingDirectory}</div>
+                  <div className="d">
+                    {formatLastActive(s.lastUpdatedAt)} · {formatSize(s.sizeBytes)}
+                    {s.segmentCount > 0 ? ` · ${s.segmentCount + 1} segments` : ''}
+                  </div>
+                </div>
+              ))
+            )}
+          </div>
+
+          <div style={{ flex: '1 1 55%', overflowY: 'auto', minWidth: 0 }}>
+            {selectedId === null ? (
+              <div className="p4-form-row"><span className="d">Select a session to view its transcript.</span></div>
+            ) : contentLoading ? (
+              <div className="p4-form-row"><span className="d">Loading transcript…</span></div>
+            ) : contentMissing ? (
+              <div className="p4-form-row">
+                <span className="d">This session&apos;s transcript could not be loaded — it may have been deleted.</span>
+              </div>
+            ) : (
+              <pre
+                data-testid="history-content"
+                style={{
+                  whiteSpace: 'pre-wrap',
+                  wordBreak: 'break-word',
+                  fontFamily: 'var(--mono, monospace)',
+                  fontSize: 12,
+                  margin: 0,
+                  padding: 8,
+                }}
+              >
+                {content}
+              </pre>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/renderer/components/shell/index.ts
+++ b/src/renderer/components/shell/index.ts
@@ -25,3 +25,4 @@ export { RemoteAccessPanel } from './RemoteAccessPanel';
 export { IntegrationsPanel } from './IntegrationsPanel';
 export { ShipItSheet } from './ShipItSheet';
 export { VoiceSettingsPanel } from './VoiceSettingsPanel';
+export { HistoryPanel } from './HistoryPanel';


### PR DESCRIPTION
## Summary
Adds a read-only **Session History Explorer** panel (epic #214, child 2):
left pane lists recorded sessions newest-first (name, working directory,
last-active time, size, segment count); right pane shows the full
transcript for whichever session is selected.

- New `HistoryPanel.tsx` in `src/renderer/components/shell/`, following the
  existing `p4-*` sheet/overlay pattern used by `RemoteAccessPanel`,
  `IntegrationsPanel`, `VoiceSettingsPanel`, etc.
- Reuses the already-shipped `useHistory()` hook (#217) — no new IPC surface,
  no new dependencies.
- Wired into `App.tsx`: `showHistory` state, a new "Session history…" command
  palette action, Escape-to-dismiss, and mounted in both the mobile and
  desktop layout render branches (matching how every other shell panel is
  wired).
- Barrel-exported from `src/renderer/components/shell/index.ts`.

Search, export, delete, and settings are explicitly out of scope here —
deferred to later children of #214 (cross-session search is next, per
compass).

Closes #218

## Test plan
- [x] `tsc --noEmit -p tsconfig.json` — clean
- [x] `tsc --noEmit -p tsconfig.node.json` — clean
- [x] `npx vitest run --config vitest.workspace.ts --project renderer` — new
      `HistoryPanel.test.tsx` (6 cases: newest-first sort, transcript load on
      select, graceful missing-transcript message, empty state, error state,
      onClose callback) all pass
- [x] `npm test` (full suite) — 114 files / 1360 tests, all green