### PR TITLE
feat(main): compute real approval/error counts via provider marker replay (#235)

### DIFF
--- a/src/main/ipc-handlers.ts
+++ b/src/main/ipc-handlers.ts
@@ -603,7 +603,7 @@ export function setupIPCHandlers(
   });
 
   registry.handle('getSessionDigest', async (_e, sessionId, since) => {
-    try { return await computeSessionDigest(historyManager, checkpointManager, sessionId, since); }
+    try { return await computeSessionDigest(historyManager, checkpointManager, providerRegistry, sessionId, since); }
     catch (err) { console.error('Failed to get session digest:', err); throw err; }
   });
 

--- a/src/main/session-digest-service.test.ts
+++ b/src/main/session-digest-service.test.ts
@@ -3,6 +3,9 @@ import type { HistorySessionEntry } from '../shared/types/history-types';
 import type { Checkpoint } from '../shared/types/checkpoint-types';
 import type { HistoryManager } from './history-manager';
 import type { CheckpointManager } from './checkpoint-manager';
+import type { ProviderRegistry } from './providers/provider-registry';
+import type { IProvider } from './providers/provider';
+import type { StateSignals } from '../shared/session-state-types';
 import { computeSessionDigest } from './session-digest-service';
 
 function makeSessionEntry(overrides: Partial<HistorySessionEntry> = {}): HistorySessionEntry {
@@ -31,9 +34,10 @@ function makeCheckpoint(overrides: Partial<Checkpoint> = {}): Checkpoint {
   };
 }
 
-function makeHistoryManager(entry: HistorySessionEntry | null): HistoryManager {
+function makeHistoryManager(entry: HistorySessionEntry | null, content = ''): HistoryManager {
   return {
     getSessionMetadata: vi.fn().mockResolvedValue(entry),
+    getSessionContent: vi.fn().mockResolvedValue(content),
   } as unknown as HistoryManager;
 }
 
@@ -43,13 +47,39 @@ function makeCheckpointManager(checkpoints: Checkpoint[]): CheckpointManager {
   } as unknown as CheckpointManager;
 }
 
+/** A ProviderRegistry test double: `providers` maps providerId -> a partial
+ *  IProvider (only getStateSignals() is ever called by computeSessionDigest).
+ *  Unregistered ids throw, mirroring the real ProviderRegistry.get(). */
+function makeProviderRegistry(providers: Record<string, Partial<IProvider>> = {}): ProviderRegistry {
+  return {
+    get: vi.fn((id: string) => {
+      const provider = providers[id];
+      if (!provider) {
+        throw new Error(`Provider not found: ${id}`);
+      }
+      return provider as IProvider;
+    }),
+  } as unknown as ProviderRegistry;
+}
+
+function makeStateSignals(overrides: Partial<StateSignals> = {}): StateSignals {
+  return {
+    working: [],
+    approval: [],
+    awaitingInput: [],
+    fatalError: [],
+    ...overrides,
+  };
+}
+
 describe('computeSessionDigest', () => {
   it('computes a digest for a normal session with no restarts', async () => {
     const entry = makeSessionEntry({ segmentCount: 0, sizeBytes: 1234 });
     const historyManager = makeHistoryManager(entry);
     const checkpointManager = makeCheckpointManager([]);
+    const providerRegistry = makeProviderRegistry();
 
-    const digest = await computeSessionDigest(historyManager, checkpointManager, 'session-1');
+    const digest = await computeSessionDigest(historyManager, checkpointManager, providerRegistry, 'session-1');
 
     expect(digest).toEqual({
       sessionId: 'session-1',
@@ -68,8 +98,9 @@ describe('computeSessionDigest', () => {
     const entry = makeSessionEntry({ segmentCount: 3 });
     const historyManager = makeHistoryManager(entry);
     const checkpointManager = makeCheckpointManager([]);
+    const providerRegistry = makeProviderRegistry();
 
-    const digest = await computeSessionDigest(historyManager, checkpointManager, 'session-1');
+    const digest = await computeSessionDigest(historyManager, checkpointManager, providerRegistry, 'session-1');
 
     expect(digest.restartSegments).toBe(3);
   });
@@ -84,8 +115,9 @@ describe('computeSessionDigest', () => {
       makeCheckpoint({ id: 'cp-at-end', createdAt: 10000 }),
     ];
     const checkpointManager = makeCheckpointManager(checkpoints);
+    const providerRegistry = makeProviderRegistry();
 
-    const digest = await computeSessionDigest(historyManager, checkpointManager, 'session-1', 5000);
+    const digest = await computeSessionDigest(historyManager, checkpointManager, providerRegistry, 'session-1', 5000);
 
     expect(digest.windowStart).toBe(5000);
     expect(digest.windowEnd).toBe(10000);
@@ -96,18 +128,59 @@ describe('computeSessionDigest', () => {
     const entry = makeSessionEntry();
     const historyManager = makeHistoryManager(entry);
     const checkpointManager = makeCheckpointManager([]);
+    const providerRegistry = makeProviderRegistry();
 
-    const digest = await computeSessionDigest(historyManager, checkpointManager, 'session-1');
+    const digest = await computeSessionDigest(historyManager, checkpointManager, providerRegistry, 'session-1');
 
     expect(digest.checkpointsCreated).toBe(0);
   });
 
-  it('always reports approvalPromptsHit and errorsDetected as null (v1 graceful degrade)', async () => {
-    const entry = makeSessionEntry();
+  it('reports approvalPromptsHit and errorsDetected as null when the session has no providerId', async () => {
+    const entry = makeSessionEntry({ providerId: undefined });
     const historyManager = makeHistoryManager(entry);
     const checkpointManager = makeCheckpointManager([makeCheckpoint()]);
+    const providerRegistry = makeProviderRegistry();
 
-    const digest = await computeSessionDigest(historyManager, checkpointManager, 'session-1');
+    const digest = await computeSessionDigest(historyManager, checkpointManager, providerRegistry, 'session-1');
+
+    expect(digest.approvalPromptsHit).toBeNull();
+    expect(digest.errorsDetected).toBeNull();
+  });
+
+  it('replays the provider marker tables against persisted output to compute real counts (#235)', async () => {
+    const entry = makeSessionEntry({ providerId: 'claude' });
+    const content = [
+      'thinking...',
+      'Do you want to proceed with this?',
+      'more output',
+      'Do you want to make this edit to foo.ts?',
+      'API Error: 500 Internal Server Error',
+      'trailing output',
+    ].join('\n');
+    const historyManager = makeHistoryManager(entry, content);
+    const checkpointManager = makeCheckpointManager([]);
+    const providerRegistry = makeProviderRegistry({
+      claude: {
+        getStateSignals: () => makeStateSignals({
+          approval: [/Do you want to (proceed|make this edit)\b/i],
+          fatalError: [/^\s*(⎿\s*)?API Error[:\s(]/im],
+        }),
+      },
+    });
+
+    const digest = await computeSessionDigest(historyManager, checkpointManager, providerRegistry, 'session-1');
+
+    expect(digest.approvalPromptsHit).toBe(2);
+    expect(digest.errorsDetected).toBe(1);
+  });
+
+  it('leaves approvalPromptsHit/errorsDetected null (never throws) when providerId is unregistered', async () => {
+    const entry = makeSessionEntry({ providerId: 'nonexistent-provider' });
+    const historyManager = makeHistoryManager(entry, 'Do you want to proceed?');
+    const checkpointManager = makeCheckpointManager([]);
+    const providerRegistry = makeProviderRegistry(); // nothing registered
+
+    const digest = await computeSessionDigest(historyManager, checkpointManager, providerRegistry, 'session-1');
 
     expect(digest.approvalPromptsHit).toBeNull();
     expect(digest.errorsDetected).toBeNull();
@@ -117,8 +190,9 @@ describe('computeSessionDigest', () => {
     const entry = makeSessionEntry({ createdAt: 1000, lastUpdatedAt: 5000 });
     const historyManager = makeHistoryManager(entry);
     const checkpointManager = makeCheckpointManager([]);
+    const providerRegistry = makeProviderRegistry();
 
-    const digest = await computeSessionDigest(historyManager, checkpointManager, 'session-1', 0);
+    const digest = await computeSessionDigest(historyManager, checkpointManager, providerRegistry, 'session-1', 0);
 
     expect(digest.windowStart).toBe(1000);
   });
@@ -127,8 +201,9 @@ describe('computeSessionDigest', () => {
     const entry = makeSessionEntry({ createdAt: 1000, lastUpdatedAt: 5000 });
     const historyManager = makeHistoryManager(entry);
     const checkpointManager = makeCheckpointManager([]);
+    const providerRegistry = makeProviderRegistry();
 
-    const digest = await computeSessionDigest(historyManager, checkpointManager, 'session-1', 9000);
+    const digest = await computeSessionDigest(historyManager, checkpointManager, providerRegistry, 'session-1', 9000);
 
     expect(digest.windowStart).toBe(9000);
     expect(digest.windowEnd).toBe(9000);
@@ -138,9 +213,10 @@ describe('computeSessionDigest', () => {
   it('throws when the session is not found in history', async () => {
     const historyManager = makeHistoryManager(null);
     const checkpointManager = makeCheckpointManager([]);
+    const providerRegistry = makeProviderRegistry();
 
     await expect(
-      computeSessionDigest(historyManager, checkpointManager, 'missing-session')
+      computeSessionDigest(historyManager, checkpointManager, providerRegistry, 'missing-session')
     ).rejects.toThrow(/missing-session/);
   });
 });

--- a/src/main/session-digest-service.ts
+++ b/src/main/session-digest-service.ts
@@ -4,13 +4,26 @@
  * Computes a "while you were away" activity digest for a recorded session,
  * per issue #226 (epic #225 child-1). v1 is derived entirely from persisted
  * metadata (HistorySessionEntry) and the checkpoint store — it does NOT
- * depend on the live session-state classifier (epic #195), which has no
- * historical/persisted timeline to replay against a closed session.
+ * depend on the live session-state classifier (epic #195)'s runtime line
+ * buffer, though it does reuse each provider's getStateSignals() marker
+ * tables (see approvalPromptsHit/errorsDetected below) to replay against a
+ * closed session's persisted raw output.
  */
 
 import type { HistoryManager } from './history-manager';
 import type { CheckpointManager } from './checkpoint-manager';
+import type { ProviderRegistry } from './providers/provider-registry';
+import type { ProviderId } from '../shared/types/provider-types';
 import type { SessionDigest } from '../shared/types/history-types';
+
+/** Count total regex matches for `pattern` across `text`, forcing the global
+ *  flag so a single `String.match()` call returns every occurrence instead
+ *  of just the first. The source `RegExp` (from a provider's StateSignals
+ *  table) is never mutated — a new RegExp is constructed if `g` is missing. */
+function countMatches(pattern: RegExp, text: string): number {
+  const withGlobalFlag = pattern.flags.includes('g') ? pattern : new RegExp(pattern.source, pattern.flags + 'g');
+  return text.match(withGlobalFlag)?.length ?? 0;
+}
 
 /**
  * Compute a SessionDigest for `sessionId`.
@@ -27,19 +40,24 @@ import type { SessionDigest } from '../shared/types/history-types';
  * `since` window cannot be resolved more finely than "the whole session".
  * This is a documented v1 approximation (see issue #226 Notes).
  *
- * `approvalPromptsHit` and `errorsDetected` are always `null` in v1: marker
- * replay would require knowing which provider's getStateSignals() regex
- * table produced this session's output, but `providerId` is tracked only on
- * live sessions (SessionManager / shared/ipc-types.ts) and is never
- * persisted into HistorySessionEntry or the history index. There is
- * currently no way to recover it for a closed/historical session, so per
- * issue #226's explicit fallback this ships as `null` (best-effort / not
- * derivable) rather than guessing or throwing. Follow-up: persist
- * `providerId` on HistorySessionEntry to unblock real marker replay.
+ * `approvalPromptsHit` and `errorsDetected` (issue #235, epic #225 child-5):
+ * when `entry.providerId` is set AND resolves to a registered provider, both
+ * fields are computed by replaying that provider's getStateSignals().approval
+ * and .fatalError regex tables against the session's full persisted output
+ * (historyManager.getSessionContent) and summing match counts. Like
+ * restartSegments/outputBytes above, this is a whole-session total — the
+ * persisted content has no per-line timestamps to resolve a `since` window
+ * more finely. When `providerId` is absent, or set to an id the current
+ * ProviderRegistry does not have registered (registry.get throws), both
+ * fields stay `null` — never `0` and never a thrown error — matching the
+ * same "best-effort, not derivable" convention already used elsewhere in
+ * this digest. `working`/`awaitingInput` signals are not used here; they
+ * describe in-flight/idle states that don't correspond to a countable event.
  */
 export async function computeSessionDigest(
   historyManager: HistoryManager,
   checkpointManager: CheckpointManager,
+  providerRegistry: ProviderRegistry,
   sessionId: string,
   since?: number
 ): Promise<SessionDigest> {
@@ -60,8 +78,23 @@ export async function computeSessionDigest(
     (cp) => cp.createdAt >= windowStart && cp.createdAt <= windowEnd
   ).length;
 
-  const approvalPromptsHit: number | null = null;
-  const errorsDetected: number | null = null;
+  let approvalPromptsHit: number | null = null;
+  let errorsDetected: number | null = null;
+
+  if (entry.providerId) {
+    try {
+      const provider = providerRegistry.get(entry.providerId as ProviderId);
+      const signals = provider.getStateSignals();
+      const content = await historyManager.getSessionContent(sessionId);
+      approvalPromptsHit = signals.approval.reduce((sum, re) => sum + countMatches(re, content), 0);
+      errorsDetected = signals.fatalError.reduce((sum, re) => sum + countMatches(re, content), 0);
+    } catch {
+      // Unregistered/unknown providerId, or content unavailable — leave both
+      // null (best-effort, not derivable) rather than guessing or throwing.
+      approvalPromptsHit = null;
+      errorsDetected = null;
+    }
+  }
 
   return {
     sessionId,


### PR DESCRIPTION
## Summary

Closes #235 (epic #225 child-5, final deterministic child).

`computeSessionDigest` previously left `approvalPromptsHit`/`errorsDetected` unimplemented. This PR computes them for real: when the session's `providerId` resolves in the `ProviderRegistry`, it replays that provider's `getStateSignals().approval` / `.fatalError` regex tables against the session's full persisted output (`historyManager.getSessionContent`) and sums match counts across the session's whole history (same whole-session-total convention already used for `restartSegments`/`outputBytes`, since persisted content has no per-line timestamps to resolve a `since` window more finely).

Graceful degradation: both fields stay `null` (never `0`, never throw) when `providerId` is absent, unregistered, or content retrieval fails — matching the existing "best-effort, not derivable" pattern.

## Changes

- `src/main/session-digest-service.ts`: add `countMatches()` helper (rebuilds a regex with the global flag forced, without mutating the source `RegExp` from the provider's marker table), thread `providerRegistry` through `computeSessionDigest`, cast `entry.providerId` (a plain `string` on `HistorySessionEntry`) to `ProviderId` at the `ProviderRegistry.get()` call site.
- `src/main/ipc-handlers.ts`: pass `providerRegistry` into the `getSessionDigest` IPC handler's call to `computeSessionDigest`.
- `src/main/session-digest-service.test.ts`: updated all call sites for the new `providerRegistry` param; added coverage for real marker-replay counts (approval + fatalError), an unregistered `providerId`, and a missing `providerId`.

No new dependencies.

## Verification

- `npx tsc --noEmit` — clean.
- `npm run test:unit` (vitest workspace, `shared` + `main` projects) — 974/974 tests passed across 64 files, including `src/main/session-digest-service.test.ts (10 tests)`.
- `npm run test:integration` (vitest workspace, `renderer` project) — 452/452 tests passed across 54 files (confirms no regression in `SessionPane.test.tsx`, which consumes this digest data — this PR only touches main-process code).