### PR TITLE
release: v2.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [2.7.1] - 2026-07-28
+
+### Added
+- **Recap at a glance on the live session pane.** The "while you were away" recap now also appears as a compact row on the session pane itself — not just in the history panel — refreshing whenever you switch sessions.
+- **Real approval & error counts in session digests.** The recap's approval-prompts and errors-detected figures are now computed by replaying the session's recorded output against the provider's own state-signal patterns. When a count genuinely can't be derived (e.g. shell sessions), it shows "not tracked" rather than a misleading 0.
+
+---
+
 ## [2.7.0] - 2026-07-27
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@
 ### Session History & Checkpoints
 - **Session History Explorer** (`Ctrl/Cmd+K → "Session history…"`) — browse the transcripts of past sessions, newest first, with the full transcript view for any recorded session
 - **Cross-session content search** — search the *content* of every recorded session at once (debounced, optional case sensitivity) and jump to matches
-- **"While you were away" recap** — a per-session digest of what happened since you last looked, right in the history panel
+- **"While you were away" recap** — a per-session digest of what happened since you last looked, shown in the history panel and as a glance row on the live session pane; agent sessions report real approval-prompt and error counts (shell sessions show "not tracked" instead of a misleading 0)
 - **Export, delete, stats & retention** — export any transcript as Markdown or JSON, delete individually or all at once, see storage stats, and set a retention policy
 - **Checkpoints panel** (`Ctrl/Cmd+K → "Checkpoints…"`) — create named checkpoints of a session's context, edit their details, export them as Markdown/JSON, and delete them
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@carloluisito/omnidesk",
-  "version": "2.6.1",
+  "version": "2.7.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@carloluisito/omnidesk",
-      "version": "2.6.1",
+      "version": "2.7.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@carloluisito/omnidesk",
-  "version": "2.7.0",
+  "version": "2.7.1",
   "description": "A multi-provider Electron desktop application for AI coding CLIs",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## release: v2.7.1

Patch release with two refinements to the v2.7.0 session-recap feature.

### Added
- **Recap at a glance on the live session pane.** The "while you were away" recap now also appears as a compact row on the session pane itself — not just in the history panel — refreshing whenever you switch sessions. (#232/#234)
- **Real approval & error counts in session digests.** The recap's approval-prompts and errors-detected figures are now computed by replaying the session's recorded output against the provider's own state-signal patterns. When a count genuinely can't be derived (e.g. shell sessions), it shows "not tracked" rather than a misleading 0. (#235/#236)

Also updates README and CHANGELOG for the release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
