### PR TITLE
feat(history): add SessionDigestService + typed IPC for session digests

### DIFF
--- a/src/main/ipc-handlers.ts
+++ b/src/main/ipc-handlers.ts
@@ -13,6 +13,7 @@ import { SessionPool } from './session-pool';
 import { SettingsManager } from './settings-persistence';
 import { HistoryManager } from './history-manager';
 import { CheckpointManager } from './checkpoint-manager';
+import { computeSessionDigest } from './session-digest-service';
 import { GitManager } from './git-manager';
 import { ProviderRegistry } from './providers/provider-registry';
 import { queryClaudeQuota, clearQuotaCache, getBurnRate, resolveClaudeConfigDir } from './quota-service';
@@ -599,6 +600,11 @@ export function setupIPCHandlers(
   registry.handle('getHistoryStats', async () => {
     try { return await historyManager.getStats(); }
     catch (err) { console.error('Failed to get history stats:', err); throw err; }
+  });
+
+  registry.handle('getSessionDigest', async (_e, sessionId, since) => {
+    try { return await computeSessionDigest(historyManager, checkpointManager, sessionId, since); }
+    catch (err) { console.error('Failed to get session digest:', err); throw err; }
   });
 
   // ── Checkpoints ──

--- a/src/main/session-digest-service.test.ts
+++ b/src/main/session-digest-service.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect, vi } from 'vitest';
+import type { HistorySessionEntry } from '../shared/types/history-types';
+import type { Checkpoint } from '../shared/types/checkpoint-types';
+import type { HistoryManager } from './history-manager';
+import type { CheckpointManager } from './checkpoint-manager';
+import { computeSessionDigest } from './session-digest-service';
+
+function makeSessionEntry(overrides: Partial<HistorySessionEntry> = {}): HistorySessionEntry {
+  return {
+    id: 'session-1',
+    name: 'Session One',
+    workingDirectory: '/tmp/project',
+    createdAt: 1000,
+    lastUpdatedAt: 5000,
+    sizeBytes: 4242,
+    segmentCount: 0,
+    ...overrides,
+  };
+}
+
+function makeCheckpoint(overrides: Partial<Checkpoint> = {}): Checkpoint {
+  return {
+    id: 'cp-1',
+    sessionId: 'session-1',
+    name: 'checkpoint',
+    createdAt: 2000,
+    historyPosition: 0,
+    historySegment: 0,
+    tags: [],
+    ...overrides,
+  };
+}
+
+function makeHistoryManager(entry: HistorySessionEntry | null): HistoryManager {
+  return {
+    getSessionMetadata: vi.fn().mockResolvedValue(entry),
+  } as unknown as HistoryManager;
+}
+
+function makeCheckpointManager(checkpoints: Checkpoint[]): CheckpointManager {
+  return {
+    listCheckpoints: vi.fn().mockResolvedValue(checkpoints),
+  } as unknown as CheckpointManager;
+}
+
+describe('computeSessionDigest', () => {
+  it('computes a digest for a normal session with no restarts', async () => {
+    const entry = makeSessionEntry({ segmentCount: 0, sizeBytes: 1234 });
+    const historyManager = makeHistoryManager(entry);
+    const checkpointManager = makeCheckpointManager([]);
+
+    const digest = await computeSessionDigest(historyManager, checkpointManager, 'session-1');
+
+    expect(digest).toEqual({
+      sessionId: 'session-1',
+      windowStart: 1000,
+      windowEnd: 5000,
+      activeDurationMs: 4000,
+      restartSegments: 0,
+      outputBytes: 1234,
+      checkpointsCreated: 0,
+      approvalPromptsHit: null,
+      errorsDetected: null,
+    });
+  });
+
+  it('reports segmentCount as restartSegments for a session with restarts', async () => {
+    const entry = makeSessionEntry({ segmentCount: 3 });
+    const historyManager = makeHistoryManager(entry);
+    const checkpointManager = makeCheckpointManager([]);
+
+    const digest = await computeSessionDigest(historyManager, checkpointManager, 'session-1');
+
+    expect(digest.restartSegments).toBe(3);
+  });
+
+  it('counts only checkpoints created within the since-clamped window', async () => {
+    const entry = makeSessionEntry({ createdAt: 1000, lastUpdatedAt: 10000 });
+    const historyManager = makeHistoryManager(entry);
+    const checkpoints = [
+      makeCheckpoint({ id: 'cp-before', createdAt: 500 }), // before session even existed
+      makeCheckpoint({ id: 'cp-in-window', createdAt: 6000 }),
+      makeCheckpoint({ id: 'cp-outside-since', createdAt: 3000 }), // before `since`
+      makeCheckpoint({ id: 'cp-at-end', createdAt: 10000 }),
+    ];
+    const checkpointManager = makeCheckpointManager(checkpoints);
+
+    const digest = await computeSessionDigest(historyManager, checkpointManager, 'session-1', 5000);
+
+    expect(digest.windowStart).toBe(5000);
+    expect(digest.windowEnd).toBe(10000);
+    expect(digest.checkpointsCreated).toBe(2); // cp-in-window, cp-at-end
+  });
+
+  it('returns checkpointsCreated 0 when the session has no checkpoints', async () => {
+    const entry = makeSessionEntry();
+    const historyManager = makeHistoryManager(entry);
+    const checkpointManager = makeCheckpointManager([]);
+
+    const digest = await computeSessionDigest(historyManager, checkpointManager, 'session-1');
+
+    expect(digest.checkpointsCreated).toBe(0);
+  });
+
+  it('always reports approvalPromptsHit and errorsDetected as null (v1 graceful degrade)', async () => {
+    const entry = makeSessionEntry();
+    const historyManager = makeHistoryManager(entry);
+    const checkpointManager = makeCheckpointManager([makeCheckpoint()]);
+
+    const digest = await computeSessionDigest(historyManager, checkpointManager, 'session-1');
+
+    expect(digest.approvalPromptsHit).toBeNull();
+    expect(digest.errorsDetected).toBeNull();
+  });
+
+  it('clamps windowStart to createdAt when since predates the session', async () => {
+    const entry = makeSessionEntry({ createdAt: 1000, lastUpdatedAt: 5000 });
+    const historyManager = makeHistoryManager(entry);
+    const checkpointManager = makeCheckpointManager([]);
+
+    const digest = await computeSessionDigest(historyManager, checkpointManager, 'session-1', 0);
+
+    expect(digest.windowStart).toBe(1000);
+  });
+
+  it('yields a zero-length window (not negative) when since is after lastUpdatedAt', async () => {
+    const entry = makeSessionEntry({ createdAt: 1000, lastUpdatedAt: 5000 });
+    const historyManager = makeHistoryManager(entry);
+    const checkpointManager = makeCheckpointManager([]);
+
+    const digest = await computeSessionDigest(historyManager, checkpointManager, 'session-1', 9000);
+
+    expect(digest.windowStart).toBe(9000);
+    expect(digest.windowEnd).toBe(9000);
+    expect(digest.activeDurationMs).toBe(0);
+  });
+
+  it('throws when the session is not found in history', async () => {
+    const historyManager = makeHistoryManager(null);
+    const checkpointManager = makeCheckpointManager([]);
+
+    await expect(
+      computeSessionDigest(historyManager, checkpointManager, 'missing-session')
+    ).rejects.toThrow(/missing-session/);
+  });
+});

--- a/src/main/session-digest-service.ts
+++ b/src/main/session-digest-service.ts
@@ -1,0 +1,77 @@
+/**
+ * Session Digest Service
+ *
+ * Computes a "while you were away" activity digest for a recorded session,
+ * per issue #226 (epic #225 child-1). v1 is derived entirely from persisted
+ * metadata (HistorySessionEntry) and the checkpoint store — it does NOT
+ * depend on the live session-state classifier (epic #195), which has no
+ * historical/persisted timeline to replay against a closed session.
+ */
+
+import type { HistoryManager } from './history-manager';
+import type { CheckpointManager } from './checkpoint-manager';
+import type { SessionDigest } from '../shared/types/history-types';
+
+/**
+ * Compute a SessionDigest for `sessionId`.
+ *
+ * @param since Optional lower bound (ms, epoch) for the digest window. When
+ *   provided, the window start is clamped to the session's `createdAt` (a
+ *   `since` before the session existed has no effect), and the window is
+ *   never allowed to go negative (a `since` after `lastUpdatedAt` yields a
+ *   zero-length window rather than a negative duration).
+ *
+ * `restartSegments` and `outputBytes` are reported as session-wide totals
+ * regardless of `since`: HistorySessionEntry persists only aggregate
+ * `segmentCount`/`sizeBytes`, not per-segment or per-byte timestamps, so a
+ * `since` window cannot be resolved more finely than "the whole session".
+ * This is a documented v1 approximation (see issue #226 Notes).
+ *
+ * `approvalPromptsHit` and `errorsDetected` are always `null` in v1: marker
+ * replay would require knowing which provider's getStateSignals() regex
+ * table produced this session's output, but `providerId` is tracked only on
+ * live sessions (SessionManager / shared/ipc-types.ts) and is never
+ * persisted into HistorySessionEntry or the history index. There is
+ * currently no way to recover it for a closed/historical session, so per
+ * issue #226's explicit fallback this ships as `null` (best-effort / not
+ * derivable) rather than guessing or throwing. Follow-up: persist
+ * `providerId` on HistorySessionEntry to unblock real marker replay.
+ */
+export async function computeSessionDigest(
+  historyManager: HistoryManager,
+  checkpointManager: CheckpointManager,
+  sessionId: string,
+  since?: number
+): Promise<SessionDigest> {
+  const entry = await historyManager.getSessionMetadata(sessionId);
+  if (!entry) {
+    throw new Error(`Session ${sessionId} not found in history`);
+  }
+
+  const windowStart = since !== undefined ? Math.max(since, entry.createdAt) : entry.createdAt;
+  const windowEnd = Math.max(windowStart, entry.lastUpdatedAt);
+  const activeDurationMs = windowEnd - windowStart;
+
+  const restartSegments = entry.segmentCount;
+  const outputBytes = entry.sizeBytes;
+
+  const checkpoints = await checkpointManager.listCheckpoints(sessionId);
+  const checkpointsCreated = checkpoints.filter(
+    (cp) => cp.createdAt >= windowStart && cp.createdAt <= windowEnd
+  ).length;
+
+  const approvalPromptsHit: number | null = null;
+  const errorsDetected: number | null = null;
+
+  return {
+    sessionId,
+    windowStart,
+    windowEnd,
+    activeDurationMs,
+    restartSegments,
+    outputBytes,
+    checkpointsCreated,
+    approvalPromptsHit,
+    errorsDetected,
+  };
+}

--- a/src/shared/ipc-contract.ts
+++ b/src/shared/ipc-contract.ts
@@ -1,4 +1,4 @@
-// @atlas-entrypoint: IPC single source of truth — 115 methods, auto-derives preload bridge and types
+// @atlas-entrypoint: IPC single source of truth — 116 methods, auto-derives preload bridge and types
 /**
  * IPC Contract — Single source of truth for all IPC methods.
  *
@@ -44,6 +44,7 @@ import type {
   HistorySearchResult,
   HistorySettings,
   HistoryStats,
+  SessionDigest,
 } from './types/history-types';
 
 import type {
@@ -201,6 +202,7 @@ export interface IPCContractMap {
   getHistorySettings:  InvokeContract<'history:getSettings',     [],                             HistorySettings>;
   updateHistorySettings: InvokeContract<'history:updateSettings', [Partial<HistorySettings>],    boolean>;
   getHistoryStats:     InvokeContract<'history:getStats',        [],                             HistoryStats>;
+  getSessionDigest:    InvokeContract<'history:getSessionDigest', [string, number?],              SessionDigest>;
 
   // ── Checkpoints (invoke) ──
   createCheckpoint:    InvokeContract<'checkpoint:create',    [CheckpointCreateRequest],         Checkpoint>;
@@ -388,6 +390,7 @@ export const channels: { [K in keyof IPCContractMap]: ChannelOf<K> } = {
   getHistorySettings:  'history:getSettings',
   updateHistorySettings: 'history:updateSettings',
   getHistoryStats:     'history:getStats',
+  getSessionDigest:    'history:getSessionDigest',
 
   // Checkpoints
   createCheckpoint:    'checkpoint:create',
@@ -556,6 +559,7 @@ export const contractKinds: { [K in keyof IPCContractMap]: KindOf<K> } = {
   getHistorySettings:  'invoke',
   updateHistorySettings: 'invoke',
   getHistoryStats:     'invoke',
+  getSessionDigest:    'invoke',
 
   createCheckpoint:    'invoke',
   listCheckpoints:     'invoke',

--- a/src/shared/types/history-types.ts
+++ b/src/shared/types/history-types.ts
@@ -85,6 +85,40 @@ export interface HistoryStats {
 }
 
 /**
+ * Per-session activity digest ("while you were away" recap).
+ *
+ * v1 is computed entirely from persisted metadata (HistorySessionEntry) plus
+ * the checkpoint store — it does NOT depend on the live session-state
+ * classifier (epic #195), which has no historical/persisted timeline to
+ * replay. See SessionDigestService for the computation rules.
+ */
+export interface SessionDigest {
+  /** Session this digest describes */
+  sessionId: string;
+  /** Start of the window this digest covers (ms, epoch) */
+  windowStart: number;
+  /** End of the window this digest covers (ms, epoch) */
+  windowEnd: number;
+  /** windowEnd - windowStart */
+  activeDurationMs: number;
+  /** Restart segments observed (from HistorySessionEntry.segmentCount) */
+  restartSegments: number;
+  /** Bytes of recorded output in the window (from sizeBytes) */
+  outputBytes: number;
+  /** Checkpoints created within the window */
+  checkpointsCreated: number;
+  /**
+   * Best-effort count of approval-prompt markers hit in the window, derived
+   * by replaying the session's provider's getStateSignals() patterns over
+   * stored raw output. `null` when not derivable (e.g. no persisted provider
+   * association for the session) rather than an error.
+   */
+  approvalPromptsHit: number | null;
+  /** Best-effort count of error markers hit in the window; null when not derivable. */
+  errorsDetected: number | null;
+}
+
+/**
  * JSON export format
  */
 export interface HistoryExportJson {


### PR DESCRIPTION
## Summary

Adds the backend for the "while you were away" per-session activity recap (epic #225, child-1):

- `SessionDigest` type in `src/shared/types/history-types.ts`
- `computeSessionDigest(historyManager, checkpointManager, sessionId, since?)` in the new `src/main/session-digest-service.ts`
- `getSessionDigest` IPC method, wired through the auto-derived `src/shared/ipc-contract.ts` (preload bridge + renderer `DerivedElectronAPI` type both derive from this contract — no manual preload edit needed) and registered in `src/main/ipc-handlers.ts`

This is backend-only, per the issue: no UI change. Compass's child-2 (`useSessionDigest` hook + recap card in `HistoryPanel`) builds on top of this once merged.

### v1 computation rules (see JSDoc in `session-digest-service.ts` for full rationale)

- `windowStart`/`windowEnd`/`activeDurationMs`: derived from an optional `since`, clamped to the session's `createdAt..lastUpdatedAt` range. A `since` before the session existed has no effect; a `since` after `lastUpdatedAt` yields a zero-length window rather than a negative duration.
- `restartSegments`/`outputBytes`: reported as session-wide totals (`segmentCount`/`sizeBytes`) regardless of `since` — `HistorySessionEntry` only persists aggregates, not per-segment/per-byte timestamps, so these can't be resolved more finely against a `since` window. Documented as a v1 approximation.
- `checkpointsCreated`: count of checkpoints (from `CheckpointManager.listCheckpoints`) with `createdAt` inside the clamped window.
- `approvalPromptsHit`/`errorsDetected`: always `null` in v1. Real marker replay would need to know which provider's `getStateSignals()` regex table produced a session's output, but `providerId` is only tracked on live sessions (`SessionManager`/`shared/ipc-types.ts`) and is never persisted into `HistorySessionEntry` or the history index — there's currently no way to recover it for a closed session. Ships as `null` (best-effort/not derivable) per the issue's explicit fallback, rather than guessing or throwing. Follow-up: persist `providerId` on `HistorySessionEntry` to unblock real replay later.

No new runtime dependency; no LLM call.

## Test plan

- [x] `npx tsc --noEmit -p tsconfig.json` — clean, zero errors
- [x] `npx tsc --noEmit -p tsconfig.main.json` — clean, zero errors
- [x] New `src/main/session-digest-service.test.ts`: 8/8 tests passing (normal session, restart segments via `segmentCount`, since-window checkpoint filtering, no-checkpoints case, `null` graceful-degrade for approval/error counts, since-before-createdAt clamping, since-after-lastUpdatedAt zero-length window, session-not-found throw)
- [x] Full baseline suite `npm test` (vitest workspace, no `--project` filter): 116 test files / 1397 tests passing — no regressions