### PR TITLE
feat(shell): surface session recap glance in SessionPane (#232)

### DIFF
--- a/src/renderer/components/shell/HistoryPanel.tsx
+++ b/src/renderer/components/shell/HistoryPanel.tsx
@@ -6,7 +6,7 @@
 // full transcript for the selected one plus its export/delete actions.
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { P4Icon } from './P4Icon';
-import { formatLastActive } from './shell-utils';
+import { formatLastActive, formatByteSize, formatActiveDuration } from './shell-utils';
 import { useHistory } from '../../hooks/useHistory';
 import { useSessionDigest } from '../../hooks/useSessionDigest';
 import { ConfirmDialog } from '../ui/ConfirmDialog';
@@ -17,26 +17,6 @@ const SEARCH_DEBOUNCE_MS = 200;
 
 interface HistoryPanelProps {
   onClose: () => void;
-}
-
-/** Humanize a byte count as e.g. "1.2 KB" / "3.4 MB". */
-function formatSize(bytes: number): string {
-  if (bytes < 1024) return `${bytes} B`;
-  const kb = bytes / 1024;
-  if (kb < 1024) return `${kb.toFixed(1)} KB`;
-  const mb = kb / 1024;
-  return `${mb.toFixed(1)} MB`;
-}
-
-/** Humanize a duration in ms as e.g. "42s" / "5m" / "2h 15m". */
-function formatDuration(ms: number): string {
-  const totalSeconds = Math.floor(ms / 1000);
-  if (totalSeconds < 60) return `${totalSeconds}s`;
-  const totalMinutes = Math.floor(totalSeconds / 60);
-  if (totalMinutes < 60) return `${totalMinutes}m`;
-  const hours = Math.floor(totalMinutes / 60);
-  const minutes = totalMinutes % 60;
-  return minutes > 0 ? `${hours}h ${minutes}m` : `${hours}h`;
 }
 
 export function HistoryPanel({ onClose }: HistoryPanelProps) {
@@ -290,7 +270,7 @@ export function HistoryPanel({ onClose }: HistoryPanelProps) {
                   <div className="t" style={{ fontWeight: 600 }}>{s.name}</div>
                   <div className="d">{s.workingDirectory}</div>
                   <div className="d">
-                    {formatLastActive(s.lastUpdatedAt)} · {formatSize(s.sizeBytes)}
+                    {formatLastActive(s.lastUpdatedAt)} · {formatByteSize(s.sizeBytes)}
                     {s.segmentCount > 0 ? ` · ${s.segmentCount + 1} segments` : ''}
                   </div>
                 </div>
@@ -325,9 +305,9 @@ export function HistoryPanel({ onClose }: HistoryPanelProps) {
                     data-testid="history-digest-summary"
                     style={{ display: 'flex', flexWrap: 'wrap', gap: 12, fontSize: 12 }}
                   >
-                    <span>Active: {formatDuration(digest.activeDurationMs)}</span>
+                    <span>Active: {formatActiveDuration(digest.activeDurationMs)}</span>
                     <span>Restarts: {digest.restartSegments}</span>
-                    <span>Output: {formatSize(digest.outputBytes)}</span>
+                    <span>Output: {formatByteSize(digest.outputBytes)}</span>
                     <span>Checkpoints: {digest.checkpointsCreated}</span>
                     <span data-testid="history-digest-approvals">
                       Approval prompts: {digest.approvalPromptsHit === null ? '— (not tracked)' : digest.approvalPromptsHit}
@@ -393,7 +373,7 @@ export function HistoryPanel({ onClose }: HistoryPanelProps) {
           {stats && (
             <div className="p4-form-row" data-testid="history-stats" style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
               <span className="d">
-                {stats.totalSessions} session{stats.totalSessions === 1 ? '' : 's'} · {formatSize(stats.totalSizeBytes)}
+                {stats.totalSessions} session{stats.totalSessions === 1 ? '' : 's'} · {formatByteSize(stats.totalSizeBytes)}
                 {stats.oldestSessionDate !== null && stats.newestSessionDate !== null
                   ? ` · ${formatLastActive(stats.oldestSessionDate)} – ${formatLastActive(stats.newestSessionDate)}`
                   : ''}

--- a/src/renderer/components/shell/SessionPane.test.tsx
+++ b/src/renderer/components/shell/SessionPane.test.tsx
@@ -1,0 +1,112 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { getElectronAPI, resetElectronAPI } from '../../../../test/helpers/electron-api-mock';
+import { SessionPane } from './SessionPane';
+import type { TabData } from '../ui/Tab';
+import type { SessionDigest } from '../../../shared/types/history-types';
+
+function makeSession(overrides: Partial<TabData> = {}): TabData {
+  return {
+    id: 's1',
+    name: 'fix auth bug',
+    workingDirectory: 'C:\\repos\\omnidesk',
+    permissionMode: 'standard',
+    status: 'running',
+    kind: 'agent',
+    ...overrides,
+  };
+}
+
+function makeDigest(overrides: Partial<SessionDigest> = {}): SessionDigest {
+  return {
+    sessionId: 's1',
+    windowStart: Date.now() - 120_000,
+    windowEnd: Date.now(),
+    activeDurationMs: 90_000,
+    restartSegments: 0,
+    outputBytes: 2048,
+    checkpointsCreated: 3,
+    approvalPromptsHit: 2,
+    errorsDetected: 0,
+    ...overrides,
+  };
+}
+
+describe('SessionPane recap glance (#232)', () => {
+  it('renders the digest recap once the fetch resolves', async () => {
+    const api = resetElectronAPI();
+    api.getSessionDigest = vi.fn().mockResolvedValue(makeDigest());
+
+    render(<SessionPane session={makeSession()} />);
+
+    await waitFor(() => expect(api.getSessionDigest).toHaveBeenCalledWith('s1', undefined));
+    const digestRow = await screen.findByTestId('session-pane-digest');
+    expect(digestRow).toHaveTextContent('Active 1m');
+    expect(digestRow).toHaveTextContent('Output 2.0 KB');
+    expect(digestRow).toHaveTextContent('Checkpoints 3');
+    expect(screen.getByTestId('session-pane-digest-approvals')).toHaveTextContent('Approvals 2');
+    expect(screen.getByTestId('session-pane-digest-errors')).toHaveTextContent('Errors 0');
+  });
+
+  it('never renders 0 for null approvals/errors — shows the not-tracked fallback instead', async () => {
+    const api = resetElectronAPI();
+    api.getSessionDigest = vi.fn().mockResolvedValue(
+      makeDigest({ approvalPromptsHit: null, errorsDetected: null }),
+    );
+
+    render(<SessionPane session={makeSession()} />);
+
+    const approvals = await screen.findByTestId('session-pane-digest-approvals');
+    const errors = screen.getByTestId('session-pane-digest-errors');
+    expect(approvals).toHaveTextContent('— (not tracked)');
+    expect(errors).toHaveTextContent('— (not tracked)');
+    // Guard against a regression that coerces null to 0.
+    expect(approvals.textContent).not.toContain('Approvals 0');
+    expect(errors.textContent).not.toContain('Errors 0');
+  });
+
+  it('only shows the Restarts chip when restartSegments is greater than zero', async () => {
+    const api = resetElectronAPI();
+    api.getSessionDigest = vi.fn().mockResolvedValue(makeDigest({ restartSegments: 0 }));
+
+    const { rerender } = render(<SessionPane session={makeSession()} />);
+    await screen.findByTestId('session-pane-digest');
+    expect(screen.queryByText(/Restarts/)).not.toBeInTheDocument();
+
+    api.getSessionDigest = vi.fn().mockResolvedValue(makeDigest({ restartSegments: 2 }));
+    rerender(<SessionPane session={makeSession({ id: 's2' })} />);
+    await waitFor(() => expect(screen.getByText('Restarts 2')).toBeInTheDocument());
+  });
+
+  it('hides the recap row while the digest fetch is pending', () => {
+    const api = resetElectronAPI();
+    // Never resolves within this test — asserts the loading state renders nothing.
+    api.getSessionDigest = vi.fn(() => new Promise<SessionDigest>(() => {}));
+
+    render(<SessionPane session={makeSession()} />);
+
+    expect(screen.queryByTestId('session-pane-digest')).not.toBeInTheDocument();
+  });
+
+  it('hides the recap row when the digest fetch errors', async () => {
+    const api = resetElectronAPI();
+    api.getSessionDigest = vi.fn().mockRejectedValue(new Error('digest computation failed'));
+
+    render(<SessionPane session={makeSession()} />);
+
+    await waitFor(() => expect(api.getSessionDigest).toHaveBeenCalled());
+    expect(screen.queryByTestId('session-pane-digest')).not.toBeInTheDocument();
+  });
+
+  it('re-fetches the digest when the focused session changes', async () => {
+    const api = resetElectronAPI();
+    api.getSessionDigest = vi.fn().mockResolvedValue(makeDigest());
+
+    const { rerender } = render(<SessionPane session={makeSession({ id: 's1' })} />);
+    await waitFor(() => expect(api.getSessionDigest).toHaveBeenCalledWith('s1', undefined));
+
+    rerender(<SessionPane session={makeSession({ id: 's2', name: 'second session' })} />);
+    await waitFor(() => expect(api.getSessionDigest).toHaveBeenCalledWith('s2', undefined));
+    expect(api.getSessionDigest).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/renderer/components/shell/SessionPane.tsx
+++ b/src/renderer/components/shell/SessionPane.tsx
@@ -3,12 +3,15 @@
 // The actual xterm lives in TerminalHost at App level — we just expose our
 // content area as a slot via useTerminalSlot so the host portals the
 // terminal's DOM into it.
+import { useEffect } from 'react';
 import { P4Icon } from './P4Icon';
 import {
-  colorBg, colorFg, initials, STATUS_META, isSessionStopped, type RepoColor,
+  colorBg, colorFg, initials, STATUS_META, isSessionStopped, formatByteSize,
+  formatActiveDuration, type RepoColor,
 } from './shell-utils';
 import { mapTabStatus } from './SessionRail';
 import { useTerminalSlot } from './TerminalHost';
+import { useSessionDigest } from '../../hooks/useSessionDigest';
 import type { TabData } from '../ui/Tab';
 
 interface SessionPaneProps {
@@ -20,6 +23,14 @@ interface SessionPaneProps {
 
 export function SessionPane({ session, onClose, onRestart, onKill }: SessionPaneProps) {
   const slotRef = useTerminalSlot(session.id);
+
+  // "While you were away" recap glance (epic #225 child-4) — same digest data
+  // HistoryPanel shows for past sessions, surfaced here for the live one.
+  // Re-fetched whenever the focused session changes.
+  const { digest, loading: digestLoading, error: digestError, fetch: fetchDigest } = useSessionDigest();
+  useEffect(() => {
+    void fetchDigest(session.id);
+  }, [session.id, fetchDigest]);
 
   // The underlying CLI process is gone once a session exits or errors. Offer
   // restart. (A 'starting' session is not stopped — don't flash the overlay
@@ -111,6 +122,29 @@ export function SessionPane({ session, onClose, onRestart, onKill }: SessionPane
           )}
         </div>
       </div>
+
+      {/* "While you were away" recap glance — mirrors HistoryPanel's digest
+          rendering (same null-handling convention: approvalPromptsHit /
+          errorsDetected show "— (not tracked)" when null, never 0). Hidden
+          entirely while loading or on error to avoid a flash of empty chips. */}
+      {!digestLoading && !digestError && digest && (
+        <div className="p4-sess-strip" data-testid="session-pane-digest" style={{ paddingTop: 0, paddingBottom: 8 }}>
+          <div className="meta" style={{ display: 'flex', flexWrap: 'wrap', gap: 6 }}>
+            <span className="p4-chip">Active {formatActiveDuration(digest.activeDurationMs)}</span>
+            <span className="p4-chip">Output {formatByteSize(digest.outputBytes)}</span>
+            <span className="p4-chip">Checkpoints {digest.checkpointsCreated}</span>
+            {digest.restartSegments > 0 && (
+              <span className="p4-chip">Restarts {digest.restartSegments}</span>
+            )}
+            <span className="p4-chip" data-testid="session-pane-digest-approvals">
+              Approvals {digest.approvalPromptsHit === null ? '— (not tracked)' : digest.approvalPromptsHit}
+            </span>
+            <span className="p4-chip" data-testid="session-pane-digest-errors">
+              Errors {digest.errorsDetected === null ? '— (not tracked)' : digest.errorsDetected}
+            </span>
+          </div>
+        </div>
+      )}
 
       {/* Slot: TerminalHost portals this session's persistent xterm into here. */}
       <div ref={slotRef} className="p4-term-host" style={{ position: 'relative' }}>

--- a/src/renderer/components/shell/shell-utils.ts
+++ b/src/renderer/components/shell/shell-utils.ts
@@ -170,6 +170,31 @@ export const formatWaitDuration = (msElapsed: number): string => {
   return `${h}h`;
 };
 
+/** Humanize a byte count as e.g. "512 B" / "1.2 KB" / "3.4 MB" — used by the
+ *  session digest recap (HistoryPanel's past-session card and SessionPane's
+ *  live-session glance) for output volume. */
+export const formatByteSize = (bytes: number): string => {
+  if (bytes < 1024) return `${bytes} B`;
+  const kb = bytes / 1024;
+  if (kb < 1024) return `${kb.toFixed(1)} KB`;
+  const mb = kb / 1024;
+  return `${mb.toFixed(1)} MB`;
+};
+
+/** Humanize a duration in ms as e.g. "42s" / "5m" / "2h 15m" — used by the
+ *  session digest recap for `activeDurationMs`. Unlike formatWaitDuration
+ *  (short in-session waits) this covers a whole session's active window, so
+ *  it combines hours + remaining minutes instead of collapsing to just "Nh". */
+export const formatActiveDuration = (ms: number): string => {
+  const totalSeconds = Math.floor(ms / 1000);
+  if (totalSeconds < 60) return `${totalSeconds}s`;
+  const totalMinutes = Math.floor(totalSeconds / 60);
+  if (totalMinutes < 60) return `${totalMinutes}m`;
+  const hours = Math.floor(totalMinutes / 60);
+  const minutes = totalMinutes % 60;
+  return minutes > 0 ? `${hours}h ${minutes}m` : `${hours}h`;
+};
+
 /** Format a Date or epoch ms as "Nh ago", "Nd ago", etc. — used in rail meta. */
 export const formatLastActive = (date: Date | number | undefined): string => {
   if (!date) return '—';


### PR DESCRIPTION
## Summary
Adds the "while you were away" recap glance to the live `SessionPane` (epic #225, child 4). It reuses the existing `useSessionDigest` hook (already used by `HistoryPanel` for past sessions), fetching the digest for whichever session is focused and refetching whenever focus changes.

- New recap row renders: Active duration, Output size, Checkpoints, Restarts (only when > 0), Approvals, Errors.
- Row is hidden entirely while the fetch is pending or errored, so there's no flash of empty/zeroed chips.
- `approvalPromptsHit` / `errorsDetected` are `number | null` (null = not derivable, e.g. shell sessions with no provider). Per the issue's mandatory constraint, these render `"— (not tracked)"` when null and the raw number otherwise — **never coerced to 0**.
- Extracted `formatByteSize` / `formatActiveDuration` out of `HistoryPanel.tsx` into the shared `shell-utils.ts` so both surfaces (past-session card in HistoryPanel, live-session glance in SessionPane) use one implementation instead of duplicating formatting logic.

No new dependencies.

## Verification
- `npx tsc --noEmit -p tsconfig.json` — clean, zero errors.
- `npx vitest run --config vitest.workspace.ts` (full workspace, no `--project` filter) — **118/118 test files, 1424/1424 tests passing**, including the new `SessionPane.test.tsx` (6 tests):
  - renders the digest recap once the fetch resolves
  - never renders 0 for null approvals/errors — shows the not-tracked fallback instead (the regression guard the issue calls for)
  - only shows the Restarts chip when restartSegments > 0
  - hides the recap row while the digest fetch is pending
  - hides the recap row when the digest fetch errors
  - re-fetches the digest when the focused session changes

Closes #232