### PR TITLE
feat(history): add cross-session content search to HistoryPanel

### DIFF
--- a/src/renderer/components/shell/HistoryPanel.test.tsx
+++ b/src/renderer/components/shell/HistoryPanel.test.tsx
@@ -2,7 +2,7 @@ import { describe, it, expect, vi } from 'vitest';
 import { render, screen, waitFor, fireEvent } from '@testing-library/react';
 import { getElectronAPI } from '../../../../test/helpers/electron-api-mock';
 import { HistoryPanel } from './HistoryPanel';
-import type { HistorySessionEntry } from '../../../shared/types/history-types';
+import type { HistorySessionEntry, HistorySearchResult } from '../../../shared/types/history-types';
 
 function makeSession(overrides: Partial<HistorySessionEntry> = {}): HistorySessionEntry {
   return {
@@ -17,10 +17,22 @@ function makeSession(overrides: Partial<HistorySessionEntry> = {}): HistorySessi
   };
 }
 
+function makeSearchResult(overrides: Partial<HistorySearchResult> = {}): HistorySearchResult {
+  return {
+    session: makeSession(),
+    matchCount: 2,
+    previews: [
+      { lineNumber: 3, before: 'context before ', match: 'needle', after: ' context after' },
+    ],
+    ...overrides,
+  };
+}
+
 function setupApi(sessions: HistorySessionEntry[] = [makeSession()]) {
   const api = getElectronAPI();
   api.listHistory = vi.fn().mockResolvedValue(sessions);
   api.getHistory = vi.fn().mockResolvedValue('transcript line 1\ntranscript line 2');
+  api.searchHistory = vi.fn().mockResolvedValue([]);
   return api;
 }
 
@@ -90,5 +102,102 @@ describe('HistoryPanel', () => {
     await waitFor(() => screen.getByTestId('history-row-s1'));
     fireEvent.click(screen.getByLabelText('Close'));
     expect(onClose).toHaveBeenCalled();
+  });
+
+  it('debounces search input and calls search with the query and case-sensitivity flag', async () => {
+    const api = setupApi();
+    api.searchHistory = vi.fn().mockResolvedValue([makeSearchResult()]);
+    render(<HistoryPanel onClose={() => {}} />);
+
+    await waitFor(() => screen.getByTestId('history-row-s1'));
+    fireEvent.change(screen.getByTestId('history-search-input'), { target: { value: 'needle' } });
+
+    await waitFor(() => expect(api.searchHistory).toHaveBeenCalledWith('needle', false));
+  });
+
+  it('passes the match-case toggle through to the search call', async () => {
+    const api = setupApi();
+    api.searchHistory = vi.fn().mockResolvedValue([makeSearchResult()]);
+    render(<HistoryPanel onClose={() => {}} />);
+
+    await waitFor(() => screen.getByTestId('history-row-s1'));
+    fireEvent.click(screen.getByTestId('history-search-case'));
+    fireEvent.change(screen.getByTestId('history-search-input'), { target: { value: 'needle' } });
+
+    await waitFor(() => expect(api.searchHistory).toHaveBeenCalledWith('needle', true));
+  });
+
+  it('renders search results grouped by session with match counts and highlighted previews', async () => {
+    const api = setupApi();
+    api.searchHistory = vi.fn().mockResolvedValue([makeSearchResult()]);
+    render(<HistoryPanel onClose={() => {}} />);
+
+    await waitFor(() => screen.getByTestId('history-row-s1'));
+    fireEvent.change(screen.getByTestId('history-search-input'), { target: { value: 'needle' } });
+
+    await waitFor(() => expect(screen.getByTestId('history-search-result-s1')).toBeInTheDocument());
+    expect(screen.getByText('2 matches')).toBeInTheDocument();
+    expect(screen.getByText('needle')).toBeInTheDocument();
+  });
+
+  it('shows a "no matches" state when the search returns no results', async () => {
+    const api = setupApi();
+    api.searchHistory = vi.fn().mockResolvedValue([]);
+    render(<HistoryPanel onClose={() => {}} />);
+
+    await waitFor(() => screen.getByTestId('history-row-s1'));
+    fireEvent.change(screen.getByTestId('history-search-input'), { target: { value: 'nothingmatches' } });
+
+    await waitFor(() =>
+      expect(screen.getByText('No matches for "nothingmatches".')).toBeInTheDocument()
+    );
+  });
+
+  it('shows a "searching" state while a search is in flight', async () => {
+    const api = setupApi();
+    let resolveSearch: (value: HistorySearchResult[]) => void = () => {};
+    api.searchHistory = vi.fn(() => new Promise((resolve) => { resolveSearch = resolve; }));
+    render(<HistoryPanel onClose={() => {}} />);
+
+    await waitFor(() => screen.getByTestId('history-row-s1'));
+    fireEvent.change(screen.getByTestId('history-search-input'), { target: { value: 'needle' } });
+
+    await waitFor(() => expect(screen.getByText('Searching…')).toBeInTheDocument());
+    await waitFor(() => expect(api.searchHistory).toHaveBeenCalled());
+    resolveSearch([makeSearchResult()]);
+    await waitFor(() => expect(screen.getByTestId('history-search-result-s1')).toBeInTheDocument());
+  });
+
+  it('falls back to the browse list when the search query is cleared', async () => {
+    const api = setupApi();
+    api.searchHistory = vi.fn().mockResolvedValue([makeSearchResult()]);
+    render(<HistoryPanel onClose={() => {}} />);
+
+    await waitFor(() => screen.getByTestId('history-row-s1'));
+    const input = screen.getByTestId('history-search-input');
+    fireEvent.change(input, { target: { value: 'needle' } });
+    await waitFor(() => expect(screen.getByTestId('history-search-result-s1')).toBeInTheDocument());
+
+    fireEvent.change(input, { target: { value: '' } });
+    await waitFor(() => expect(screen.getByTestId('history-row-s1')).toBeInTheDocument());
+    expect(screen.queryByTestId('history-search-result-s1')).not.toBeInTheDocument();
+  });
+
+  it('clicking a search result loads and displays its transcript', async () => {
+    const other = makeSession({ id: 's2', name: 'other session' });
+    const api = setupApi([makeSession(), other]);
+    api.searchHistory = vi.fn().mockResolvedValue([makeSearchResult({ session: other, matchCount: 1 })]);
+    render(<HistoryPanel onClose={() => {}} />);
+
+    await waitFor(() => screen.getByTestId('history-row-s1'));
+    fireEvent.change(screen.getByTestId('history-search-input'), { target: { value: 'needle' } });
+
+    await waitFor(() => screen.getByTestId('history-search-result-s2'));
+    fireEvent.click(screen.getByTestId('history-search-result-s2'));
+
+    await waitFor(() => expect(api.getHistory).toHaveBeenCalledWith('s2'));
+    await waitFor(() =>
+      expect(screen.getByTestId('history-content')).toHaveTextContent('transcript line 1')
+    );
   });
 });

--- a/src/renderer/components/shell/HistoryPanel.tsx
+++ b/src/renderer/components/shell/HistoryPanel.tsx
@@ -1,11 +1,17 @@
 // @atlas-entrypoint: Session History Explorer — read-only browser for recorded
-// session transcripts (epic #214 child 2). Left pane lists recorded sessions
-// newest-first; right pane shows the full transcript for the selected one.
-// Search/export/delete/settings are deferred to later children of #214.
-import { useCallback, useMemo, useState } from 'react';
+// session transcripts (epic #214 child 2), now with cross-session content
+// search (epic #214 child 3). Left pane lists recorded sessions newest-first,
+// or search results grouped by session when a query is active; right pane
+// shows the full transcript for the selected one.
+// Export/delete/settings are deferred to later children of #214.
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { P4Icon } from './P4Icon';
 import { formatLastActive } from './shell-utils';
 import { useHistory } from '../../hooks/useHistory';
+import type { HistorySearchResult } from '../../../shared/types/history-types';
+
+/** Debounce delay (ms) between the last keystroke and firing a search. */
+const SEARCH_DEBOUNCE_MS = 200;
 
 interface HistoryPanelProps {
   onClose: () => void;
@@ -21,11 +27,48 @@ function formatSize(bytes: number): string {
 }
 
 export function HistoryPanel({ onClose }: HistoryPanelProps) {
-  const { sessions, loading, error, getContent } = useHistory();
+  const { sessions, loading, error, getContent, search } = useHistory();
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [content, setContent] = useState<string | null>(null);
   const [contentLoading, setContentLoading] = useState(false);
   const [contentMissing, setContentMissing] = useState(false);
+
+  const [query, setQuery] = useState('');
+  const [caseSensitive, setCaseSensitive] = useState(false);
+  const [searchResults, setSearchResults] = useState<HistorySearchResult[] | null>(null);
+  const [searching, setSearching] = useState(false);
+  const searchTimerRef = useRef<number | null>(null);
+  const searchSeqRef = useRef(0);
+
+  const trimmedQuery = query.trim();
+
+  useEffect(() => {
+    if (searchTimerRef.current !== null) {
+      window.clearTimeout(searchTimerRef.current);
+      searchTimerRef.current = null;
+    }
+    if (trimmedQuery === '') {
+      setSearchResults(null);
+      setSearching(false);
+      return;
+    }
+    setSearching(true);
+    const seq = ++searchSeqRef.current;
+    searchTimerRef.current = window.setTimeout(() => {
+      searchTimerRef.current = null;
+      void search(trimmedQuery, caseSensitive).then((results) => {
+        if (seq !== searchSeqRef.current) return; // superseded by a newer query
+        setSearchResults(results);
+        setSearching(false);
+      });
+    }, SEARCH_DEBOUNCE_MS);
+    return () => {
+      if (searchTimerRef.current !== null) {
+        window.clearTimeout(searchTimerRef.current);
+        searchTimerRef.current = null;
+      }
+    };
+  }, [trimmedQuery, caseSensitive, search]);
 
   const sorted = useMemo(
     () => [...sessions].sort((a, b) => b.lastUpdatedAt - a.lastUpdatedAt),
@@ -65,7 +108,71 @@ export function HistoryPanel({ onClose }: HistoryPanelProps) {
 
         <div className="p4-sheet-body" style={{ display: 'flex', gap: 12, minHeight: 320 }}>
           <div style={{ flex: '0 0 45%', overflowY: 'auto', borderRight: '1px solid var(--border, #2a2a2a)', paddingRight: 8 }}>
-            {loading ? (
+            <div className="p4-form-row" style={{ display: 'flex', gap: 6, alignItems: 'center' }}>
+              <P4Icon name="search" size={14} />
+              <input
+                type="text"
+                placeholder="Search transcripts…"
+                value={query}
+                onChange={(e) => setQuery(e.target.value)}
+                data-testid="history-search-input"
+                style={{ flex: 1 }}
+              />
+            </div>
+            <label
+              className="p4-form-row"
+              style={{ display: 'flex', gap: 6, alignItems: 'center', fontSize: 12, cursor: 'pointer' }}
+            >
+              <input
+                type="checkbox"
+                checked={caseSensitive}
+                onChange={(e) => setCaseSensitive(e.target.checked)}
+                data-testid="history-search-case"
+              />
+              Match case
+            </label>
+
+            {trimmedQuery !== '' ? (
+              searching ? (
+                <div className="p4-form-row"><span className="d">Searching…</span></div>
+              ) : !searchResults || searchResults.length === 0 ? (
+                <div className="p4-form-row">
+                  <span className="d">No matches for &quot;{trimmedQuery}&quot;.</span>
+                </div>
+              ) : (
+                searchResults.map((r) => (
+                  <div
+                    key={r.session.id}
+                    className="p4-form-row"
+                    data-testid={`history-search-result-${r.session.id}`}
+                    role="button"
+                    tabIndex={0}
+                    onClick={() => void selectSession(r.session.id)}
+                    onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') void selectSession(r.session.id); }}
+                    style={{
+                      cursor: 'pointer',
+                      background: selectedId === r.session.id ? 'var(--surface-hover, rgba(255,255,255,0.06))' : undefined,
+                    }}
+                  >
+                    <div className="t" style={{ fontWeight: 600 }}>{r.session.name}</div>
+                    <div className="d">
+                      {r.matchCount} match{r.matchCount === 1 ? '' : 'es'}
+                    </div>
+                    {r.previews.slice(0, 3).map((p, i) => (
+                      <div
+                        key={i}
+                        className="d"
+                        style={{ fontFamily: 'var(--mono, monospace)', fontSize: 11, whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}
+                      >
+                        {p.before}
+                        <mark>{p.match}</mark>
+                        {p.after}
+                      </div>
+                    ))}
+                  </div>
+                ))
+              )
+            ) : loading ? (
               <div className="p4-form-row"><span className="d">Loading…</span></div>
             ) : error ? (
               <div className="p4-form-row">


### PR DESCRIPTION
## Summary

Adds cross-session content search to the Session History Explorer (epic #214 child 3). Left pane now shows a debounced search input + match-case toggle above the session list; when a query is active, it renders search results grouped by session (match count + up to 3 highlighted previews) instead of the plain browse list. Clicking a search result reuses the existing `selectSession`/`getContent` flow to load the transcript.

- Reuses the existing `useHistory().search` IPC method — no new IPC surface.
- No `App.tsx` wiring changes required.
- 200ms debounce + sequence-guard against stale/out-of-order search responses, matching the existing debounce idiom used elsewhere in the renderer (`useSessionPreviews.ts`).
- Falls back to the original loading/error/empty/browse-list rendering when the query is cleared.

Closes #220

## Verification

- `tsc --noEmit` clean on both `tsconfig.json` and `tsconfig.node.json`.
- Full `npm test`: **114/114 test files passed, 1367/1367 tests passed** (zero regressions).
- 7 new tests added to `HistoryPanel.test.tsx` covering: debounced search call args (query + case-sensitivity), match-case toggle pass-through, grouped/highlighted results rendering, "no matches" state, "searching" loading state, clear-query fallback to browse list, and click-to-load-transcript for a search result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)