### PR TITLE
feat(history): surface per-session recap in HistoryPanel

### DIFF
--- a/src/renderer/components/shell/HistoryPanel.test.tsx
+++ b/src/renderer/components/shell/HistoryPanel.test.tsx
@@ -7,6 +7,7 @@ import type {
   HistorySearchResult,
   HistorySettings,
   HistoryStats,
+  SessionDigest,
 } from '../../../shared/types/history-types';
 
 function makeSettings(overrides: Partial<HistorySettings> = {}): HistorySettings {
@@ -41,6 +42,21 @@ function makeSession(overrides: Partial<HistorySessionEntry> = {}): HistorySessi
   };
 }
 
+function makeDigest(overrides: Partial<SessionDigest> = {}): SessionDigest {
+  return {
+    sessionId: 's1',
+    windowStart: Date.now() - 120_000,
+    windowEnd: Date.now(),
+    activeDurationMs: 90_000,
+    restartSegments: 1,
+    outputBytes: 2048,
+    checkpointsCreated: 3,
+    approvalPromptsHit: 2,
+    errorsDetected: 0,
+    ...overrides,
+  };
+}
+
 function makeSearchResult(overrides: Partial<HistorySearchResult> = {}): HistorySearchResult {
   return {
     session: makeSession(),
@@ -65,6 +81,7 @@ function setupApi(sessions: HistorySessionEntry[] = [makeSession()]) {
   api.deleteHistory = vi.fn().mockResolvedValue(true);
   api.deleteAllHistory = vi.fn().mockResolvedValue(true);
   api.updateHistorySettings = vi.fn().mockResolvedValue(true);
+  api.getSessionDigest = vi.fn().mockResolvedValue(makeDigest());
   return api;
 }
 
@@ -351,5 +368,71 @@ describe('HistoryPanel', () => {
 
     fireEvent.click(screen.getByTestId('history-setting-auto-cleanup'));
     await waitFor(() => expect(api.updateHistorySettings).toHaveBeenCalledWith({ autoCleanup: true }));
+  });
+
+  it('selecting a session fetches and renders its "while you were away" recap', async () => {
+    const api = setupApi([makeSession({ id: 's1' })]);
+    api.getSessionDigest = vi.fn().mockResolvedValue(
+      makeDigest({ activeDurationMs: 90_000, restartSegments: 1, checkpointsCreated: 3, approvalPromptsHit: 2, errorsDetected: 0 })
+    );
+    render(<HistoryPanel onClose={() => {}} />);
+
+    await waitFor(() => screen.getByTestId('history-row-s1'));
+    fireEvent.click(screen.getByTestId('history-row-s1'));
+
+    await waitFor(() => expect(api.getSessionDigest).toHaveBeenCalledWith('s1', undefined));
+    const summary = await screen.findByTestId('history-digest-summary');
+    expect(within(summary).getByText('Active: 1m')).toBeInTheDocument();
+    expect(within(summary).getByText('Restarts: 1')).toBeInTheDocument();
+    expect(within(summary).getByText('Checkpoints: 3')).toBeInTheDocument();
+    expect(screen.getByTestId('history-digest-approvals')).toHaveTextContent('Approval prompts: 2');
+    expect(screen.getByTestId('history-digest-errors')).toHaveTextContent('Errors: 0');
+  });
+
+  it('renders "not tracked" instead of 0 for null approvalPromptsHit/errorsDetected', async () => {
+    const api = setupApi([makeSession({ id: 's1' })]);
+    api.getSessionDigest = vi.fn().mockResolvedValue(
+      makeDigest({ approvalPromptsHit: null, errorsDetected: null })
+    );
+    render(<HistoryPanel onClose={() => {}} />);
+
+    await waitFor(() => screen.getByTestId('history-row-s1'));
+    fireEvent.click(screen.getByTestId('history-row-s1'));
+
+    await waitFor(() => screen.getByTestId('history-digest-summary'));
+    expect(screen.getByTestId('history-digest-approvals')).toHaveTextContent('— (not tracked)');
+    expect(screen.getByTestId('history-digest-errors')).toHaveTextContent('— (not tracked)');
+    expect(screen.getByTestId('history-digest-approvals')).not.toHaveTextContent('0');
+    expect(screen.getByTestId('history-digest-errors')).not.toHaveTextContent('0');
+  });
+
+  it('shows a non-fatal inline error when the digest fetch fails, without hiding the transcript', async () => {
+    const api = setupApi([makeSession({ id: 's1' })]);
+    api.getSessionDigest = vi.fn().mockRejectedValue(new Error('digest computation failed'));
+    render(<HistoryPanel onClose={() => {}} />);
+
+    await waitFor(() => screen.getByTestId('history-row-s1'));
+    fireEvent.click(screen.getByTestId('history-row-s1'));
+
+    await waitFor(() => expect(screen.getByText(/Recap unavailable: digest computation failed/)).toBeInTheDocument());
+    await waitFor(() =>
+      expect(screen.getByTestId('history-content')).toHaveTextContent('transcript line 1')
+    );
+  });
+
+  it('clears the recap card when the selection is cleared', async () => {
+    const api = setupApi([makeSession({ id: 's1' })]);
+    render(<HistoryPanel onClose={() => {}} />);
+
+    await waitFor(() => screen.getByTestId('history-row-s1'));
+    fireEvent.click(screen.getByTestId('history-row-s1'));
+    await waitFor(() => screen.getByTestId('history-digest-summary'));
+
+    fireEvent.click(screen.getByTestId('history-delete'));
+    const dialog = await screen.findByRole('alertdialog');
+    fireEvent.mouseDown(within(dialog).getByRole('button', { name: /^Delete/ }));
+
+    await waitFor(() => expect(api.deleteHistory).toHaveBeenCalledWith('s1'));
+    expect(screen.queryByTestId('history-digest')).not.toBeInTheDocument();
   });
 });

--- a/src/renderer/components/shell/HistoryPanel.tsx
+++ b/src/renderer/components/shell/HistoryPanel.tsx
@@ -8,6 +8,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { P4Icon } from './P4Icon';
 import { formatLastActive } from './shell-utils';
 import { useHistory } from '../../hooks/useHistory';
+import { useSessionDigest } from '../../hooks/useSessionDigest';
 import { ConfirmDialog } from '../ui/ConfirmDialog';
 import type { HistorySearchResult, HistorySettings, HistoryStats } from '../../../shared/types/history-types';
 
@@ -27,12 +28,30 @@ function formatSize(bytes: number): string {
   return `${mb.toFixed(1)} MB`;
 }
 
+/** Humanize a duration in ms as e.g. "42s" / "5m" / "2h 15m". */
+function formatDuration(ms: number): string {
+  const totalSeconds = Math.floor(ms / 1000);
+  if (totalSeconds < 60) return `${totalSeconds}s`;
+  const totalMinutes = Math.floor(totalSeconds / 60);
+  if (totalMinutes < 60) return `${totalMinutes}m`;
+  const hours = Math.floor(totalMinutes / 60);
+  const minutes = totalMinutes % 60;
+  return minutes > 0 ? `${hours}h ${minutes}m` : `${hours}h`;
+}
+
 export function HistoryPanel({ onClose }: HistoryPanelProps) {
   const {
     sessions, loading, error, getContent, search,
     remove, removeAll, exportMarkdown, exportJson,
     getSettings, updateSettings, getStats,
   } = useHistory();
+  const {
+    digest,
+    loading: digestLoading,
+    error: digestError,
+    fetch: fetchDigest,
+    clear: clearDigest,
+  } = useSessionDigest();
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [content, setContent] = useState<string | null>(null);
   const [contentLoading, setContentLoading] = useState(false);
@@ -106,6 +125,7 @@ export function HistoryPanel({ onClose }: HistoryPanelProps) {
     setContentLoading(true);
     setContentMissing(false);
     setContent(null);
+    void fetchDigest(id);
     try {
       const result = await getContent(id);
       if (result === null) {
@@ -116,13 +136,14 @@ export function HistoryPanel({ onClose }: HistoryPanelProps) {
     } finally {
       setContentLoading(false);
     }
-  }, [getContent]);
+  }, [getContent, fetchDigest]);
 
   const clearSelection = useCallback(() => {
     setSelectedId(null);
     setContent(null);
     setContentMissing(false);
-  }, []);
+    clearDigest();
+  }, [clearDigest]);
 
   const handleExportMarkdown = useCallback(async (id: string, name: string) => {
     const path = await window.electronAPI.showSaveDialog({
@@ -278,6 +299,47 @@ export function HistoryPanel({ onClose }: HistoryPanelProps) {
           </div>
 
           <div style={{ flex: '1 1 55%', overflowY: 'auto', minWidth: 0, display: 'flex', flexDirection: 'column', gap: 8 }}>
+            {selectedId !== null && (
+              <div
+                className="p4-form-row"
+                data-testid="history-digest"
+                style={{
+                  display: 'flex',
+                  flexDirection: 'column',
+                  gap: 4,
+                  padding: 8,
+                  border: '1px solid var(--border, #2a2a2a)',
+                  borderRadius: 4,
+                }}
+              >
+                <div className="t" style={{ fontWeight: 600 }}>While you were away</div>
+                {digestLoading ? (
+                  <span className="d">Loading recap…</span>
+                ) : digestError ? (
+                  <span className="d" style={{ color: 'var(--danger, #F7678E)' }}>
+                    Recap unavailable: {digestError}
+                  </span>
+                ) : digest ? (
+                  <div
+                    className="d"
+                    data-testid="history-digest-summary"
+                    style={{ display: 'flex', flexWrap: 'wrap', gap: 12, fontSize: 12 }}
+                  >
+                    <span>Active: {formatDuration(digest.activeDurationMs)}</span>
+                    <span>Restarts: {digest.restartSegments}</span>
+                    <span>Output: {formatSize(digest.outputBytes)}</span>
+                    <span>Checkpoints: {digest.checkpointsCreated}</span>
+                    <span data-testid="history-digest-approvals">
+                      Approval prompts: {digest.approvalPromptsHit === null ? '— (not tracked)' : digest.approvalPromptsHit}
+                    </span>
+                    <span data-testid="history-digest-errors">
+                      Errors: {digest.errorsDetected === null ? '— (not tracked)' : digest.errorsDetected}
+                    </span>
+                  </div>
+                ) : null}
+              </div>
+            )}
+
             {selectedId !== null && (
               <div className="p4-form-row" style={{ display: 'flex', gap: 6 }}>
                 <button

--- a/src/renderer/hooks/useSessionDigest.test.ts
+++ b/src/renderer/hooks/useSessionDigest.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { vi } from 'vitest';
+import { getElectronAPI, resetElectronAPI } from '../../../test/helpers/electron-api-mock';
+import type { SessionDigest } from '../../shared/types/history-types';
+import { useSessionDigest } from './useSessionDigest';
+
+function makeDigest(overrides: Partial<SessionDigest> = {}): SessionDigest {
+  return {
+    sessionId: 'session-1',
+    windowStart: 1000,
+    windowEnd: 5000,
+    activeDurationMs: 4000,
+    restartSegments: 0,
+    outputBytes: 4242,
+    checkpointsCreated: 2,
+    approvalPromptsHit: null,
+    errorsDetected: null,
+    ...overrides,
+  };
+}
+
+describe('useSessionDigest', () => {
+  beforeEach(() => {
+    resetElectronAPI();
+  });
+
+  it('starts with no digest, not loading, no error', () => {
+    const { result } = renderHook(() => useSessionDigest());
+
+    expect(result.current.digest).toBeNull();
+    expect(result.current.loading).toBe(false);
+    expect(result.current.error).toBeNull();
+  });
+
+  it('fetch loads a digest and calls electronAPI with sessionId and since', async () => {
+    const api = getElectronAPI();
+    const digest = makeDigest();
+    api.getSessionDigest = vi.fn().mockResolvedValue(digest);
+
+    const { result } = renderHook(() => useSessionDigest());
+
+    await act(async () => {
+      await result.current.fetch('session-1', 500);
+    });
+
+    expect(api.getSessionDigest).toHaveBeenCalledWith('session-1', 500);
+    expect(result.current.digest).toEqual(digest);
+    expect(result.current.error).toBeNull();
+    expect(result.current.loading).toBe(false);
+  });
+
+  it('fetch works without a since argument', async () => {
+    const api = getElectronAPI();
+    const digest = makeDigest();
+    api.getSessionDigest = vi.fn().mockResolvedValue(digest);
+
+    const { result } = renderHook(() => useSessionDigest());
+
+    await act(async () => {
+      await result.current.fetch('session-1');
+    });
+
+    expect(api.getSessionDigest).toHaveBeenCalledWith('session-1', undefined);
+    expect(result.current.digest).toEqual(digest);
+  });
+
+  it('sets loading true while the fetch is in flight', async () => {
+    const api = getElectronAPI();
+    let resolveFetch: (value: SessionDigest) => void = () => {};
+    api.getSessionDigest = vi.fn().mockImplementation(
+      () =>
+        new Promise<SessionDigest>((resolve) => {
+          resolveFetch = resolve;
+        })
+    );
+
+    const { result } = renderHook(() => useSessionDigest());
+
+    let fetchPromise: Promise<void>;
+    act(() => {
+      fetchPromise = result.current.fetch('session-1');
+    });
+
+    await waitFor(() => expect(result.current.loading).toBe(true));
+
+    resolveFetch(makeDigest());
+    await act(async () => {
+      await fetchPromise!;
+    });
+
+    expect(result.current.loading).toBe(false);
+    expect(result.current.digest).not.toBeNull();
+  });
+
+  it('sets an error and clears the digest on rejection', async () => {
+    const api = getElectronAPI();
+    api.getSessionDigest = vi.fn().mockResolvedValue(makeDigest());
+
+    const { result } = renderHook(() => useSessionDigest());
+
+    await act(async () => {
+      await result.current.fetch('session-1');
+    });
+    expect(result.current.digest).not.toBeNull();
+
+    api.getSessionDigest = vi.fn().mockRejectedValue(new Error('session not found'));
+    await act(async () => {
+      await result.current.fetch('missing-session');
+    });
+
+    expect(result.current.digest).toBeNull();
+    expect(result.current.error).toBe('session not found');
+    expect(result.current.loading).toBe(false);
+  });
+
+  it('clear resets digest, error, and loading', async () => {
+    const api = getElectronAPI();
+    api.getSessionDigest = vi.fn().mockResolvedValue(makeDigest());
+
+    const { result } = renderHook(() => useSessionDigest());
+
+    await act(async () => {
+      await result.current.fetch('session-1');
+    });
+    expect(result.current.digest).not.toBeNull();
+
+    act(() => {
+      result.current.clear();
+    });
+
+    expect(result.current.digest).toBeNull();
+    expect(result.current.error).toBeNull();
+    expect(result.current.loading).toBe(false);
+  });
+
+  it('preserves null approvalPromptsHit and errorsDetected fields from the API result', async () => {
+    const api = getElectronAPI();
+    api.getSessionDigest = vi.fn().mockResolvedValue(
+      makeDigest({ approvalPromptsHit: null, errorsDetected: null })
+    );
+
+    const { result } = renderHook(() => useSessionDigest());
+
+    await act(async () => {
+      await result.current.fetch('session-1');
+    });
+
+    expect(result.current.digest?.approvalPromptsHit).toBeNull();
+    expect(result.current.digest?.errorsDetected).toBeNull();
+  });
+});

--- a/src/renderer/hooks/useSessionDigest.ts
+++ b/src/renderer/hooks/useSessionDigest.ts
@@ -1,0 +1,43 @@
+// Thin wrapper around the window.electronAPI.getSessionDigest IPC call.
+// Mirrors the loading/error shape of useHistory.ts. Unlike useHistory, there
+// is no automatic mount-time fetch: a digest is only meaningful once a
+// specific session has been selected, so callers (HistoryPanel) explicitly
+// call fetch(sessionId) when selection changes and clear() when it's cleared.
+import { useState, useCallback } from 'react';
+import type { SessionDigest } from '../../shared/types/history-types';
+
+export interface UseSessionDigestApi {
+  digest: SessionDigest | null;
+  loading: boolean;
+  error: string | null;
+  fetch: (sessionId: string, since?: number) => Promise<void>;
+  clear: () => void;
+}
+
+export function useSessionDigest(): UseSessionDigestApi {
+  const [digest, setDigest] = useState<SessionDigest | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetch = useCallback(async (sessionId: string, since?: number) => {
+    setLoading(true);
+    try {
+      const result = await window.electronAPI.getSessionDigest(sessionId, since);
+      setDigest(result);
+      setError(null);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+      setDigest(null);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  const clear = useCallback(() => {
+    setDigest(null);
+    setError(null);
+    setLoading(false);
+  }, []);
+
+  return { digest, loading, error, fetch, clear };
+}


### PR DESCRIPTION
## Summary

Wires the already-shipped `SessionDigest` IPC (`getSessionDigest`, from #226/#227) into the renderer, closing out epic #225's child-2.

- New `useSessionDigest` hook: thin `fetch(sessionId, since?)` / `clear()` wrapper mirroring `useHistory`'s loading/error convention (no auto mount-time fetch — a digest is only meaningful once a session is selected).
- `HistoryPanel.tsx`: calls `fetchDigest` on session select and `clearDigest` on deselect/delete. Renders a "while you were away" recap card (active duration, restarts, checkpoints, approval prompts, errors) above the export/delete row.
- Per spec, `approvalPromptsHit`/`errorsDetected` are `number | null` (null because `HistorySessionEntry` doesn't yet persist `providerId` at session-close — a separately tracked gap). The UI renders `null` as `"— (not tracked)"`, never `0`, to avoid implying "zero approvals" when it's actually "not measured."
- Digest fetch failure is non-fatal: shows an inline "Recap unavailable: ..." message without hiding the transcript.

Closes #228

## Test plan

- [x] `tsc --noEmit` clean on both `tsconfig.json` and `tsconfig.node.json`
- [x] Targeted renderer run (`vitest --config vitest.workspace.ts --project renderer`) for `useSessionDigest.test.ts` (7 tests) and `HistoryPanel.test.tsx` (24 tests, 4 new) — all pass
- [x] Full suite (`npm test`, all 3 workspace projects, no `--project` filter): 117 files / 1408 tests, all green, zero regressions
- New component-level tests specifically cover the acceptance criteria: non-null digest renders counts; null `approvalPromptsHit`/`errorsDetected` render as `"— (not tracked)"` (asserted via `.not.toHaveTextContent('0')`); fetch error is non-fatal; recap clears when selection is cleared

No new dependencies added.