### PR TITLE
feat(history): persist providerId on session history entries (#230, steps 1-3)

### DIFF
--- a/src/main/history-manager.test.ts
+++ b/src/main/history-manager.test.ts
@@ -26,6 +26,11 @@ function stateOf(mgr: HistoryManager, id: string): any {
   return (mgr as unknown as { sessionStates: Map<string, any> }).sessionStates.get(id);
 }
 
+// White-box helper: read the persisted index entry for a session.
+function entryOf(mgr: HistoryManager, id: string): any {
+  return (mgr as unknown as { index: { sessions: Record<string, any> } }).index.sessions[id];
+}
+
 describe('HistoryManager.recordOutput — readiness gate (F4)', () => {
   let mgr: HistoryManager;
 
@@ -69,5 +74,48 @@ describe('HistoryManager.recordOutput — readiness gate (F4)', () => {
     expect(s.isClaudeReady).toBe(true);
     expect(s.preClaudeBuffer).toBe('');
     expect(s.buffer).toContain('Claude Code');
+  });
+});
+
+describe('HistoryManager.updateSessionMetadata — providerId persistence (issue #230)', () => {
+  let mgr: HistoryManager;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mgr = new HistoryManager();
+  });
+
+  it('persists providerId on a brand-new entry when supplied', () => {
+    mgr.updateSessionMetadata('s1', 'Session 1', '/repo', 'claude');
+    expect(entryOf(mgr, 's1').providerId).toBe('claude');
+  });
+
+  it('leaves providerId undefined on a brand-new entry when not supplied', () => {
+    mgr.updateSessionMetadata('s2', 'Session 2', '/repo');
+    expect(entryOf(mgr, 's2').providerId).toBeUndefined();
+  });
+
+  it('sets providerId on an existing entry when a value is later supplied', () => {
+    mgr.updateSessionMetadata('s3', 'Session 3', '/repo');
+    expect(entryOf(mgr, 's3').providerId).toBeUndefined();
+
+    mgr.updateSessionMetadata('s3', 'Session 3', '/repo', 'codex');
+    expect(entryOf(mgr, 's3').providerId).toBe('codex');
+  });
+
+  it('does not clobber an existing providerId when a later call omits it (non-clobbering rename)', () => {
+    mgr.updateSessionMetadata('s4', 'Session 4', '/repo', 'claude');
+    expect(entryOf(mgr, 's4').providerId).toBe('claude');
+
+    // Simulates a manual rename call site that doesn't know the provider.
+    mgr.updateSessionMetadata('s4', 'Renamed Session 4', '/repo');
+    expect(entryOf(mgr, 's4').providerId).toBe('claude');
+    expect(entryOf(mgr, 's4').name).toBe('Renamed Session 4');
+  });
+
+  it('updates providerId when a later call supplies a different value', () => {
+    mgr.updateSessionMetadata('s5', 'Session 5', '/repo', 'claude');
+    mgr.updateSessionMetadata('s5', 'Session 5', '/repo', 'codex');
+    expect(entryOf(mgr, 's5').providerId).toBe('codex');
   });
 });

--- a/src/main/history-manager.ts
+++ b/src/main/history-manager.ts
@@ -196,10 +196,20 @@ export class HistoryManager {
   }
 
   /**
-   * Update session metadata (name, directory)
+   * Update session metadata (name, directory, and optionally provider).
+   *
+   * `providerId` is deliberately non-clobbering: it is only written when the
+   * caller supplies a value. Several call sites (e.g. manual rename) invoke
+   * this without knowing the provider, and must not erase a providerId a
+   * previous call already persisted (issue #230).
    */
-  updateSessionMetadata(sessionId: string, name: string, workingDirectory: string): void {
-    console.log(`[HistoryManager] updateSessionMetadata called:`, { sessionId, name, workingDirectory });
+  updateSessionMetadata(
+    sessionId: string,
+    name: string,
+    workingDirectory: string,
+    providerId?: string
+  ): void {
+    console.log(`[HistoryManager] updateSessionMetadata called:`, { sessionId, name, workingDirectory, providerId });
     let entry = this.index.sessions[sessionId];
 
     // Create entry if it doesn't exist
@@ -213,6 +223,7 @@ export class HistoryManager {
         lastUpdatedAt: Date.now(),
         sizeBytes: 0,
         segmentCount: 0,
+        providerId,
       };
       this.index.sessions[sessionId] = entry;
     } else {
@@ -220,6 +231,9 @@ export class HistoryManager {
       // Update existing entry
       entry.name = name;
       entry.workingDirectory = workingDirectory;
+      if (providerId !== undefined) {
+        entry.providerId = providerId;
+      }
     }
 
     console.log(`[HistoryManager] Entry after update:`, entry);

--- a/src/main/session-manager.test.ts
+++ b/src/main/session-manager.test.ts
@@ -628,6 +628,58 @@ describe('SessionManager — model/launchMode persistence & restart (F3)', () =>
   });
 });
 
+describe('SessionManager — providerId threaded into history metadata (issue #230)', () => {
+  let manager: SessionManager;
+  const baseRequest = { workingDirectory: '/mock/home', permissionMode: 'standard' as const };
+
+  function lastUpdateCall(): unknown[] {
+    const fn = HistoryManager.prototype.updateSessionMetadata as ReturnType<typeof vi.fn>;
+    return fn.mock.calls[fn.mock.calls.length - 1];
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    manager = createSessionManager();
+    manager.setMainWindow({} as never);
+    const registry = { get: vi.fn(() => ({ getEnvironmentVariables: () => ({}), buildCommand: () => 'claude', getStateSignals: () => ({ working: [], approval: [], awaitingInput: [], fatalError: [] }) })) };
+    manager.setProviderRegistry(registry as any);
+  });
+
+  it('createSession passes the resolved providerId ("claude" default) to history', async () => {
+    const meta = await manager.createSession({ ...baseRequest, kind: 'agent' } as never);
+    expect(meta.providerId).toBe('claude');
+    expect(lastUpdateCall()).toEqual(['test-session-id', expect.any(String), '/mock/home', 'claude']);
+  });
+
+  it('createSession passes undefined providerId for shell sessions', async () => {
+    await manager.createSession({ ...baseRequest, kind: 'shell' } as never);
+    expect(lastUpdateCall()).toEqual(['test-session-id', expect.any(String), '/mock/home', undefined]);
+  });
+
+  it("renameSession forwards the session's providerId, not just name/directory", async () => {
+    await manager.createSession({ ...baseRequest, kind: 'agent' } as never);
+    vi.clearAllMocks();
+    await manager.renameSession('test-session-id', 'Manual Name');
+    expect(lastUpdateCall()).toEqual(['test-session-id', 'Manual Name', '/mock/home', 'claude']);
+  });
+
+  it("applyAutoRename (title-driven) forwards the session's providerId", async () => {
+    await manager.createSession({ ...baseRequest, kind: 'agent' } as never);
+    const onOutput = CLIManager.prototype.onOutput as ReturnType<typeof vi.fn>;
+    const tap = onOutput.mock.calls[0][0];
+    vi.clearAllMocks();
+    tap('\x1b]0;⠂ Fix login bug\x07');
+    expect(lastUpdateCall()).toEqual(['test-session-id', 'Fix login bug', '/mock/home', 'claude']);
+  });
+
+  it("restartSession forwards the session's providerId", async () => {
+    await manager.createSession({ ...baseRequest, kind: 'agent' } as never);
+    vi.clearAllMocks();
+    await manager.restartSession('test-session-id');
+    expect(lastUpdateCall()).toEqual(['test-session-id', expect.any(String), '/mock/home', 'claude']);
+  });
+});
+
 describe('SessionManager scrollback buffer', () => {
   let manager: SessionManager;
 

--- a/src/main/session-manager.ts
+++ b/src/main/session-manager.ts
@@ -393,7 +393,7 @@ export class SessionManager {
     }
 
     // Update history metadata with session details
-    this.historyManager.updateSessionMetadata(id, metadata.name, workingDir);
+    this.historyManager.updateSessionMetadata(id, metadata.name, workingDir, metadata.providerId);
 
     this.persistState();
     this.emitter?.emit('onSessionCreated', metadata);
@@ -476,7 +476,12 @@ export class SessionManager {
     session.metadata.name = name;
     this.emitter?.emit('onSessionUpdated', session.metadata);
     this.persistState();
-    this.historyManager.updateSessionMetadata(sessionId, name, session.metadata.workingDirectory);
+    this.historyManager.updateSessionMetadata(
+      sessionId,
+      name,
+      session.metadata.workingDirectory,
+      session.metadata.providerId
+    );
   }
 
   /** Record + broadcast a session's live activity state (transient, not persisted). */
@@ -796,7 +801,8 @@ export class SessionManager {
     this.historyManager.updateSessionMetadata(
       sessionId,
       trimmedName,
-      session.metadata.workingDirectory
+      session.metadata.workingDirectory,
+      session.metadata.providerId
     );
 
     return session.metadata;
@@ -853,7 +859,8 @@ export class SessionManager {
     this.historyManager.updateSessionMetadata(
       sessionId,
       session.metadata.name,
-      session.metadata.workingDirectory
+      session.metadata.workingDirectory,
+      session.metadata.providerId
     );
 
     const isShell = session.metadata.kind === 'shell';

--- a/src/shared/types/history-types.ts
+++ b/src/shared/types/history-types.ts
@@ -20,6 +20,13 @@ export interface HistorySessionEntry {
   sizeBytes: number;
   /** Number of restart segments (starts at 0) */
   segmentCount: number;
+  /**
+   * Provider that ran this session (e.g. 'claude', 'codex'); undefined for
+   * shell sessions or sessions recorded before this field existed. Persisted
+   * so a closed/historical session's digest can eventually resolve the
+   * provider's marker patterns for real approval/error counts (issue #230).
+   */
+  providerId?: string;
 }
 
 /**


### PR DESCRIPTION
## Summary

Implements steps 1-3 of #230's proposal: persist `providerId` on `HistorySessionEntry` and thread it through every `SessionManager` write path, so a future pass can do real marker-replay in `SessionDigestService` instead of hard-coding `approvalPromptsHit`/`errorsDetected` to `null`.

- `src/shared/types/history-types.ts` — added optional `providerId?: string` to `HistorySessionEntry`.
- `src/main/history-manager.ts` — `updateSessionMetadata` now accepts an optional `providerId`. New entries get it set directly; existing entries only have it overwritten when a value is actually supplied, so a later rename/metadata call that doesn't know the provider can't clobber a previously persisted one.
- `src/main/session-manager.ts` — all four call sites (`createSession`, `renameSession`, `applyAutoRename`, `restartSession`) now pass the session's `providerId` through.

**Scope note (per the issue's own framing):** step 4 — actually resolving a provider's `getStateSignals()` table and replaying it over stored output in `SessionDigestService` to turn the digest's null fields into real counts — is intentionally left as follow-up work. Per the issue's own notes, this PR does not close #230; the issue stays open until that follow-up lands and the digest counts are non-null for provider sessions.

## Why non-clobbering

Several call sites (e.g. a manual rename) don't know the provider at call time and would otherwise pass `undefined`. Without the non-clobber rule, a rename right after session creation would wipe the `providerId` that `createSession` had just persisted. Covered by a dedicated test.

## Testing

- `npx tsc --noEmit` — clean.
- Full suite: `npm test` (vitest workspace: shared + main + renderer projects) — **117 test files / 1418 tests passing**, no regressions.
- New/updated coverage:
  - `src/main/history-manager.test.ts` — 5 new tests for `updateSessionMetadata`'s providerId persistence (new entry with/without providerId, later-set on existing entry, non-clobbering rename, updating to a different value).
  - `src/main/session-manager.test.ts` — new describe block with 5 tests asserting each of the 4 call sites (createSession for agent + shell, renameSession, applyAutoRename via the title-driven auto-rename tap, restartSession) forwards the correct providerId (or `undefined` for shell) into `HistoryManager.updateSessionMetadata`.

No new dependencies.