### PR TITLE
feat(history): wire export/delete/stats/retention actions into HistoryPanel

### DIFF
--- a/src/renderer/components/shell/HistoryPanel.test.tsx
+++ b/src/renderer/components/shell/HistoryPanel.test.tsx
@@ -1,8 +1,32 @@
 import { describe, it, expect, vi } from 'vitest';
-import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { render, screen, waitFor, fireEvent, within } from '@testing-library/react';
 import { getElectronAPI } from '../../../../test/helpers/electron-api-mock';
 import { HistoryPanel } from './HistoryPanel';
-import type { HistorySessionEntry, HistorySearchResult } from '../../../shared/types/history-types';
+import type {
+  HistorySessionEntry,
+  HistorySearchResult,
+  HistorySettings,
+  HistoryStats,
+} from '../../../shared/types/history-types';
+
+function makeSettings(overrides: Partial<HistorySettings> = {}): HistorySettings {
+  return {
+    maxAgeDays: 30,
+    maxSizeMB: 500,
+    autoCleanup: false,
+    ...overrides,
+  };
+}
+
+function makeStats(overrides: Partial<HistoryStats> = {}): HistoryStats {
+  return {
+    totalSessions: 3,
+    totalSizeBytes: 1024 * 1024 * 5, // 5 MB
+    oldestSessionDate: Date.now() - 7 * 24 * 60 * 60 * 1000,
+    newestSessionDate: Date.now() - 60_000,
+    ...overrides,
+  };
+}
 
 function makeSession(overrides: Partial<HistorySessionEntry> = {}): HistorySessionEntry {
   return {
@@ -33,6 +57,14 @@ function setupApi(sessions: HistorySessionEntry[] = [makeSession()]) {
   api.listHistory = vi.fn().mockResolvedValue(sessions);
   api.getHistory = vi.fn().mockResolvedValue('transcript line 1\ntranscript line 2');
   api.searchHistory = vi.fn().mockResolvedValue([]);
+  api.getHistorySettings = vi.fn().mockResolvedValue(makeSettings());
+  api.getHistoryStats = vi.fn().mockResolvedValue(makeStats());
+  api.showSaveDialog = vi.fn().mockResolvedValue('C:\\exports\\out.md');
+  api.exportHistoryMarkdown = vi.fn().mockResolvedValue(true);
+  api.exportHistoryJson = vi.fn().mockResolvedValue(true);
+  api.deleteHistory = vi.fn().mockResolvedValue(true);
+  api.deleteAllHistory = vi.fn().mockResolvedValue(true);
+  api.updateHistorySettings = vi.fn().mockResolvedValue(true);
   return api;
 }
 
@@ -199,5 +231,125 @@ describe('HistoryPanel', () => {
     await waitFor(() =>
       expect(screen.getByTestId('history-content')).toHaveTextContent('transcript line 1')
     );
+  });
+
+  it('exports the selected session as Markdown via the save dialog', async () => {
+    const api = setupApi([makeSession({ id: 's1', name: 'fix auth bug' })]);
+    render(<HistoryPanel onClose={() => {}} />);
+
+    await waitFor(() => screen.getByTestId('history-row-s1'));
+    fireEvent.click(screen.getByTestId('history-row-s1'));
+    await waitFor(() => screen.getByTestId('history-export-md'));
+    fireEvent.click(screen.getByTestId('history-export-md'));
+
+    await waitFor(() =>
+      expect(api.showSaveDialog).toHaveBeenCalledWith({
+        defaultPath: 'fix auth bug.md',
+        filters: [{ name: 'Markdown', extensions: ['md'] }],
+      })
+    );
+    await waitFor(() =>
+      expect(api.exportHistoryMarkdown).toHaveBeenCalledWith('s1', 'C:\\exports\\out.md')
+    );
+  });
+
+  it('exports the selected session as JSON via the save dialog', async () => {
+    const api = setupApi([makeSession({ id: 's1', name: 'fix auth bug' })]);
+    api.showSaveDialog = vi.fn().mockResolvedValue('C:\\exports\\out.json');
+    render(<HistoryPanel onClose={() => {}} />);
+
+    await waitFor(() => screen.getByTestId('history-row-s1'));
+    fireEvent.click(screen.getByTestId('history-row-s1'));
+    await waitFor(() => screen.getByTestId('history-export-json'));
+    fireEvent.click(screen.getByTestId('history-export-json'));
+
+    await waitFor(() =>
+      expect(api.showSaveDialog).toHaveBeenCalledWith({
+        defaultPath: 'fix auth bug.json',
+        filters: [{ name: 'JSON', extensions: ['json'] }],
+      })
+    );
+    await waitFor(() =>
+      expect(api.exportHistoryJson).toHaveBeenCalledWith('s1', 'C:\\exports\\out.json')
+    );
+  });
+
+  it('does not export when the save dialog is cancelled', async () => {
+    const api = setupApi([makeSession({ id: 's1' })]);
+    api.showSaveDialog = vi.fn().mockResolvedValue(null);
+    render(<HistoryPanel onClose={() => {}} />);
+
+    await waitFor(() => screen.getByTestId('history-row-s1'));
+    fireEvent.click(screen.getByTestId('history-row-s1'));
+    await waitFor(() => screen.getByTestId('history-export-md'));
+    fireEvent.click(screen.getByTestId('history-export-md'));
+    fireEvent.click(screen.getByTestId('history-export-json'));
+
+    await waitFor(() => expect(api.showSaveDialog).toHaveBeenCalledTimes(2));
+    expect(api.exportHistoryMarkdown).not.toHaveBeenCalled();
+    expect(api.exportHistoryJson).not.toHaveBeenCalled();
+  });
+
+  it('deletes the selected session after confirming, and clears the transcript viewer', async () => {
+    const api = setupApi([makeSession({ id: 's1' })]);
+    render(<HistoryPanel onClose={() => {}} />);
+
+    await waitFor(() => screen.getByTestId('history-row-s1'));
+    fireEvent.click(screen.getByTestId('history-row-s1'));
+    await waitFor(() =>
+      expect(screen.getByTestId('history-content')).toHaveTextContent('transcript line 1')
+    );
+
+    fireEvent.click(screen.getByTestId('history-delete'));
+    const dialog = await screen.findByRole('alertdialog');
+    expect(within(dialog).getByText('Delete session')).toBeInTheDocument();
+    fireEvent.mouseDown(within(dialog).getByRole('button', { name: /^Delete/ }));
+
+    await waitFor(() => expect(api.deleteHistory).toHaveBeenCalledWith('s1'));
+    await waitFor(() =>
+      expect(screen.getByText('Select a session to view its transcript.')).toBeInTheDocument()
+    );
+  });
+
+  it('deletes all sessions after confirming via the final-destructive dialog', async () => {
+    const api = setupApi([makeSession({ id: 's1' })]);
+    render(<HistoryPanel onClose={() => {}} />);
+
+    await waitFor(() => screen.getByTestId('history-delete-all'));
+    fireEvent.click(screen.getByTestId('history-delete-all'));
+    const dialog = await screen.findByRole('alertdialog');
+    expect(within(dialog).getByText('Delete all sessions')).toBeInTheDocument();
+    fireEvent.mouseDown(within(dialog).getByRole('button', { name: /^Delete all/ }));
+
+    await waitFor(() => expect(api.deleteAllHistory).toHaveBeenCalled());
+  });
+
+  it('renders history stats with session count and size', async () => {
+    setupApi();
+    render(<HistoryPanel onClose={() => {}} />);
+
+    await waitFor(() => screen.getByTestId('history-stats'));
+    const stats = screen.getByTestId('history-stats');
+    expect(within(stats).getByText(/3 sessions/)).toBeInTheDocument();
+    expect(within(stats).getByText(/5(\.0)? MB/)).toBeInTheDocument();
+  });
+
+  it('loads history settings and persists changes to each field', async () => {
+    const api = setupApi();
+    render(<HistoryPanel onClose={() => {}} />);
+
+    await waitFor(() => screen.getByTestId('history-settings'));
+    expect(screen.getByTestId('history-setting-max-age')).toHaveValue(30);
+    expect(screen.getByTestId('history-setting-max-size')).toHaveValue(500);
+    expect(screen.getByTestId('history-setting-auto-cleanup')).not.toBeChecked();
+
+    fireEvent.change(screen.getByTestId('history-setting-max-age'), { target: { value: '60' } });
+    await waitFor(() => expect(api.updateHistorySettings).toHaveBeenCalledWith({ maxAgeDays: 60 }));
+
+    fireEvent.change(screen.getByTestId('history-setting-max-size'), { target: { value: '1000' } });
+    await waitFor(() => expect(api.updateHistorySettings).toHaveBeenCalledWith({ maxSizeMB: 1000 }));
+
+    fireEvent.click(screen.getByTestId('history-setting-auto-cleanup'));
+    await waitFor(() => expect(api.updateHistorySettings).toHaveBeenCalledWith({ autoCleanup: true }));
   });
 });

--- a/src/renderer/components/shell/HistoryPanel.tsx
+++ b/src/renderer/components/shell/HistoryPanel.tsx
@@ -1,14 +1,15 @@
 // @atlas-entrypoint: Session History Explorer — read-only browser for recorded
-// session transcripts (epic #214 child 2), now with cross-session content
-// search (epic #214 child 3). Left pane lists recorded sessions newest-first,
-// or search results grouped by session when a query is active; right pane
-// shows the full transcript for the selected one.
-// Export/delete/settings are deferred to later children of #214.
+// session transcripts (epic #214 child 2), with cross-session content search
+// (epic #214 child 3), and export / delete / stats / retention actions (epic
+// #214 child 4). Left pane lists recorded sessions newest-first, or search
+// results grouped by session when a query is active; right pane shows the
+// full transcript for the selected one plus its export/delete actions.
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { P4Icon } from './P4Icon';
 import { formatLastActive } from './shell-utils';
 import { useHistory } from '../../hooks/useHistory';
-import type { HistorySearchResult } from '../../../shared/types/history-types';
+import { ConfirmDialog } from '../ui/ConfirmDialog';
+import type { HistorySearchResult, HistorySettings, HistoryStats } from '../../../shared/types/history-types';
 
 /** Debounce delay (ms) between the last keystroke and firing a search. */
 const SEARCH_DEBOUNCE_MS = 200;
@@ -27,7 +28,11 @@ function formatSize(bytes: number): string {
 }
 
 export function HistoryPanel({ onClose }: HistoryPanelProps) {
-  const { sessions, loading, error, getContent, search } = useHistory();
+  const {
+    sessions, loading, error, getContent, search,
+    remove, removeAll, exportMarkdown, exportJson,
+    getSettings, updateSettings, getStats,
+  } = useHistory();
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [content, setContent] = useState<string | null>(null);
   const [contentLoading, setContentLoading] = useState(false);
@@ -39,6 +44,16 @@ export function HistoryPanel({ onClose }: HistoryPanelProps) {
   const [searching, setSearching] = useState(false);
   const searchTimerRef = useRef<number | null>(null);
   const searchSeqRef = useRef(0);
+
+  const [confirmDeleteId, setConfirmDeleteId] = useState<string | null>(null);
+  const [confirmDeleteAll, setConfirmDeleteAll] = useState(false);
+  const [stats, setStats] = useState<HistoryStats | null>(null);
+  const [settings, setSettings] = useState<HistorySettings | null>(null);
+
+  useEffect(() => {
+    void getStats().then(setStats);
+    void getSettings().then(setSettings);
+  }, [getStats, getSettings]);
 
   const trimmedQuery = query.trim();
 
@@ -75,6 +90,17 @@ export function HistoryPanel({ onClose }: HistoryPanelProps) {
     [sessions]
   );
 
+  /** Display name of the currently selected session — looked up from either the
+   *  browse list or the active search results, since a selection can come from
+   *  either. Used as the default export filename. */
+  const selectedName = useMemo(() => {
+    if (selectedId === null) return null;
+    const fromSorted = sorted.find((s) => s.id === selectedId);
+    if (fromSorted) return fromSorted.name;
+    const fromSearch = searchResults?.find((r) => r.session.id === selectedId);
+    return fromSearch?.session.name ?? null;
+  }, [selectedId, sorted, searchResults]);
+
   const selectSession = useCallback(async (id: string) => {
     setSelectedId(id);
     setContentLoading(true);
@@ -91,6 +117,51 @@ export function HistoryPanel({ onClose }: HistoryPanelProps) {
       setContentLoading(false);
     }
   }, [getContent]);
+
+  const clearSelection = useCallback(() => {
+    setSelectedId(null);
+    setContent(null);
+    setContentMissing(false);
+  }, []);
+
+  const handleExportMarkdown = useCallback(async (id: string, name: string) => {
+    const path = await window.electronAPI.showSaveDialog({
+      defaultPath: `${name}.md`,
+      filters: [{ name: 'Markdown', extensions: ['md'] }],
+    });
+    if (path === null) return; // user cancelled
+    await exportMarkdown(id, path);
+  }, [exportMarkdown]);
+
+  const handleExportJson = useCallback(async (id: string, name: string) => {
+    const path = await window.electronAPI.showSaveDialog({
+      defaultPath: `${name}.json`,
+      filters: [{ name: 'JSON', extensions: ['json'] }],
+    });
+    if (path === null) return; // user cancelled
+    await exportJson(id, path);
+  }, [exportJson]);
+
+  const handleConfirmDelete = useCallback(async () => {
+    if (confirmDeleteId === null) return;
+    const id = confirmDeleteId;
+    setConfirmDeleteId(null);
+    const ok = await remove(id);
+    if (ok && selectedId === id) clearSelection();
+    setStats(await getStats());
+  }, [confirmDeleteId, remove, selectedId, clearSelection, getStats]);
+
+  const handleConfirmDeleteAll = useCallback(async () => {
+    setConfirmDeleteAll(false);
+    const ok = await removeAll();
+    if (ok) clearSelection();
+    setStats(await getStats());
+  }, [removeAll, clearSelection, getStats]);
+
+  const handleSettingsChange = useCallback(async (patch: Partial<HistorySettings>) => {
+    setSettings((prev) => (prev ? { ...prev, ...patch } : prev));
+    await updateSettings(patch);
+  }, [updateSettings]);
 
   return (
     <div className="p4-overlay" onClick={(e) => { if (e.target === e.currentTarget) onClose(); }}>
@@ -206,7 +277,30 @@ export function HistoryPanel({ onClose }: HistoryPanelProps) {
             )}
           </div>
 
-          <div style={{ flex: '1 1 55%', overflowY: 'auto', minWidth: 0 }}>
+          <div style={{ flex: '1 1 55%', overflowY: 'auto', minWidth: 0, display: 'flex', flexDirection: 'column', gap: 8 }}>
+            {selectedId !== null && (
+              <div className="p4-form-row" style={{ display: 'flex', gap: 6 }}>
+                <button
+                  data-testid="history-export-md"
+                  onClick={() => void handleExportMarkdown(selectedId, selectedName ?? selectedId)}
+                >
+                  Export Markdown
+                </button>
+                <button
+                  data-testid="history-export-json"
+                  onClick={() => void handleExportJson(selectedId, selectedName ?? selectedId)}
+                >
+                  Export JSON
+                </button>
+                <button
+                  data-testid="history-delete"
+                  onClick={() => setConfirmDeleteId(selectedId)}
+                >
+                  Delete
+                </button>
+              </div>
+            )}
+
             {selectedId === null ? (
               <div className="p4-form-row"><span className="d">Select a session to view its transcript.</span></div>
             ) : contentLoading ? (
@@ -232,7 +326,78 @@ export function HistoryPanel({ onClose }: HistoryPanelProps) {
             )}
           </div>
         </div>
+
+        <div className="p4-sheet-foot" style={{ display: 'flex', flexDirection: 'column', gap: 6, borderTop: '1px solid var(--border, #2a2a2a)', padding: '8px 0' }}>
+          {stats && (
+            <div className="p4-form-row" data-testid="history-stats" style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+              <span className="d">
+                {stats.totalSessions} session{stats.totalSessions === 1 ? '' : 's'} · {formatSize(stats.totalSizeBytes)}
+                {stats.oldestSessionDate !== null && stats.newestSessionDate !== null
+                  ? ` · ${formatLastActive(stats.oldestSessionDate)} – ${formatLastActive(stats.newestSessionDate)}`
+                  : ''}
+              </span>
+              <button data-testid="history-delete-all" onClick={() => setConfirmDeleteAll(true)}>
+                Delete all
+              </button>
+            </div>
+          )}
+
+          {settings && (
+            <div className="p4-form-row" data-testid="history-settings" style={{ display: 'flex', gap: 12, alignItems: 'center', fontSize: 12 }}>
+              <label style={{ display: 'flex', gap: 4, alignItems: 'center' }}>
+                Max age (days)
+                <input
+                  type="number"
+                  min={0}
+                  data-testid="history-setting-max-age"
+                  value={settings.maxAgeDays}
+                  onChange={(e) => void handleSettingsChange({ maxAgeDays: Number(e.target.value) })}
+                  style={{ width: 64 }}
+                />
+              </label>
+              <label style={{ display: 'flex', gap: 4, alignItems: 'center' }}>
+                Max size (MB)
+                <input
+                  type="number"
+                  min={0}
+                  data-testid="history-setting-max-size"
+                  value={settings.maxSizeMB}
+                  onChange={(e) => void handleSettingsChange({ maxSizeMB: Number(e.target.value) })}
+                  style={{ width: 64 }}
+                />
+              </label>
+              <label style={{ display: 'flex', gap: 4, alignItems: 'center', cursor: 'pointer' }}>
+                <input
+                  type="checkbox"
+                  data-testid="history-setting-auto-cleanup"
+                  checked={settings.autoCleanup}
+                  onChange={(e) => void handleSettingsChange({ autoCleanup: e.target.checked })}
+                />
+                Auto cleanup
+              </label>
+            </div>
+          )}
+        </div>
       </div>
+
+      <ConfirmDialog
+        isOpen={confirmDeleteId !== null}
+        title="Delete session"
+        body="This will permanently delete the recorded transcript for this session. This cannot be undone."
+        severity="destructive"
+        confirmLabel="Delete"
+        onConfirm={() => void handleConfirmDelete()}
+        onCancel={() => setConfirmDeleteId(null)}
+      />
+      <ConfirmDialog
+        isOpen={confirmDeleteAll}
+        title="Delete all sessions"
+        body="This will permanently delete every recorded session transcript. This cannot be undone."
+        severity="final-destructive"
+        confirmLabel="Delete all"
+        onConfirm={() => void handleConfirmDeleteAll()}
+        onCancel={() => setConfirmDeleteAll(false)}
+      />
     </div>
   );
 }

--- a/src/renderer/hooks/useHistory.ts
+++ b/src/renderer/hooks/useHistory.ts
@@ -117,9 +117,12 @@ export function useHistory(): UseHistoryApi {
 
   const getSettings = useCallback(async () => {
     try {
-      const settings = await window.electronAPI.getHistorySettings();
-      setError(null);
-      return settings;
+      // Deliberately does not clear `error` on success: this is fetched
+      // alongside getStats in a mount-time effect that races with the
+      // primary refresh() list load, and clearing `error` here would
+      // clobber a real listHistory failure the moment this unrelated,
+      // supplementary fetch happens to resolve second.
+      return await window.electronAPI.getHistorySettings();
     } catch (e) {
       setError(e instanceof Error ? e.message : String(e));
       return null;
@@ -139,9 +142,9 @@ export function useHistory(): UseHistoryApi {
 
   const getStats = useCallback(async () => {
     try {
-      const stats = await window.electronAPI.getHistoryStats();
-      setError(null);
-      return stats;
+      // See getSettings above: no setError(null) on success, for the same
+      // race-with-mount-time-refresh() reason.
+      return await window.electronAPI.getHistoryStats();
     } catch (e) {
       setError(e instanceof Error ? e.message : String(e));
       return null;


### PR DESCRIPTION
## Summary

Closes #222 (epic #214, child 4).

Wires the Session History Explorer panel (`HistoryPanel.tsx`) up to the
export/delete/stats/retention IPC actions that `useHistory` already
exposed but the panel wasn't using yet:

- Per-session export to Markdown and JSON (via `showSaveDialog` + `exportHistoryMarkdown`/`exportHistoryJson`)
- Delete single session and delete-all, both behind the existing `ConfirmDialog` (destructive/final-destructive severities)
- A stats view (session count, total size, oldest/newest session date)
- A retention-settings view/editor (`maxAgeDays`, `maxSizeMB`, `autoCleanup`) via `getSettings`/`updateSettings`

## Additional fix: error-state race in `useHistory`

While verifying, I found a genuine regression: the new `HistoryPanel`
mount effect calls `getStats()` and `getSettings()` concurrently with
the hook's own internal `refresh()` (which loads the session list and
sets `error` on failure). Every method in `useHistory` unconditionally
called `setError(null)` on success against one shared `error` field, so
whichever of these calls resolved last won — a real `listHistory()`
failure could get silently clobbered back to `null` the moment the
unrelated stats/settings fetch happened to resolve afterward.

Fixed by dropping the `setError(null)` clear from `getStats`/`getSettings`
only, since they don't own the list-load error. Left the clear-on-success
behavior on `getContent`, `search`, `remove`, `removeAll`, `exportMarkdown`,
`exportJson`, and `updateSettings` untouched — those are user-triggered
after mount, not fired concurrently with the initial list load, so their
existing tested behavior stays as-is.

## Verification

- `tsc --noEmit` clean on both `tsconfig.json` and `tsconfig.node.json`
- `npx vitest run --config vitest.workspace.ts --project renderer src/renderer/components/shell/HistoryPanel.test.tsx` → 20/20 passed (was 19/20 before the `useHistory.ts` fix — "shows an error state when listHistory fails" was flaky/racy without it)
- `npx vitest run --config vitest.workspace.ts` (full workspace) → 114 files, 1374 tests, all passed

No new dependencies added.