### PR TITLE
feat(shell): add checkpoint management UI panel

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -7,7 +7,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import {
   RepoActivityBar, SessionRail, MainView, RepoSwitcher,
   AddRepoSheet, NewSessionSheet, Palette, RightInspector,
-  TitleBar, StatusBar, RemoteAccessPanel, VoiceSettingsPanel, IntegrationsPanel, ShipItSheet, HistoryPanel, P4Icon,
+  TitleBar, StatusBar, RemoteAccessPanel, VoiceSettingsPanel, IntegrationsPanel, ShipItSheet, HistoryPanel, CheckpointsPanel, P4Icon,
   sessionsForRepo, liveCount, resolveSessionWorktree,
   type ViewMode, type PaletteAction, type NewSessionForm, type NewSessionPrefill,
 } from './components/shell';
@@ -155,6 +155,7 @@ function App() {
   const [showIntegrations, setShowIntegrations] = useState(false);
   const [showVoiceSettings, setShowVoiceSettings] = useState(false);
   const [showHistory, setShowHistory] = useState(false);
+  const [showCheckpoints, setShowCheckpoints] = useState(false);
   const [navOpen, setNavOpen] = useState(false); // mobile drawer (activity bar + rail)
   const touchMode = useTouchMode();
   // Pending close confirmation. null while no prompt is open.
@@ -500,11 +501,12 @@ function App() {
         if (showVoiceSettings) setShowVoiceSettings(false);
         if (showIntegrations) setShowIntegrations(false);
         if (showHistory)    setShowHistory(false);
+        if (showCheckpoints) setShowCheckpoints(false);
       }
     };
     window.addEventListener('keydown', onKey);
     return () => window.removeEventListener('keydown', onKey);
-  }, [showPalette, showCockpit, showNewSession, showAddRepo, showRemote, showVoiceSettings, showIntegrations, showHistory, cycleSession]);
+  }, [showPalette, showCockpit, showNewSession, showAddRepo, showRemote, showVoiceSettings, showIntegrations, showHistory, showCheckpoints, cycleSession]);
 
   useEffect(() => {
     const open = () => setShowVoiceSettings(true);
@@ -558,6 +560,11 @@ function App() {
       id: 'history', icon: 'history', title: 'Session history…',
       sub: 'Browse recorded sessions and their transcripts',
       run: () => { setShowPalette(false); setShowHistory(true); },
+    },
+    {
+      id: 'checkpoints', icon: 'snapshot', title: 'Checkpoints…',
+      sub: 'Named snapshots of a session — save, restore, export',
+      run: () => { setShowPalette(false); setShowCheckpoints(true); },
     },
     {
       id: 'issue-intake', icon: 'branch', title: 'Start from GitHub issue…',
@@ -720,6 +727,7 @@ function App() {
         )}
         {showVoiceSettings && <VoiceSettingsPanel onClose={() => setShowVoiceSettings(false)} />}
         {showHistory && <HistoryPanel onClose={() => setShowHistory(false)} />}
+        {showCheckpoints && <CheckpointsPanel onClose={() => setShowCheckpoints(false)} />}
         {nonGitChoice && (
           <NonGitFolderDialog
             name={nonGitChoice.name}
@@ -966,6 +974,7 @@ function App() {
       )}
       {showVoiceSettings && <VoiceSettingsPanel onClose={() => setShowVoiceSettings(false)} />}
       {showHistory && <HistoryPanel onClose={() => setShowHistory(false)} />}
+      {showCheckpoints && <CheckpointsPanel onClose={() => setShowCheckpoints(false)} />}
 
       {confirmClose && (() => {
         const target = sessions.find(s => s.id === confirmClose.id);

--- a/src/renderer/components/shell/CheckpointsPanel.test.tsx
+++ b/src/renderer/components/shell/CheckpointsPanel.test.tsx
@@ -1,0 +1,299 @@
+import { describe, it, expect, vi } from 'vitest';
+import { act, render, screen, waitFor, fireEvent, within } from '@testing-library/react';
+import { getElectronAPI } from '../../../../test/helpers/electron-api-mock';
+import { CheckpointsPanel } from './CheckpointsPanel';
+import type { Checkpoint } from '../../../shared/types/checkpoint-types';
+import type { HistorySessionEntry } from '../../../shared/types/history-types';
+
+function makeSession(overrides: Partial<HistorySessionEntry> = {}): HistorySessionEntry {
+  return {
+    id: 's1',
+    name: 'fix auth bug',
+    workingDirectory: 'C:\\repos\\omnidesk',
+    createdAt: Date.now() - 120_000,
+    lastUpdatedAt: Date.now() - 60_000,
+    sizeBytes: 2048,
+    segmentCount: 0,
+    ...overrides,
+  };
+}
+
+function makeCheckpoint(overrides: Partial<Checkpoint> = {}): Checkpoint {
+  return {
+    id: 'cp1',
+    sessionId: 's1',
+    name: 'before refactor',
+    description: 'stable point',
+    createdAt: Date.now() - 60_000,
+    historyPosition: 128,
+    historySegment: 0,
+    tags: ['stable'],
+    isTemplate: false,
+    ...overrides,
+  };
+}
+
+function setupApi(
+  checkpoints: Checkpoint[] = [makeCheckpoint()],
+  sessions: HistorySessionEntry[] = [makeSession()],
+) {
+  const api = getElectronAPI();
+  api.listCheckpoints = vi.fn().mockResolvedValue(checkpoints);
+  api.listHistory = vi.fn().mockResolvedValue(sessions);
+  api.createCheckpoint = vi.fn().mockResolvedValue(makeCheckpoint());
+  api.getCheckpoint = vi.fn().mockResolvedValue(makeCheckpoint());
+  api.deleteCheckpoint = vi.fn().mockResolvedValue(true);
+  api.updateCheckpoint = vi.fn().mockResolvedValue(makeCheckpoint());
+  api.exportCheckpoint = vi.fn().mockResolvedValue('checkpoint export content');
+  api.getCheckpointCount = vi.fn().mockResolvedValue(checkpoints.length);
+  api.showSaveDialog = vi.fn().mockResolvedValue('C:\\exports\\out.md');
+  api.writeFile = vi.fn().mockResolvedValue(true);
+
+  let createdPush: ((c: Checkpoint) => void) | null = null;
+  api.onCheckpointCreated = vi.fn().mockImplementation((cb: (c: Checkpoint) => void) => {
+    createdPush = cb;
+    return () => { createdPush = null; };
+  });
+  let deletedPush: ((id: string) => void) | null = null;
+  api.onCheckpointDeleted = vi.fn().mockImplementation((cb: (id: string) => void) => {
+    deletedPush = cb;
+    return () => { deletedPush = null; };
+  });
+
+  return {
+    api,
+    emitCreated: (c: Checkpoint) => act(() => { createdPush?.(c); }),
+    emitDeleted: (id: string) => act(() => { deletedPush?.(id); }),
+  };
+}
+
+describe('CheckpointsPanel', () => {
+  it('lists checkpoints grouped by session', async () => {
+    setupApi([makeCheckpoint({ id: 'cp1', name: 'before refactor' })]);
+    render(<CheckpointsPanel onClose={() => {}} />);
+
+    await waitFor(() => expect(screen.getByTestId('checkpoint-row-cp1')).toBeInTheDocument());
+    expect(screen.getByTestId('checkpoint-group-s1')).toBeInTheDocument();
+    expect(screen.getByText('before refactor')).toBeInTheDocument();
+    expect(screen.getByText('fix auth bug')).toBeInTheDocument();
+  });
+
+  it('shows an empty state when there are no checkpoints', async () => {
+    setupApi([]);
+    render(<CheckpointsPanel onClose={() => {}} />);
+    await waitFor(() => expect(screen.getByText('No checkpoints yet.')).toBeInTheDocument());
+  });
+
+  it('shows an error state when listCheckpoints fails', async () => {
+    const api = getElectronAPI();
+    api.listCheckpoints = vi.fn().mockRejectedValue(new Error('disk read failed'));
+    render(<CheckpointsPanel onClose={() => {}} />);
+    await waitFor(() => expect(screen.getByText('disk read failed')).toBeInTheDocument());
+  });
+
+  it('calls onClose when the close button is clicked', async () => {
+    setupApi();
+    const onClose = vi.fn();
+    render(<CheckpointsPanel onClose={onClose} />);
+    await waitFor(() => screen.getByTestId('checkpoint-row-cp1'));
+    fireEvent.click(screen.getByLabelText('Close'));
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('selecting a checkpoint loads its details into the edit form', async () => {
+    setupApi([makeCheckpoint({ id: 'cp1', name: 'before refactor', description: 'stable point', tags: ['a', 'b'] })]);
+    render(<CheckpointsPanel onClose={() => {}} />);
+
+    await waitFor(() => screen.getByTestId('checkpoint-row-cp1'));
+    fireEvent.click(screen.getByTestId('checkpoint-row-cp1'));
+
+    await waitFor(() => expect(screen.getByTestId('checkpoint-edit-name')).toHaveValue('before refactor'));
+    expect(screen.getByTestId('checkpoint-edit-description')).toHaveValue('stable point');
+    expect(screen.getByTestId('checkpoint-edit-tags')).toHaveValue('a, b');
+    expect(screen.getByTestId('checkpoint-meta')).toHaveTextContent('history position 128');
+  });
+
+  it('shows a placeholder when no checkpoint is selected', async () => {
+    setupApi();
+    render(<CheckpointsPanel onClose={() => {}} />);
+    await waitFor(() => screen.getByTestId('checkpoint-row-cp1'));
+    expect(screen.getByText('Select a checkpoint to view its details.')).toBeInTheDocument();
+  });
+
+  it('creates a new checkpoint from the new-checkpoint form', async () => {
+    const { api, emitCreated } = setupApi([], [makeSession({ id: 's1', name: 'fix auth bug' })]);
+    const created = makeCheckpoint({ id: 'cp-new', name: 'my checkpoint' });
+    api.createCheckpoint = vi.fn().mockResolvedValue(created);
+    render(<CheckpointsPanel onClose={() => {}} />);
+
+    await waitFor(() => expect(screen.getByText('No checkpoints yet.')).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId('checkpoint-new-toggle'));
+    await waitFor(() => screen.getByTestId('checkpoint-new-form'));
+
+    fireEvent.change(screen.getByTestId('checkpoint-new-name'), { target: { value: 'my checkpoint' } });
+    fireEvent.change(screen.getByTestId('checkpoint-new-description'), { target: { value: 'notes here' } });
+    fireEvent.click(screen.getByTestId('checkpoint-new-create'));
+
+    await waitFor(() =>
+      expect(api.createCheckpoint).toHaveBeenCalledWith({
+        sessionId: 's1',
+        name: 'my checkpoint',
+        description: 'notes here',
+      })
+    );
+
+    // Simulate the main process round-trip: useCheckpoints only updates local
+    // state via the onCheckpointCreated event, not the create() return value.
+    emitCreated(created);
+    await waitFor(() => expect(screen.getByTestId('checkpoint-row-cp-new')).toBeInTheDocument());
+    expect(screen.queryByTestId('checkpoint-new-form')).not.toBeInTheDocument();
+  });
+
+  it('disables create until a session and name are chosen', async () => {
+    setupApi([], []);
+    render(<CheckpointsPanel onClose={() => {}} />);
+
+    await waitFor(() => expect(screen.getByText('No checkpoints yet.')).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId('checkpoint-new-toggle'));
+    await waitFor(() => screen.getByTestId('checkpoint-new-form'));
+
+    expect(screen.getByTestId('checkpoint-new-create')).toBeDisabled();
+  });
+
+  it('cancels the new-checkpoint form without creating', async () => {
+    setupApi();
+    render(<CheckpointsPanel onClose={() => {}} />);
+    await waitFor(() => screen.getByTestId('checkpoint-row-cp1'));
+
+    fireEvent.click(screen.getByTestId('checkpoint-new-toggle'));
+    await waitFor(() => screen.getByTestId('checkpoint-new-form'));
+    fireEvent.click(screen.getByTestId('checkpoint-new-cancel'));
+
+    expect(screen.queryByTestId('checkpoint-new-form')).not.toBeInTheDocument();
+  });
+
+  it('saves edits to the selected checkpoint', async () => {
+    const api = setupApi([makeCheckpoint({ id: 'cp1', name: 'before refactor' })]).api;
+    const updated = makeCheckpoint({ id: 'cp1', name: 'renamed', tags: ['x'] });
+    api.updateCheckpoint = vi.fn().mockResolvedValue(updated);
+    render(<CheckpointsPanel onClose={() => {}} />);
+
+    await waitFor(() => screen.getByTestId('checkpoint-row-cp1'));
+    fireEvent.click(screen.getByTestId('checkpoint-row-cp1'));
+    await waitFor(() => expect(screen.getByTestId('checkpoint-edit-name')).toHaveValue('before refactor'));
+
+    fireEvent.change(screen.getByTestId('checkpoint-edit-name'), { target: { value: 'renamed' } });
+    fireEvent.change(screen.getByTestId('checkpoint-edit-tags'), { target: { value: 'x' } });
+    fireEvent.click(screen.getByTestId('checkpoint-edit-template'));
+    fireEvent.click(screen.getByTestId('checkpoint-save'));
+
+    await waitFor(() =>
+      expect(api.updateCheckpoint).toHaveBeenCalledWith('cp1', {
+        name: 'renamed',
+        description: 'stable point',
+        tags: ['x'],
+        isTemplate: true,
+      })
+    );
+    // update() optimistically patches local state, so the row label updates too.
+    await waitFor(() => expect(screen.getByText('renamed')).toBeInTheDocument());
+  });
+
+  it('exports the selected checkpoint as Markdown via the save dialog', async () => {
+    const { api } = setupApi([makeCheckpoint({ id: 'cp1', name: 'before refactor' })]);
+    render(<CheckpointsPanel onClose={() => {}} />);
+
+    await waitFor(() => screen.getByTestId('checkpoint-row-cp1'));
+    fireEvent.click(screen.getByTestId('checkpoint-row-cp1'));
+    await waitFor(() => screen.getByTestId('checkpoint-export-md'));
+    fireEvent.click(screen.getByTestId('checkpoint-export-md'));
+
+    await waitFor(() =>
+      expect(api.showSaveDialog).toHaveBeenCalledWith({
+        defaultPath: 'before refactor.md',
+        filters: [{ name: 'Markdown', extensions: ['md'] }],
+      })
+    );
+    await waitFor(() => expect(api.exportCheckpoint).toHaveBeenCalledWith('cp1', 'markdown'));
+    await waitFor(() =>
+      expect(api.writeFile).toHaveBeenCalledWith('C:\\exports\\out.md', 'checkpoint export content')
+    );
+  });
+
+  it('exports the selected checkpoint as JSON via the save dialog', async () => {
+    const { api } = setupApi([makeCheckpoint({ id: 'cp1', name: 'before refactor' })]);
+    api.showSaveDialog = vi.fn().mockResolvedValue('C:\\exports\\out.json');
+    render(<CheckpointsPanel onClose={() => {}} />);
+
+    await waitFor(() => screen.getByTestId('checkpoint-row-cp1'));
+    fireEvent.click(screen.getByTestId('checkpoint-row-cp1'));
+    await waitFor(() => screen.getByTestId('checkpoint-export-json'));
+    fireEvent.click(screen.getByTestId('checkpoint-export-json'));
+
+    await waitFor(() =>
+      expect(api.showSaveDialog).toHaveBeenCalledWith({
+        defaultPath: 'before refactor.json',
+        filters: [{ name: 'JSON', extensions: ['json'] }],
+      })
+    );
+    await waitFor(() => expect(api.exportCheckpoint).toHaveBeenCalledWith('cp1', 'json'));
+    await waitFor(() =>
+      expect(api.writeFile).toHaveBeenCalledWith('C:\\exports\\out.json', 'checkpoint export content')
+    );
+  });
+
+  it('does not export when the save dialog is cancelled', async () => {
+    const { api } = setupApi([makeCheckpoint({ id: 'cp1' })]);
+    api.showSaveDialog = vi.fn().mockResolvedValue(null);
+    render(<CheckpointsPanel onClose={() => {}} />);
+
+    await waitFor(() => screen.getByTestId('checkpoint-row-cp1'));
+    fireEvent.click(screen.getByTestId('checkpoint-row-cp1'));
+    await waitFor(() => screen.getByTestId('checkpoint-export-md'));
+    fireEvent.click(screen.getByTestId('checkpoint-export-md'));
+    fireEvent.click(screen.getByTestId('checkpoint-export-json'));
+
+    await waitFor(() => expect(api.showSaveDialog).toHaveBeenCalledTimes(2));
+    expect(api.exportCheckpoint).not.toHaveBeenCalled();
+    expect(api.writeFile).not.toHaveBeenCalled();
+  });
+
+  it('deletes the selected checkpoint after confirming, and clears the detail view', async () => {
+    const { api, emitDeleted } = setupApi([makeCheckpoint({ id: 'cp1', name: 'before refactor' })]);
+    render(<CheckpointsPanel onClose={() => {}} />);
+
+    await waitFor(() => screen.getByTestId('checkpoint-row-cp1'));
+    fireEvent.click(screen.getByTestId('checkpoint-row-cp1'));
+    await waitFor(() => screen.getByTestId('checkpoint-delete'));
+
+    fireEvent.click(screen.getByTestId('checkpoint-delete'));
+    const dialog = await screen.findByRole('alertdialog');
+    expect(within(dialog).getByText('Delete checkpoint')).toBeInTheDocument();
+    fireEvent.mouseDown(within(dialog).getByRole('button', { name: /^Delete/ }));
+
+    await waitFor(() => expect(api.deleteCheckpoint).toHaveBeenCalledWith('cp1'));
+
+    // Simulate the main process round-trip: useCheckpoints only removes the
+    // item from local state via the onCheckpointDeleted event.
+    emitDeleted('cp1');
+    await waitFor(() =>
+      expect(screen.getByText('Select a checkpoint to view its details.')).toBeInTheDocument()
+    );
+    expect(screen.queryByTestId('checkpoint-row-cp1')).not.toBeInTheDocument();
+  });
+
+  it('cancels checkpoint deletion without calling deleteCheckpoint', async () => {
+    const { api } = setupApi([makeCheckpoint({ id: 'cp1' })]);
+    render(<CheckpointsPanel onClose={() => {}} />);
+
+    await waitFor(() => screen.getByTestId('checkpoint-row-cp1'));
+    fireEvent.click(screen.getByTestId('checkpoint-row-cp1'));
+    await waitFor(() => screen.getByTestId('checkpoint-delete'));
+    fireEvent.click(screen.getByTestId('checkpoint-delete'));
+
+    const dialog = await screen.findByRole('alertdialog');
+    fireEvent.mouseDown(within(dialog).getByRole('button', { name: /^Cancel/ }));
+
+    expect(api.deleteCheckpoint).not.toHaveBeenCalled();
+  });
+});

--- a/src/renderer/components/shell/CheckpointsPanel.tsx
+++ b/src/renderer/components/shell/CheckpointsPanel.tsx
@@ -1,0 +1,332 @@
+// @atlas-entrypoint: Checkpoint management UI (epic #214 child 5, final child) —
+// list/create/update/delete/export checkpoints across all sessions. Mirrors the
+// HistoryPanel convention (overlay + split-pane list/detail), but checkpoints are
+// live data: useCheckpoints() keeps local state in sync via onCheckpointCreated /
+// onCheckpointDeleted events rather than refresh-after-mutate, so create()/remove()
+// here rely on that round-trip rather than touching local state directly. Only
+// update() (rename/description/tags/isTemplate) optimistically patches local state.
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { P4Icon } from './P4Icon';
+import { formatLastActive } from './shell-utils';
+import { useCheckpoints } from '../../hooks/useCheckpoints';
+import { useHistory } from '../../hooks/useHistory';
+import { ConfirmDialog } from '../ui/ConfirmDialog';
+import type { Checkpoint, CheckpointExportFormat, CheckpointGroup } from '../../../shared/types/checkpoint-types';
+
+interface CheckpointsPanelProps {
+  onClose: () => void;
+}
+
+export function CheckpointsPanel({ onClose }: CheckpointsPanelProps) {
+  const { checkpoints, loading, error, create, remove, update, exportCheckpoint } = useCheckpoints();
+  const { sessions } = useHistory();
+
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [confirmDeleteId, setConfirmDeleteId] = useState<string | null>(null);
+
+  const [showNewForm, setShowNewForm] = useState(false);
+  const [newSessionId, setNewSessionId] = useState('');
+  const [newName, setNewName] = useState('');
+  const [newDescription, setNewDescription] = useState('');
+
+  // Default the new-checkpoint session picker to the first known session once
+  // sessions have loaded, so the form isn't stuck on an empty select.
+  useEffect(() => {
+    if (newSessionId === '' && sessions.length > 0) setNewSessionId(sessions[0].id);
+  }, [sessions, newSessionId]);
+
+  const sessionNameById = useMemo(() => {
+    const map = new Map<string, string>();
+    for (const s of sessions) map.set(s.id, s.name);
+    return map;
+  }, [sessions]);
+
+  const groups = useMemo<CheckpointGroup[]>(() => {
+    const bySession = new Map<string, Checkpoint[]>();
+    for (const c of checkpoints) {
+      const arr = bySession.get(c.sessionId);
+      if (arr) arr.push(c);
+      else bySession.set(c.sessionId, [c]);
+    }
+    const result: CheckpointGroup[] = [];
+    for (const [sessionId, list] of bySession) {
+      result.push({
+        sessionId,
+        sessionName: sessionNameById.get(sessionId) ?? sessionId,
+        checkpoints: [...list].sort((a, b) => b.createdAt - a.createdAt),
+      });
+    }
+    result.sort((a, b) => (b.checkpoints[0]?.createdAt ?? 0) - (a.checkpoints[0]?.createdAt ?? 0));
+    return result;
+  }, [checkpoints, sessionNameById]);
+
+  const selected = useMemo(
+    () => checkpoints.find((c) => c.id === selectedId) ?? null,
+    [checkpoints, selectedId]
+  );
+
+  const [editName, setEditName] = useState('');
+  const [editDescription, setEditDescription] = useState('');
+  const [editTags, setEditTags] = useState('');
+  const [editIsTemplate, setEditIsTemplate] = useState(false);
+
+  // Re-seed the edit form whenever the selection changes (not on every field
+  // edit of the same checkpoint — this is a controlled form, saved explicitly).
+  useEffect(() => {
+    if (selected) {
+      setEditName(selected.name);
+      setEditDescription(selected.description ?? '');
+      setEditTags((selected.tags ?? []).join(', '));
+      setEditIsTemplate(!!selected.isTemplate);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [selected?.id]);
+
+  const handleCreate = useCallback(async () => {
+    if (newSessionId === '' || newName.trim() === '') return;
+    const created = await create({
+      sessionId: newSessionId,
+      name: newName.trim(),
+      description: newDescription.trim() === '' ? undefined : newDescription.trim(),
+    });
+    if (created) setSelectedId(created.id);
+    setNewName('');
+    setNewDescription('');
+    setShowNewForm(false);
+  }, [newSessionId, newName, newDescription, create]);
+
+  const handleSave = useCallback(async () => {
+    if (!selected) return;
+    const tags = editTags.split(',').map((t) => t.trim()).filter((t) => t !== '');
+    await update(selected.id, {
+      name: editName.trim() === '' ? selected.name : editName.trim(),
+      description: editDescription.trim() === '' ? undefined : editDescription.trim(),
+      tags,
+      isTemplate: editIsTemplate,
+    });
+  }, [selected, editName, editDescription, editTags, editIsTemplate, update]);
+
+  const handleExport = useCallback(async (id: string, name: string, format: CheckpointExportFormat) => {
+    const ext = format === 'markdown' ? 'md' : 'json';
+    const path = await window.electronAPI.showSaveDialog({
+      defaultPath: `${name}.${ext}`,
+      filters: [{ name: format === 'markdown' ? 'Markdown' : 'JSON', extensions: [ext] }],
+    });
+    if (path === null) return; // user cancelled
+    const content = await exportCheckpoint(id, format);
+    if (content === null) return;
+    await window.electronAPI.writeFile(path, content);
+  }, [exportCheckpoint]);
+
+  const handleConfirmDelete = useCallback(async () => {
+    if (confirmDeleteId === null) return;
+    const id = confirmDeleteId;
+    setConfirmDeleteId(null);
+    const ok = await remove(id);
+    if (ok && selectedId === id) setSelectedId(null);
+  }, [confirmDeleteId, remove, selectedId]);
+
+  return (
+    <div className="p4-overlay" onClick={(e) => { if (e.target === e.currentTarget) onClose(); }}>
+      <div className="p4-sheet" role="dialog" aria-modal="true" aria-label="Checkpoints">
+        <div className="p4-sheet-head">
+          <div className="icon"><P4Icon name="snapshot" size={16} /></div>
+          <div>
+            <div className="t">Checkpoints</div>
+            <div className="d">Save and restore named points in a session&apos;s history.</div>
+          </div>
+          <button className="x" onClick={onClose} aria-label="Close">
+            <P4Icon name="x" size={14} />
+          </button>
+        </div>
+
+        <div className="p4-sheet-body" style={{ display: 'flex', gap: 12, minHeight: 320 }}>
+          <div style={{ flex: '0 0 45%', overflowY: 'auto', borderRight: '1px solid var(--border, #2a2a2a)', paddingRight: 8 }}>
+            <div className="p4-form-row" style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+              <span className="d">
+                {checkpoints.length} checkpoint{checkpoints.length === 1 ? '' : 's'}
+              </span>
+              <button data-testid="checkpoint-new-toggle" onClick={() => setShowNewForm((v) => !v)}>
+                New checkpoint
+              </button>
+            </div>
+
+            {showNewForm && (
+              <div
+                className="p4-form-row"
+                data-testid="checkpoint-new-form"
+                style={{ display: 'flex', flexDirection: 'column', gap: 6 }}
+              >
+                <label style={{ display: 'flex', flexDirection: 'column', gap: 4, fontSize: 12 }}>
+                  Session
+                  <select
+                    data-testid="checkpoint-new-session"
+                    value={newSessionId}
+                    onChange={(e) => setNewSessionId(e.target.value)}
+                  >
+                    {sessions.length === 0 && <option value="">No sessions available</option>}
+                    {sessions.map((s) => (
+                      <option key={s.id} value={s.id}>{s.name}</option>
+                    ))}
+                  </select>
+                </label>
+                <input
+                  type="text"
+                  placeholder="Checkpoint name"
+                  data-testid="checkpoint-new-name"
+                  value={newName}
+                  onChange={(e) => setNewName(e.target.value)}
+                />
+                <textarea
+                  placeholder="Description (optional)"
+                  data-testid="checkpoint-new-description"
+                  value={newDescription}
+                  onChange={(e) => setNewDescription(e.target.value)}
+                  rows={2}
+                />
+                <div style={{ display: 'flex', gap: 6 }}>
+                  <button
+                    data-testid="checkpoint-new-create"
+                    disabled={newSessionId === '' || newName.trim() === ''}
+                    onClick={() => void handleCreate()}
+                  >
+                    Create
+                  </button>
+                  <button data-testid="checkpoint-new-cancel" onClick={() => setShowNewForm(false)}>
+                    Cancel
+                  </button>
+                </div>
+              </div>
+            )}
+
+            {loading ? (
+              <div className="p4-form-row"><span className="d">Loading…</span></div>
+            ) : error ? (
+              <div className="p4-form-row">
+                <span className="d" style={{ color: 'var(--danger, #F7678E)' }}>{error}</span>
+              </div>
+            ) : groups.length === 0 ? (
+              <div className="p4-form-row"><span className="d">No checkpoints yet.</span></div>
+            ) : (
+              groups.map((g) => (
+                <div key={g.sessionId} data-testid={`checkpoint-group-${g.sessionId}`}>
+                  <div
+                    className="d"
+                    style={{ fontWeight: 600, fontSize: 11, textTransform: 'uppercase', opacity: 0.7, marginTop: 8 }}
+                  >
+                    {g.sessionName}
+                  </div>
+                  {g.checkpoints.map((c) => (
+                    <div
+                      key={c.id}
+                      className="p4-form-row"
+                      data-testid={`checkpoint-row-${c.id}`}
+                      role="button"
+                      tabIndex={0}
+                      onClick={() => setSelectedId(c.id)}
+                      onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') setSelectedId(c.id); }}
+                      style={{
+                        cursor: 'pointer',
+                        background: selectedId === c.id ? 'var(--surface-hover, rgba(255,255,255,0.06))' : undefined,
+                      }}
+                    >
+                      <div className="t" style={{ fontWeight: 600 }}>
+                        {c.name}{c.isTemplate ? ' ★' : ''}
+                      </div>
+                      <div className="d">{formatLastActive(c.createdAt)}</div>
+                    </div>
+                  ))}
+                </div>
+              ))
+            )}
+          </div>
+
+          <div style={{ flex: '1 1 55%', overflowY: 'auto', minWidth: 0, display: 'flex', flexDirection: 'column', gap: 8 }}>
+            {selected === null ? (
+              <div className="p4-form-row"><span className="d">Select a checkpoint to view its details.</span></div>
+            ) : (
+              <>
+                <div className="p4-form-row" style={{ display: 'flex', gap: 6 }}>
+                  <button
+                    data-testid="checkpoint-export-md"
+                    onClick={() => void handleExport(selected.id, selected.name, 'markdown')}
+                  >
+                    Export Markdown
+                  </button>
+                  <button
+                    data-testid="checkpoint-export-json"
+                    onClick={() => void handleExport(selected.id, selected.name, 'json')}
+                  >
+                    Export JSON
+                  </button>
+                  <button data-testid="checkpoint-delete" onClick={() => setConfirmDeleteId(selected.id)}>
+                    Delete
+                  </button>
+                </div>
+
+                <label className="p4-form-row" style={{ display: 'flex', flexDirection: 'column', gap: 4, fontSize: 12 }}>
+                  Name
+                  <input
+                    type="text"
+                    data-testid="checkpoint-edit-name"
+                    value={editName}
+                    onChange={(e) => setEditName(e.target.value)}
+                  />
+                </label>
+                <label className="p4-form-row" style={{ display: 'flex', flexDirection: 'column', gap: 4, fontSize: 12 }}>
+                  Description
+                  <textarea
+                    data-testid="checkpoint-edit-description"
+                    value={editDescription}
+                    onChange={(e) => setEditDescription(e.target.value)}
+                    rows={3}
+                  />
+                </label>
+                <label className="p4-form-row" style={{ display: 'flex', flexDirection: 'column', gap: 4, fontSize: 12 }}>
+                  Tags (comma separated)
+                  <input
+                    type="text"
+                    data-testid="checkpoint-edit-tags"
+                    value={editTags}
+                    onChange={(e) => setEditTags(e.target.value)}
+                  />
+                </label>
+                <label
+                  className="p4-form-row"
+                  style={{ display: 'flex', gap: 6, alignItems: 'center', fontSize: 12, cursor: 'pointer' }}
+                >
+                  <input
+                    type="checkbox"
+                    data-testid="checkpoint-edit-template"
+                    checked={editIsTemplate}
+                    onChange={(e) => setEditIsTemplate(e.target.checked)}
+                  />
+                  Template
+                </label>
+                <div className="p4-form-row">
+                  <button data-testid="checkpoint-save" onClick={() => void handleSave()}>Save</button>
+                </div>
+
+                <div className="p4-form-row" data-testid="checkpoint-meta">
+                  <span className="d">
+                    {formatLastActive(selected.createdAt)} · history position {selected.historyPosition} · segment {selected.historySegment}
+                  </span>
+                </div>
+              </>
+            )}
+          </div>
+        </div>
+      </div>
+
+      <ConfirmDialog
+        isOpen={confirmDeleteId !== null}
+        title="Delete checkpoint"
+        body="This will permanently delete this checkpoint. This cannot be undone."
+        severity="destructive"
+        confirmLabel="Delete"
+        onConfirm={() => void handleConfirmDelete()}
+        onCancel={() => setConfirmDeleteId(null)}
+      />
+    </div>
+  );
+}

--- a/src/renderer/components/shell/index.ts
+++ b/src/renderer/components/shell/index.ts
@@ -26,3 +26,4 @@ export { IntegrationsPanel } from './IntegrationsPanel';
 export { ShipItSheet } from './ShipItSheet';
 export { VoiceSettingsPanel } from './VoiceSettingsPanel';
 export { HistoryPanel } from './HistoryPanel';
+export { CheckpointsPanel } from './CheckpointsPanel';

--- a/src/renderer/hooks/useHistory.ts
+++ b/src/renderer/hooks/useHistory.ts
@@ -34,7 +34,7 @@ export function useHistory(): UseHistoryApi {
   const refresh = useCallback(async () => {
     try {
       const list = await window.electronAPI.listHistory();
-      setSessions(list);
+      setSessions(Array.isArray(list) ? list : []);
       setError(null);
     } catch (e) {
       setError(e instanceof Error ? e.message : String(e));


### PR DESCRIPTION
## Summary

Adds the **Checkpoint management UI** — the fifth and final child of the checkpoints epic (#214). Children 1-4 (data model, IPC, create/restore flow, HistoryPanel integration) already shipped as #217, #219, #221, #223.

- New `CheckpointsPanel`: lists named checkpoints grouped by session (session name resolved via `useHistory()`), with create, select-to-edit (name/description/tags), delete, and export (markdown/JSON) actions, plus loading/empty/error states.
- Wired into the shell like every other overlay panel: barrel export (`shell/index.ts`), `App.tsx` state (`showCheckpoints`), Escape-key dismiss handler + effect deps, a command-palette action (`Checkpoints…`, `snapshot` icon), and both JSX mount points (App.tsx has two panel-mount sites).
- Hardened `useHistory()`: `refresh()` now guards `setSessions(Array.isArray(list) ? list : [])` instead of assigning `listHistory()`'s result unchecked. Without this, `CheckpointsPanel`'s session-name lookup (`for (const s of sessions)`) throws `TypeError: sessions is not iterable` whenever `sessions` hasn't loaded yet (surfaced as an unhandled render crash in the "listCheckpoints fails" test, where the IPC mock resolves `listHistory` to the default `undefined`).

No new dependencies.

## Test plan
- [x] `tsc --noEmit` clean on all 3 tsconfig targets (renderer/main/node)
- [x] `CheckpointsPanel.test.tsx`: 15/15 passing
- [x] `useHistory.test.ts` + `HistoryPanel.test.tsx`: 28/28 passing (confirms the `useHistory` guard doesn't regress existing consumers)
- [x] Full vitest workspace (`shared` + `main` + `renderer`): 115 files / 1389 tests passing, no regressions

Closes #214